### PR TITLE
Add option to hide Welcome screen

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -111,6 +111,9 @@ public class Config {
      */
     //
     // salesforce constants
+    
+    // Loader Preferences
+    public static final String HIDE_WELCOME_SCREEN = "loader.hideWelcome";
 
     //Special Internal Configs
     public static final String SFDC_INTERNAL = "sfdcInternal"; //$NON-NLS-1$
@@ -277,6 +280,7 @@ public class Config {
      * This sets the current defaults.
      */
     public void setDefaults() {
+		setValue(HIDE_WELCOME_SCREEN, false);
 		setValue(ENDPOINT, DEFAULT_ENDPOINT_URL);
         setValue(LOAD_BATCH_SIZE, useBulkApiByDefault() ? DEFAULT_BULK_API_BATCH_SIZE : DEFAULT_LOAD_BATCH_SIZE);
         setValue(LOAD_ROW_TO_START_AT, 0);

--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -68,6 +68,7 @@ public class AdvancedSettingsDialog extends Dialog {
     private final String defaultServer;
 
     private final Logger logger = Logger.getLogger(AdvancedSettingsDialog.class);
+    private Button buttonHideWelcomeScreen;
     private Button buttonOutputExtractStatus;
     private Button buttonReadUtf8;
     private Button buttonWriteUtf8;
@@ -247,6 +248,14 @@ public class AdvancedSettingsDialog extends Dialog {
         layout = new GridLayout(2, false);
         layout.verticalSpacing = 10;
         restComp.setLayout(layout);
+
+        // Hide welecome screen
+        Label labelHideWelcomeScreen = new Label(restComp, SWT.RIGHT);
+        labelHideWelcomeScreen.setText(Labels.getString("AdvancedSettingsDialog.hideWelcomeScreen")); //$NON-NLS-1$
+        labelHideWelcomeScreen.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_END));
+
+        buttonHideWelcomeScreen = new Button(restComp, SWT.CHECK);
+        buttonHideWelcomeScreen.setSelection(config.getBoolean(Config.HIDE_WELCOME_SCREEN));
 
         //batch size
         Label labelBatch = new Label(restComp, SWT.RIGHT);
@@ -586,6 +595,7 @@ public class AdvancedSettingsDialog extends Dialog {
                 Config config = controller.getConfig();
 
                 //set the configValues
+                config.setValue(Config.HIDE_WELCOME_SCREEN, buttonHideWelcomeScreen.getSelection());
                 config.setValue(Config.INSERT_NULLS, buttonNulls.getSelection());
                 config.setValue(Config.LOAD_BATCH_SIZE, textBatch.getText());
                 config.setValue(Config.EXTRACT_REQUEST_SIZE, textQueryBatch.getText());

--- a/src/main/java/com/salesforce/dataloader/ui/LoaderWindow.java
+++ b/src/main/java/com/salesforce/dataloader/ui/LoaderWindow.java
@@ -168,9 +168,13 @@ public class LoaderWindow extends ApplicationWindow {
 
         createButtons(comp);
 
-
         getStatusLineManager().setMessage(Labels.getString("LoaderWindow.chooseAction"));
-        displayTitleDialog(Display.getDefault(), this.operationActionsByIndex, this.controller.getConfig());
+
+        Config config = controller.getConfig();
+
+        if (!config.getBoolean(config.HIDE_WELCOME_SCREEN)) {
+            displayTitleDialog(Display.getDefault(), this.operationActionsByIndex, this.controller.getConfig());
+        }
 
         comp.pack();
         parent.pack();

--- a/src/main/resources/labels.properties
+++ b/src/main/resources/labels.properties
@@ -90,6 +90,7 @@ AdvancedSettingsDialog.allowFieldTruncation=Allow field truncation:
 AdvancedSettingsDialog.useBulkApi=Use Bulk API:
 AdvancedSettingsDialog.bulkApiSerialMode=Enable serial mode for Bulk API:
 AdvancedSettingsDialog.bulkApiZipContent=Upload Bulk API Batch as Zip File (enable to upload binary attachments):
+AdvancedSettingsDialog.hideWelcomeScreen=Hide Welcome screen:
 InsertWizard.title=Load Inserts
 InsertWizard.confFirstLine=You have chosen to insert new records.  Click Yes to begin.
 insert.UIAction.menuText=&Insert@Ctrl+I


### PR DESCRIPTION
The welcome screen doesn't provide any options over what is available on
the main window. In fact it provides less options as the user cannot
access Settings while the welcome screen is open.

This commit adds a new settings option for hiding the welcome screen as
well as a section in settings for GUI or Loader related settings
independent of the API.

Welcome Screen defaults to being shown