### PR TITLE
Update argument order of mac terminal command (fixes #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To run the Data Loader GUI, run the command
     
 Use the command below to run the Data Loader GUI on Mac
 
-    java -jar target/dataloader-32.0.0-uber.jar -XstartOnFirstThread
+    java -XstartOnFirstThread -jar target/dataloader-32.0.0-uber.jar
     
 To run Data Loader from the command line, use the command:
 


### PR DESCRIPTION
Order shouldn't matter, but locally the order does matter. Otherwise when starting:

2014-11-17 18:15:06,845 INFO  [main] controller.Controller initConfig (Controller.java:355) - The controller config has been initialized
***WARNING: Display must be created on main thread due to Cocoa restrictions.
Exception in thread "main" org.eclipse.swt.SWTException: Invalid thread access
    at org.eclipse.swt.SWT.error(SWT.java:4361)
    at org.eclipse.swt.SWT.error(SWT.java:4276)
    at org.eclipse.swt.SWT.error(SWT.java:4247)
    at org.eclipse.swt.widgets.Display.error(Display.java:1068)
    at org.eclipse.swt.widgets.Display.createDisplay(Display.java:825)
    at org.eclipse.swt.widgets.Display.create(Display.java:808)
    at org.eclipse.swt.graphics.Device.<init>(Device.java:130)
    at org.eclipse.swt.widgets.Display.<init>(Display.java:699)
    at org.eclipse.swt.widgets.Display.<init>(Display.java:690)
    at org.eclipse.swt.widgets.Display.getDefault(Display.java:1386)
    at com.salesforce.dataloader.ui.LoaderWindow.<init>(LoaderWindow.java:83)
    at com.salesforce.dataloader.controller.Controller.createAndShowGUI(Controller.java:207)
    at com.salesforce.dataloader.process.DataLoaderRunner.main(DataLoaderRunner.java:45)
