### PR TITLE
Added handling for completed batches with state message

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/BulkLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/BulkLoadVisitor.java
@@ -325,8 +325,7 @@ public class BulkLoadVisitor extends DAOLoadVisitor {
 
         // If there was an error processing the batch and the state of the batch is 'Failed' then the server 
         // will fill in stateMessage.  
-        final String stateMessage = (batch.getState() == BatchStateEnum.Completed) ? null :
-                stateMessage = batch.getStateMessage();
+        final String stateMessage = (batch.getState() == BatchStateEnum.Completed) ? null : batch.getStateMessage();
         final String errorMessage = stateMessage == null ? null : Messages.getMessage(getClass(), "batchError",
                 stateMessage);
 

--- a/src/main/java/com/salesforce/dataloader/action/visitor/BulkLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/BulkLoadVisitor.java
@@ -323,8 +323,10 @@ public class BulkLoadVisitor extends DAOLoadVisitor {
         // do some basic checks to make sure we are matching up the batches correctly
         sanityCheckBatch(clientBatchInfo, batch);
 
-        // if there was an error processing the batch then the server will fill in stateMessage
-        final String stateMessage = batch.getStateMessage();
+        // If there was an error processing the batch and the state of the batch is 'Failed' then the server 
+        // will fill in stateMessage.  
+        final String stateMessage = (batch.getState() == BatchStateEnum.Completed) ? null :
+                stateMessage = batch.getStateMessage();
         final String errorMessage = stateMessage == null ? null : Messages.getMessage(getClass(), "batchError",
                 stateMessage);
 
@@ -445,8 +447,6 @@ public class BulkLoadVisitor extends DAOLoadVisitor {
         if (state != BatchStateEnum.Completed && state != BatchStateEnum.Failed)
             sanityCheckError(batchId, "Expected batch state to be Completed or Failed, but was " + state);
         String stateMessage = batch.getStateMessage();
-        if (state == BatchStateEnum.Completed && stateMessage != null && stateMessage.length() > 0)
-            sanityCheckError(batchId, "Did not expect error message for successful batch: " + stateMessage);
         if (state == BatchStateEnum.Failed && (stateMessage == null || stateMessage.length() == 0))
             sanityCheckError(batchId, "Expected error message for failed batch but did not get one");
     }

--- a/src/main/java/com/salesforce/dataloader/action/visitor/BulkLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/BulkLoadVisitor.java
@@ -446,6 +446,12 @@ public class BulkLoadVisitor extends DAOLoadVisitor {
         if (state != BatchStateEnum.Completed && state != BatchStateEnum.Failed)
             sanityCheckError(batchId, "Expected batch state to be Completed or Failed, but was " + state);
         String stateMessage = batch.getStateMessage();
+        
+        // Commenting out due to issue with processing result files if in "Completed" state with a stateMessage
+        // May want to add back in at some future date
+        //if (state == BatchStateEnum.Completed && stateMessage != null && stateMessage.length() > 0)
+    	//sanityCheckError(batchId, "Did not expect error message for successful batch: " + stateMessage);
+        
         if (state == BatchStateEnum.Failed && (stateMessage == null || stateMessage.length() == 0))
             sanityCheckError(batchId, "Expected error message for failed batch but did not get one");
     }


### PR DESCRIPTION
If the batch completes, but had at least one failure (too many locks, too much cpu, took longer than 10 mins to process, etc...) there will be a state message.  Data Loader assumes that if there is a state message, the batch failed. 

Code change only assumes failure if there is a state message and the state is "Failed".  Otherwise, it will process the results.  Result file success and errors are still processed as previous.