### PR TITLE
Provide access to endpoint during login [Refactored]

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/SettingsPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/SettingsPage.java
@@ -94,10 +94,12 @@ public class SettingsPage extends WizardPage {
 
         textUsername = new Text(comp, SWT.BORDER);
         textUsername.setText(config.getString(Config.USERNAME));
+
         GridData data = new GridData(SWT.FILL, SWT.CENTER, true, false);
         data.widthHint = 150;
         textUsername.setLayoutData(data);
 
+        // Consume the 2 cells to the right of txtUsername and txtPassword
         Composite composite2 = new Composite(comp, SWT.NONE);
         data = new GridData();
         data.verticalSpan = 2;
@@ -114,6 +116,16 @@ public class SettingsPage extends WizardPage {
         data = new GridData(SWT.FILL, SWT.CENTER, true, false);
         data.widthHint = 150;
         textPassword.setLayoutData(data);
+
+        //endpoint
+        Label labelEndpoint = new Label(comp, SWT.RIGHT);
+        labelEndpoint.setText(Labels.getString("SettingsPage.instServerUrl")); //$NON-NLS-1$
+
+        textEndpoint = new Text(comp, SWT.BORDER);
+        textEndpoint.setText(config.getString(Config.ENDPOINT));
+        data = new GridData(SWT.FILL, SWT.CENTER, true, false);
+        data.widthHint = 150;
+        textEndpoint.setLayoutData(data);
 
         if(config.getBoolean(Config.SFDC_INTERNAL)) {
             //spacer
@@ -154,16 +166,6 @@ public class SettingsPage extends WizardPage {
             data = new GridData();
             data.verticalSpan = 2;
             composite2.setLayoutData(data);
-
-            //endpoint
-            Label labelEndpoint = new Label(comp, SWT.RIGHT);
-            labelEndpoint.setText(Labels.getString("SettingsPage.instServerUrl")); //$NON-NLS-1$
-
-            textEndpoint = new Text(comp, SWT.BORDER);
-            textEndpoint.setText(config.getString(Config.ENDPOINT));
-            data = new GridData(SWT.FILL, SWT.CENTER, true, false);
-            data.widthHint = 150;
-            textEndpoint.setLayoutData(data);
 
             reconcileLoginCredentialFieldsEnablement();
         }
@@ -226,11 +228,11 @@ public class SettingsPage extends WizardPage {
             Config config = controller.getConfig();
             config.setValue(Config.USERNAME, textUsername.getText());
             config.setValue(Config.PASSWORD, textPassword.getText());
+            config.setValue(Config.ENDPOINT, textEndpoint.getText());
 
             if(config.getBoolean(Config.SFDC_INTERNAL)) {
                 config.setValue(Config.SFDC_INTERNAL_IS_SESSION_ID_LOGIN, isSessionIdLogin.getSelection());
                 config.setValue(Config.SFDC_INTERNAL_SESSION_ID, textSessionId.getText());
-                config.setValue(Config.ENDPOINT, textEndpoint.getText());
             }
 
             controller.saveConfig();


### PR DESCRIPTION
Much more cleaned up version of #36

This time just moved the text box outside the `SFDC_INTERNAL` block since it's useful to anyone who has sandboxes and production environments and not just people internal to SFDC. This should address any concerns about there being duplicate boxes while still being convenient for users.

In order to change your login to a sandbox from production once
selecting an action required the user to cancel, go to settings, change
the endpoint, save, and finally go back into the action.

This patch provides a textbox for changing the login url straight from
the action settings page