### PR TITLE
Fixes issue #59, but makes #62 even more annoying than before.

### DIFF
--- a/src/main/java/com/salesforce/dataloader/dao/database/DatabaseReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/database/DatabaseReader.java
@@ -210,10 +210,7 @@ public class DatabaseReader implements DataReader {
 
     @Override
     public int getTotalRows() throws DataAccessObjectException {
-        if (totalRows == 0) {
-            totalRows = DAORowUtil.calculateTotalRows(this);
-        }
-        return totalRows;
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
This is the only way dataloader works well with 4+ million rows in the source data.  I tested it using an Oracle PS source database to migrate records to Salesforce.  Rather than dataloader appearing to do nothing for over an hour (as it read rows from Oracle), it now starts creating batches within a few minutes.