### PR TITLE
Created new property, daoAccess.skipTotalCount

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -83,6 +83,14 @@ public class Config {
     public static final int DEFAULT_BULK_API_BATCH_SIZE = 2000;
     public static final long DEFAULT_BULK_API_CHECK_STATUS_INTERVAL = 5000L;
 	public static final String DEFAULT_ENDPOINT_URL = "https://login.salesforce.com";
+	
+	/*
+	 * Issue #59 - Dataloader will not read all the database rows to get a total count
+	 * when skipTotalCount = "false"
+	 * 
+	 * The default is "true"
+	 */
+	public static final Boolean DEFAULT_SKIP_TOTAL_COUNT = true;
     /**
      * Constants that were made not configurable by choice
      */
@@ -178,6 +186,7 @@ public class Config {
     public static final String DAO_NAME = "dataAccess.name"; //$NON-NLS-1$
     public static final String DAO_READ_BATCH_SIZE = "dataAccess.readBatchSize";
     public static final String DAO_WRITE_BATCH_SIZE = "dataAccess.writeBatchSize";
+    public static final String DAO_SKIP_TOTAL_COUNT = "dataAccess.skipTotalCount";
 
     /*
      * TODO: when batching is introduced to the DataAccess, these parameters will become useful

--- a/src/main/java/com/salesforce/dataloader/dao/DataSource.java
+++ b/src/main/java/com/salesforce/dataloader/dao/DataSource.java
@@ -1,0 +1,33 @@
+package com.salesforce.dataloader.dao.database;
+
+import java.io.IOException;
+import sun.misc.BASE64Decoder;
+import org.apache.log4j.Logger;
+
+import org.apache.commons.dbcp.BasicDataSource;
+
+public class DataSource extends org.apache.commons.dbcp.BasicDataSource {
+
+    public DataSource() {
+        super();
+    }
+
+    public synchronized void setPassword(String encodedPassword) {
+    	logger.warn("encoded password is " + encodedPassword);
+    	this.password = decode(encodedPassword);
+    }
+    
+    private String decode(String password) {
+        BASE64Decoder decoder = new BASE64Decoder();
+        String decodedPassword = null;
+        try {
+        	decodedPassword = new String(decoder.decodeBuffer(password));
+        } catch (IOException e) {
+        	e.printStackTrace();
+        }
+        
+        return decodedPassword;
+    }
+    
+    private static Logger logger = Logger.getLogger(DataSource.class);
+}

--- a/src/main/java/com/salesforce/dataloader/dao/database/DatabaseReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/database/DatabaseReader.java
@@ -210,7 +210,19 @@ public class DatabaseReader implements DataReader {
 
     @Override
     public int getTotalRows() throws DataAccessObjectException {
-        return 0;
+    	boolean skipRowCount = Config.DEFAULT_SKIP_TOTAL_COUNT;
+    	
+    	if (config.contains(Config.DAO_SKIP_TOTAL_COUNT))
+    		skipRowCount = config.getBoolean(Config.DAO_SKIP_TOTAL_COUNT);
+    	
+    	if (skipRowCount == true)
+    		return 0;
+
+    	if (totalRows == 0) {
+    		totalRows = DAORowUtil.calculateTotalRows(this);
+    	}
+
+    	return totalRows;
     }
 
     @Override

--- a/src/main/java/com/salesforce/dataloader/dao/database/DatabaseReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/database/DatabaseReader.java
@@ -210,10 +210,7 @@ public class DatabaseReader implements DataReader {
 
     @Override
     public int getTotalRows() throws DataAccessObjectException {
-        if (totalRows == 0) {
-            totalRows = DAORowUtil.calculateTotalRows(this);
-        }
-        return totalRows;
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
This is a better solution that was submitted earlier today.  Rather than just skipping the row count, the property allows users to decide whether they want it calculated and reported in progress updates or not.

The default value is true.