### PR TITLE
New BasicDataSource subclass uses EncryptionUtil to decrypt database passwords

### DIFF
--- a/src/main/java/com/salesforce/dataloader/dao/DataSource.java
+++ b/src/main/java/com/salesforce/dataloader/dao/DataSource.java
@@ -1,0 +1,33 @@
+package com.salesforce.dataloader.dao.database;
+
+import java.io.IOException;
+import sun.misc.BASE64Decoder;
+import org.apache.log4j.Logger;
+
+import org.apache.commons.dbcp.BasicDataSource;
+
+public class DataSource extends org.apache.commons.dbcp.BasicDataSource {
+
+    public DataSource() {
+        super();
+    }
+
+    public synchronized void setPassword(String encodedPassword) {
+    	logger.warn("encoded password is " + encodedPassword);
+    	this.password = decode(encodedPassword);
+    }
+    
+    private String decode(String password) {
+        BASE64Decoder decoder = new BASE64Decoder();
+        String decodedPassword = null;
+        try {
+        	decodedPassword = new String(decoder.decodeBuffer(password));
+        } catch (IOException e) {
+        	e.printStackTrace();
+        }
+        
+        return decodedPassword;
+    }
+    
+    private static Logger logger = Logger.getLogger(DataSource.class);
+}


### PR DESCRIPTION
For Issue #64, To use encrypted passwords (encrypt -e password) as database passwords inside database-conf.xml, all users need to do is use the classname "com.salesforce.dataloader.dao.database.DataSource" instead of "org.apache.commons.dbcp.BasicDataSource" in their DB connection bean.

An example would be:
```
<bean id="qa" class="com.salesforce.dataloader.dao.database.DataSource" destroy-method="close">
    <property name="driverClassName" value="oracle.jdbc.OracleDriver"/>
    <property name="url" value="jdbc:oracle:thin:username/@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=host.domain.lan)(PORT = 1521)) (CONNECT_DATA = (SERVER = DEDICATED) (SERVICE_NAME = CRXXXXA)))"/>
    <property name="username" value="username"/>
    <property name="password" value="51df4a60230cb4fc5e7cd752e605d44108e77ee68be2d911"/>
</bean>
```
This reduces the risk of sharing configuration files with other developers, and especially through repositories like "git" where everything is remembered.