### PR TITLE
use ApplicationContext instead of XmlBeanFactory

### DIFF
--- a/src/main/java/com/salesforce/dataloader/dao/database/DatabaseConfig.java
+++ b/src/main/java/com/salesforce/dataloader/dao/database/DatabaseConfig.java
@@ -26,8 +26,8 @@
 package com.salesforce.dataloader.dao.database;
 
 import org.apache.commons.dbcp.BasicDataSource;
-import org.springframework.beans.factory.xml.XmlBeanFactory;
-import org.springframework.core.io.FileSystemResource;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.FileSystemXmlApplicationContext;
 
 public class DatabaseConfig {
     private BasicDataSource dataSource;
@@ -44,7 +44,14 @@ public class DatabaseConfig {
      * @return instance of database configuration
      */
     public static DatabaseConfig getInstance (String dbConfigFilename, String dbConnectionName) {
-        XmlBeanFactory configFactory = new XmlBeanFactory(new FileSystemResource(dbConfigFilename));
+    	String dbConfigFileLocation = dbConfigFilename;
+    	
+    	//don't modify window local file system paths or URIs
+        if (!dbConfigFileLocation.contains(":")){
+        	dbConfigFileLocation = "file://".concat(dbConfigFileLocation);
+        }
+        
+    	ApplicationContext  configFactory = new FileSystemXmlApplicationContext(dbConfigFileLocation);
         return (DatabaseConfig)configFactory.getBean(dbConnectionName);
     }
 


### PR DESCRIPTION
This change will allow using variables in the SQL's that are defined in database config file. The variables can be set in config.properties or as an environment variable.
