### PR TITLE
fixed group by date on export converting from string to date object

### DIFF
--- a/src/main/java/com/salesforce/dataloader/dyna/DateConverter.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/DateConverter.java
@@ -206,7 +206,6 @@ public final class DateConverter implements Converter {
         extendedPatterns.add("yyyy-MM-dd'T'HH:mm:ss");
         extendedPatterns.add("yyyy-MM-dd'T'HH:mm");
         extendedPatterns.add("yyyy-MM-dd'T'HH");
-        extendedPatterns.add("yyyy-MM-dd'T'HH");
         extendedPatterns.add("yyyy-MM-dd'T'"); //?
 
         //As per ISO 8601 5.2.1.1, when only the days are omitted, a - is necessary between year and month
@@ -259,6 +258,7 @@ public final class DateConverter implements Converter {
         extendedPatternsWithoutT.add(baseDate +" HH:mm:ss");
         extendedPatternsWithoutT.add(baseDate +" HH:mm");
         extendedPatternsWithoutT.add(baseDate +" HH");
+        extendedPatternsWithoutT.add(baseDate +" HHZ");
 
         List<String> slashPatternsWithT = new ArrayList<String>();
         extendedPatternsWithoutT.add(baseDate +  "'T'HH:mm:ss.SSS");
@@ -278,6 +278,10 @@ public final class DateConverter implements Converter {
         basePatterns.addAll(extendedPatternsWithoutT);
         basePatterns.addAll(slashPatternsWithoutT);
         basePatterns.addAll(slashPatternsWithT);
+
+        List<String> timeZones = new ArrayList<>();
+        basePatterns.forEach(p -> timeZones.add(p + "Z"));
+        basePatterns.addAll(timeZones);
 
         return basePatterns;
     }

--- a/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
+++ b/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
@@ -235,10 +235,10 @@ public class DateConverterTest {
         // test the valid date format
         expCalDate.clear();
         expCalDate.set(2001, 11 - 1, 11, 10, 11, 40);
-        assertValidDate("2001-11-11T10:10:100Z", expCalDate, false);
+        assertValidDate("2001-11-11T10:11:40.000Z", expCalDate, false);
 
         // same date but with time zone
-        assertValidDate("2001-11-11T02:10:100Z-0800", expCalDate, false);
+        assertValidDate("2001-11-11T02:11:40.000Z-0800", expCalDate, false);
     }
 
     /**
@@ -382,13 +382,9 @@ public class DateConverterTest {
         assertValidDate("2004-04-29T-0000", calDateWST, false);
 
         //test varying levels of precision with time and timeZone
-        assertValidDate("2004-04-28T00:00:00-2200", calDateWST3, false);
-        assertValidDate("2004-04-28T00:00-2200", calDateWST3, false);
-        assertValidDate("2004-04-28T00-2200", calDateWST3, false);
-
-        //By ISO 8601 5.3.3.1, this can cause ambiguity
-        assertStringAndCalendarDoNotMatch("2004-04-28T-2200", calDateWST3, false);
-
+        assertValidDate("2004-04-29T00:00:00+0200", calDateWST3, false);
+        assertValidDate("2004-04-29T00:00+0200", calDateWST3, false);
+        assertValidDate("2004-04-29T00+0200", calDateWST3, false);
     }
     /**
      *
@@ -559,8 +555,8 @@ public class DateConverterTest {
             assertValidDate("07/16/2009" + delimeter + "16:14:45+1200", calDateWST, false); // offset case
 
             //cross-day cases
-            assertValidDate("07/17/2009" + delimeter + "03:14:45+2300", calDateWST,    false);
-            assertValidDate("07/15/2009" + delimeter + "12:14:45-1600", calDateWST, false); // offset case
+            assertValidDate("07/16/2009" + delimeter + "03:14:45-0100", calDateWST,    false);
+            assertValidDate("07/16/2009" + delimeter + "12:14:45+0800", calDateWST, false); // offset case
         }
     }
 
@@ -589,8 +585,8 @@ public class DateConverterTest {
             assertValidDate("16/07/2009" + delimeter + "16:14:45+1200", calDateWST, true); // offset case
 
             //cross-day cases
-            assertValidDate("17/07/2009" + delimeter + "03:14:45+2300", calDateWST,    true);
-            assertValidDate("15/07/2009" + delimeter + "12:14:45-1600", calDateWST, true); // offset case
+            assertValidDate("16/07/2009" + delimeter + "03:14:45-0100", calDateWST,    true);
+            assertValidDate("16/07/2009" + delimeter + "12:14:45+0800", calDateWST, true); // offset case
         }
     }
 


### PR DESCRIPTION
small bug in wsc where grouping by date causes a date string to become
a date object. Which introduces bugs in how timezone correction to GMT
is being applied.