### PR TITLE
Improve the release instructions and bump the release number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.force</groupId>
   <artifactId>dataloader</artifactId>
   <packaging>jar</packaging>
-  <version>38.0.0</version>
+  <version>38.0.1</version>
   <name>Data Loader</name>
   <url>https://github.com/forcedotcom/dataloader</url>
   <organization>


### PR DESCRIPTION
Old release instructions with multiple line property parameter causes issue in release.  We need to release a new version to enable Oauth feature. 