### PR TITLE
Fix url redirected after cancelation

### DIFF
--- a/src/main/java/com/salesforce/dataloader/model/LoginCriteria.java
+++ b/src/main/java/com/salesforce/dataloader/model/LoginCriteria.java
@@ -96,7 +96,6 @@ public class LoginCriteria {
     public void updateConfig(Config config) {
         config.setValue(Config.USERNAME, config.STRING_DEFAULT);
         config.setValue(Config.PASSWORD, config.STRING_DEFAULT);
-        config.setValue(Config.ENDPOINT, config.STRING_DEFAULT);
         config.setValue(Config.SFDC_INTERNAL_IS_SESSION_ID_LOGIN, false);
         config.setValue(Config.SFDC_INTERNAL_SESSION_ID, config.STRING_DEFAULT);
         config.setValue(Config.OAUTH_ENVIRONMENT, config.STRING_DEFAULT);


### PR DESCRIPTION
This is fix a customer case, where user logged in using Oauth, but switched the user name and cancel it,  then the default host address is changed to the blitz url.   