### PR TITLE
Fix an issue when CLI will fail to find extracted columns while exporting to DB

### DIFF
--- a/src/main/java/com/salesforce/dataloader/model/Row.java
+++ b/src/main/java/com/salesforce/dataloader/model/Row.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * Basically a Row is a set of column names and column values which can come from a CSV file, a database
@@ -50,7 +51,7 @@ public class Row implements Map<String, Object> {
     }
 
     public Row(int columnCount) {
-        internalMap = new HashMap<String, Object>(columnCount);
+        internalMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     }
 
     public Row(Map<String, Object> internalMap) {


### PR DESCRIPTION
Fixing SF ticket W-3732361.   Dataloader command line exports objects in  windows command line environment, it will complain columns names not found while uploading to external DB. 