### PR TITLE
allow to select all idLookup-Fields in upserts (esp. Name)

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/ExternalIdPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/ExternalIdPage.java
@@ -137,11 +137,8 @@ public class ExternalIdPage extends LoadPage {
         Field[] fields = fieldTypes.getFields();
         ArrayList<String> extIdFields = new ArrayList<String>();
         for(Field field : fields) {
-            // salesforce id can be used for upsert in addition to external id fields
-            if("id".equals(field.getName().toLowerCase())) {
-                extIdFields.add(field.getName());
-            }
-            if(field.isExternalId() && (field.isCreateable() || field.isUpdateable())) {
+            // every idLookup field can be used for upserts, including Id and Name
+            if(field.isIdLookup()) {
                 extIdFields.add(field.getName());
             }
         }

--- a/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
@@ -594,7 +594,15 @@ public class MappingDialog extends Dialog {
         ArrayList<Field> mappableFieldList = new ArrayList<Field>();
         ArrayList<Field> allFieldList = new ArrayList<Field>();
         Field field;
-        OperationInfo operation = controller.getConfig().getOperationInfo();
+        Config config = controller.getConfig();
+        OperationInfo operation = config.getOperationInfo();
+        String extIdField = config.getString(Config.EXTERNAL_ID_FIELD);
+        if(extIdField == null) {
+            extIdField = "";
+        } else {
+            extIdField = extIdField.toLowerCase();
+        }
+
         for (int i = 0; i < sforceFieldInfo.length; i++) {
 
             field = sforceFieldInfo[i];
@@ -613,7 +621,9 @@ public class MappingDialog extends Dialog {
                 break;
             case upsert:
                 if (field.isUpdateable() || field.isCreateable()
-                        || field.getType().toString().toLowerCase().equals("id")) {
+                        // also add idLookup-Fields (such as Id, Name) IF they are used as extIdField in this upsert
+                        // (no need to add them otherwise, if they are not updateable/createable)
+                        || (field.isIdLookup() && extIdField.equals(field.getName().toLowerCase()))) {
                     isMappable = true;
                 }
                 break;


### PR DESCRIPTION
This PR fixes this [idea](https://partners.salesforce.com/ideaView?id=0873A000000lIS0QAM).

The Dataloader only allowed to select fields that matched these criteria:
```java
// salesforce id can be used for upsert in addition to external id fields
if("id".equals(field.getName().toLowerCase())) {
    extIdFields.add(field.getName());
}
if(field.isExternalId() && (field.isCreateable() || field.isUpdateable())) {
    extIdFields.add(field.getName());
}
```
Yet, as per [the docs](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/access_for_fields.htm), this is in fact not the right way to filter them; instead `idLookup` should be checked:

> idLookup
> Can be used to specify a record in an upsert call. The Id field of each object has this property and some Name fields. There are exceptions, so check for the property in any object you wish to upsert.

Please note that *with* these changes, the Dataloader behaves **the same way** as both the workbench and the salesforce import wizard (allowing users to select name if applicable).

Also included in this PR is a change that makes it more clear which fields can be mapped. Before, you could map `Id` in an `upsert action` where it was not the external id field, even though it is not updatable. Now, it can only be mapped if it's used as an external id.


This PR was tested and we made sure not to break any edge-case we could think of; even if you supply invalid external ids it will break in the same way as with invalid ids (with a different error message, but this would be due to the server handling invalid ids differently from invalid external ids).