### PR TITLE
Initialize static variables for command line mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.force</groupId>
   <artifactId>dataloader</artifactId>
   <packaging>jar</packaging>
-  <version>42.0.0</version>
+  <version>42.1.0</version>
   <name>Data Loader</name>
   <url>https://github.com/forcedotcom/dataloader</url>
   <organization>

--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -304,8 +304,8 @@ public class Controller {
      */
     private static File getUserConfigDir() {
         if (OS_TYPE == null) {
-            logger.error("getUserConfigDir(): Control static values are not initiallized " );
-            throw new RuntimeException("Os type not initialled correctly!");
+            logger.error("getUserConfigDir(): Control static values are not initialized." );
+            throw new RuntimeException("OS type not initialized correctly!");
         }
 
         File dir;

--- a/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
@@ -55,21 +55,28 @@ package com.salesforce.dataloader.process;
  * @author Lexi Viripaeff
  */
 
-import java.util.*;
-import java.util.Calendar;
-
-import javax.xml.parsers.FactoryConfigurationError;
-
-import org.apache.log4j.Logger;
-import org.quartz.*;
-import org.springframework.beans.factory.InitializingBean;
-
 import com.salesforce.dataloader.action.progress.ILoaderProgress;
 import com.salesforce.dataloader.action.progress.NihilistProgressAdapter;
-import com.salesforce.dataloader.config.*;
+import com.salesforce.dataloader.config.Config;
+import com.salesforce.dataloader.config.LastRun;
+import com.salesforce.dataloader.config.Messages;
 import com.salesforce.dataloader.controller.Controller;
-import com.salesforce.dataloader.exception.*;
+import com.salesforce.dataloader.exception.ControllerInitializationException;
+import com.salesforce.dataloader.exception.ParameterLoadException;
+import com.salesforce.dataloader.exception.ProcessInitializationException;
 import com.sforce.soap.partner.fault.ApiFault;
+
+import org.apache.log4j.Logger;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.InitializingBean;
+
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.FactoryConfigurationError;
 
 public class ProcessRunner implements InitializingBean, Job, Runnable {
 
@@ -170,6 +177,12 @@ public class ProcessRunner implements InitializingBean, Job, Runnable {
     }
 
     private static void ensureLogging() throws FactoryConfigurationError {
+        try {
+            Controller.initStaticVariable();
+        } catch (ControllerInitializationException e) {
+            logger.error("ensureLogging(): Control not initialized", e );
+            throw new RuntimeException(e.getMessage());
+        }
         Controller.initLog();
     }
 


### PR DESCRIPTION
We added new static variable during security fixes.  But in command line mode, they are initialized correctly.   And also bump the to 42.1.0 for release.