### PR TITLE
Sorts the fields array prior to adding data to checkbox table viewer

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionSOQLPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionSOQLPage.java
@@ -476,6 +476,14 @@ public class ExtractionSOQLPage extends ExtractionPage {
 
         DescribeSObjectResult result = controller.getFieldTypes();
         fields = result.getFields();
+        Arrays.sort(fields, new Comparator<Field>(){
+            @Override
+            public int compare(Field f1, Field f2)
+            {
+                return f1.getName().compareTo(f2.getName());
+            }
+        });
+
         fieldViewer.setInput(fields);
         fieldCombo.removeAll();
         List<String> fieldNames = new ArrayList<String>();


### PR DESCRIPTION
Please find a small modification that sorts the fields prior to adding them to the checkbox table.
I'm not sure if there was a reason this wasn't being sorted, but as a frequent Dataloader user, this small addition would be a timesaver.