### PR TITLE
Increase maximum number of proxy port digits in settings dialog

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -522,7 +522,7 @@ public class AdvancedSettingsDialog extends Dialog {
 
         textProxyPort = new Text(restComp, SWT.BORDER);
         textProxyPort.setText(config.getString(Config.PROXY_PORT));
-        textProxyPort.setTextLimit(4);
+        textProxyPort.setTextLimit(5);
         textProxyPort.addVerifyListener(new VerifyListener() {
             @Override
             public void verifyText(VerifyEvent event) {
@@ -530,7 +530,7 @@ public class AdvancedSettingsDialog extends Dialog {
             }
         });
         data = new GridData();
-        data.widthHint = 25;
+        data.widthHint = 30;
         textProxyPort.setLayoutData(data);
 
         //Proxy Username

--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionInputDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionInputDialog.java
@@ -285,7 +285,7 @@ public class ExtractionInputDialog extends Dialog {
 
         textProxyPort = new Text(restComp, SWT.BORDER);
         textProxyPort.setText(config.getString(Config.PROXY_PORT));
-        textProxyPort.setTextLimit(4);
+        textProxyPort.setTextLimit(5);
         textProxyPort.addVerifyListener(new VerifyListener() {
             @Override
             public void verifyText(VerifyEvent event) {
@@ -293,7 +293,7 @@ public class ExtractionInputDialog extends Dialog {
             }
         });
         data = new GridData();
-        data.widthHint = 25;
+        data.widthHint = 30;
         textProxyPort.setLayoutData(data);
 
         //Proxy Username


### PR DESCRIPTION
Some proxies use port numbers with greater than 4 digits. The settings dialog in Dataloader currently only accepts a maximum of 4 digits for the port number. This change increases the maximum to 5 digits and also increases the length of the text field appropriately.