### PR TITLE
Removed spammy 'no value for column' message.

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/BulkLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/BulkLoadVisitor.java
@@ -219,7 +219,7 @@ public class BulkLoadVisitor extends DAOLoadVisitor {
             writeColumnToCsv(out, col);
         } else {
             // all null values should be ignored when using bulk API
-            getLogger().warn(Messages.getMessage(getClass(), "noFieldVal", fieldName));
+            //getLogger().warn(Messages.getMessage(getClass(), "noFieldVal", fieldName));
         }
     }
 


### PR DESCRIPTION
I've seen a few complaints about this message showing up during command line bulk operations.  I can't see much value in it.. the message only appears during bulk loads, so it doesn't appear that it was important for non-bulk loads.  It's simple to remove.  I'm happy to add better commentary or anything else needed to adhere to standards.

Thanks!