### PR TITLE
fix minor limitations in installer and run scripts

### DIFF
--- a/release/mac/dataloader.command
+++ b/release/mac/dataloader.command
@@ -29,5 +29,5 @@ then
     echo "Java JRE ${MIN_JAVA_VERSION} or later is not installed. For example, download and install Zulu OpenJDK ${MIN_JAVA_VERSION} or later JRE for macOS from https://www.azul.com/downloads/zulu/zulu-mac/"
 else
     cd DATALOADER_WORK_DIRECTORY_PLACEHOLDER 
-    java -XstartOnFirstThread -jar ${DATALOADER_UBER_JAR_NAME} salesforce.config.dir=DATALOADER_WORK_DIRECTORY_PLACEHOLDER/configs
+    java -XstartOnFirstThread -jar ${DATALOADER_UBER_JAR_NAME} $@
 fi

--- a/release/mac/install.command
+++ b/release/mac/install.command
@@ -22,10 +22,13 @@ echo "**                                                                     **"
 echo "*************************************************************************"
 echo ""
 
-echo Data Loader installation creates a folder in your \'$HOME\' directory.
-read -p "Which folder should it use? [default: dataloader]: " INSTALLATION_DIR_NAME
+echo Data Loader installation requires you to provide an installation directory to create a version-specific subdirectory for the installation artifacts. 
+echo It uses \'${HOME}\/\<relative path\>\' as the installation directory if you provide a relative path for the installation directory.
+echo ""
+read -p "Provide the installation directory [default: dataloader] : " INSTALLATION_DIR_NAME
 INSTALLATION_DIR_NAME=${INSTALLATION_DIR_NAME:-dataloader}
-DL_FULL_PATH="$HOME/$INSTALLATION_DIR_NAME/v$DATALOADER_VERSION"
+
+[[ ${INSTALLATION_DIR_NAME} = /* ]] && DL_FULL_PATH="${INSTALLATION_DIR_NAME}/v${DATALOADER_VERSION}" || DL_FULL_PATH="${HOME}/${INSTALLATION_DIR_NAME}/v${DATALOADER_VERSION}"
 
 echo Data Loader v$DATALOADER_VERSION will be installed in: $DL_FULL_PATH
 

--- a/release/win/dataloader.bat
+++ b/release/win/dataloader.bat
@@ -49,7 +49,7 @@ echo.
     )
 
 :Run
-    java -jar %DATALOADER_UBER_JAR_NAME% salesforce.config.dir=configs
+    java -jar %DATALOADER_UBER_JAR_NAME% %*
     goto SuccessExit
 
 :SuccessExit

--- a/release/win/install.bat
+++ b/release/win/install.bat
@@ -26,10 +26,23 @@ echo **                                                                     **
 echo *************************************************************************
 echo.
 
-echo Data Loader installation creates a folder in your '%USERPROFILE%' directory.
-set /p DIR_NAME=Which folder should it use? [default: dataloader] || set DIR_NAME=dataloader
+echo Data Loader installation requires you to provide an installation directory to create a version-specific subdirectory for the installation artifacts.
+echo It uses '%USERPROFILE%\^<relative path^>' as the installation directory if you provide a relative path for the installation directory.
+echo.
+set /p DIR_NAME=Provide the installation directory [default: dataloader] : || set DIR_NAME=dataloader
 
-set INSTALLATION_DIR=%USERPROFILE%\%DIR_NAME%\v%DATALOADER_VERSION%
+if "%DIR_NAME%":~1,1%" == ":" (
+    REM absolute path specified
+    set INSTALLATION_DIR=%DIR_NAME%\v%DATALOADER_VERSION%
+) else (
+    if "%DIR_NAME:~0,1%" == "\" (
+        REM absolute path specified
+        set INSTALLATION_DIR=%DIR_NAME%\v%DATALOADER_VERSION%
+    ) else (
+        REM relative path specified
+        set INSTALLATION_DIR=%USERPROFILE%\%DIR_NAME%\v%DATALOADER_VERSION%
+    )
+)
 
 IF EXIST %INSTALLATION_DIR% (
     goto ExistingDir

--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -92,6 +92,7 @@ public class Controller {
      * the system property name used to determine the config directory
      */
     public static final String CONFIG_DIR_PROP = "salesforce.config.dir";
+    public static final String CONFIG_DIR_DEFAULT_VALUE = "configs";
 
     public static final String CONFIG_FILE = "config.properties"; //$NON-NLS-1$
     public static final String DEFAULT_CONFIG_FILE = "defaultConfig.properties"; //$NON-NLS-1$
@@ -383,8 +384,8 @@ public class Controller {
         File configDir;
 
         if (configDirPath == null) {
-            // CONFIG_DIR_PROP param is NOT provided - use user's config dir
-            configDir = Paths.get(System.getProperty("user.dir"), "configs").toFile();
+            // CONFIG_DIR_PROP param is NOT provided through command line or system property - use user's config dir
+            configDir = Paths.get(System.getProperty("user.dir"), CONFIG_DIR_DEFAULT_VALUE).toFile();
             logger.debug(String.format("OS: %s, '%s' NOT provided, setting config dir to : %s", OS_TYPE, CONFIG_DIR_PROP, configDir));
         } else {
             // CONFIG_DIR_PROP is provided - use provided config dir


### PR DESCRIPTION
Fix the following issues:
- installer does not let the admin specify an absolute path for the deployment.

- run script does not let the user specify location of the directory containing config.properties file through the option: salesforce.config.dir