### PR TITLE
fix the warning message by specifying a higher value for cell width.

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/OAuthFlow.java
+++ b/src/main/java/com/salesforce/dataloader/ui/OAuthFlow.java
@@ -69,7 +69,7 @@ public abstract class OAuthFlow extends Dialog {
         // Create the dialog window
         Display display = getParent().getDisplay();
         Shell shell = new Shell(getParent(), SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL | SWT.FILL);
-        Grid12 grid = new Grid12(shell, 30, 600);
+        Grid12 grid = new Grid12(shell, 32, 600);
 
         // Create the web browser
         Browser browser = new Browser(shell, SWT.NONE);


### PR DESCRIPTION
Following warning is logged when OAuth browser window is displayed by DL:

Warning: Expected min height of view: (<NSPopoverTouchBarItemButton: 0x7fc1a9255f10>) to be less than or equal to 30 but got a height of 32.000000.

The code change avoids the display of this warning which causes unnecessary concern for the users.