### PR TITLE
Fix for Windows OAuth login error "Can't access this page We don't su…

### DIFF
--- a/release/win/dataloader.bat
+++ b/release/win/dataloader.bat
@@ -49,7 +49,7 @@ echo.
     )
 
 :Run
-    java -jar %DATALOADER_UBER_JAR_NAME% %*
+    java -D"org.eclipse.swt.browser.IEVersion=12001" -jar %DATALOADER_UBER_JAR_NAME% %*
     goto SuccessExit
 
 :SuccessExit


### PR DESCRIPTION
…pport this browser. Try opening this page in a supported browser"

Fix for Windows OAuth login error "Can't access this page We don't support this browser. Try opening this page in a supported browser"