### PR TITLE
Fix for issue #280

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/BulkLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/BulkLoadVisitor.java
@@ -58,6 +58,7 @@ import com.salesforce.dataloader.exception.DataAccessObjectInitializationExcepti
 import com.salesforce.dataloader.exception.LoadException;
 import com.salesforce.dataloader.exception.OperationException;
 import com.salesforce.dataloader.model.NACalendarValue;
+import com.salesforce.dataloader.model.NADateOnlyCalendarValue;
 import com.salesforce.dataloader.model.NATextValue;
 import com.salesforce.dataloader.model.Row;
 import com.salesforce.dataloader.util.DAORowUtil;
@@ -207,7 +208,7 @@ public class BulkLoadVisitor extends DAOLoadVisitor {
     private void writeSingleColumn(PrintStream out, String fieldName, Object fieldValue) throws LoadException {
         if (fieldValue != null) {
             Object col = fieldValue;
-            if (fieldValue instanceof NACalendarValue) {
+            if (fieldValue instanceof NACalendarValue || fieldValue instanceof NADateOnlyCalendarValue) {
                 col = fieldValue.toString();
             } else if (fieldValue instanceof Calendar) {
                 col = DATE_FMT.format(((Calendar) fieldValue).getTime());

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -179,6 +179,7 @@ public class Config {
     public static final String BULK_API_ZIP_CONTENT = "sfdc.bulkApiZipContent";
     public static final String WIRE_OUTPUT = "sfdc.wireOutput";
     public static final String TIMEZONE = "sfdc.timezone";
+    public static final String ADJUST_DATE_VALUE_FOR_TIMEZONE = "sfdc.timezone.adjustdate";
 
     public static final String OAUTH_PREFIX = "sfdc.oauth.";
     public static final String OAUTH_PARTIAL_BULK = "bulk";
@@ -391,6 +392,7 @@ public class Config {
         setDefaultValue(BULK_API_CHECK_STATUS_INTERVAL, DEFAULT_BULK_API_CHECK_STATUS_INTERVAL);
         setDefaultValue(WIRE_OUTPUT, false);
         setDefaultValue(TIMEZONE, TimeZone.getDefault().getID());
+        setDefaultValue(ADJUST_DATE_VALUE_FOR_TIMEZONE, true);
         //sfdcInternal settings
         setDefaultValue(SFDC_INTERNAL, false);
         setDefaultValue(SFDC_INTERNAL_IS_SESSION_ID_LOGIN, false);

--- a/src/main/java/com/salesforce/dataloader/dyna/DateConverter.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/DateConverter.java
@@ -36,24 +36,24 @@ import org.apache.commons.beanutils.Converter;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
-public final class DateConverter implements Converter {
+public class DateConverter implements Converter {
 
-    private static final TimeZone GMT_TZ = TimeZone.getTimeZone("GMT");
-    private static final List<String> supportedEuropeanPatterns = getSupportedPatterns(true);
-    private static final List<String> supportedRegularPatterns = getSupportedPatterns(false);
+    static final TimeZone GMT_TZ = TimeZone.getTimeZone("GMT");
+    static final List<String> supportedEuropeanPatterns = getSupportedPatterns(true);
+    static final List<String> supportedRegularPatterns = getSupportedPatterns(false);
 
     static Logger logger = LogManager.getLogger(DateConverter.class);
     /**
      * The default value specified to our Constructor, if any.
      */
-    private final Object defaultValue;
+    final Object defaultValue;
 
     /**
      * Should we return the default value on conversion errors?
      */
-    private final boolean useDefault;
-    private final boolean useEuroDates;
-    private final TimeZone timeZone;
+    final boolean useDefault;
+    final boolean useEuroDates;
+    final TimeZone timeZone;
 
 
 
@@ -81,7 +81,7 @@ public final class DateConverter implements Converter {
         this(tz, defaultValue, false, true);
     }
 
-    private Calendar parseDate(TimeZone tz, String dateString, String pattern) {
+    Calendar parseDate(TimeZone tz, String dateString, String pattern) {
         final DateFormat df = new SimpleDateFormat(pattern);
         df.setTimeZone(tz);
         return parseDate(dateString, df);
@@ -93,8 +93,8 @@ public final class DateConverter implements Converter {
         final Date date = fmt.parse(dateString, pos);
         // we only want to use the date if parsing succeeded and used the entire string
         if (date != null && pos.getIndex() == dateString.length()) {
-            Calendar cal = Calendar.getInstance(timeZone);
-            cal.setTime(date);
+            Calendar cal = getCalendar();
+            cal.setTimeInMillis(date.getTime());
             return cal;
         }
         return null;
@@ -126,13 +126,13 @@ public final class DateConverter implements Converter {
         }
 
         if(value instanceof NATextValue) {
-            return NACalendarValue.getInstance();
+            return getNAValueCalendar();
         }
         
-        Calendar cal = Calendar.getInstance(this.timeZone);
+        Calendar cal = getCalendar();
 
         if (value instanceof Date) {
-            cal.setTime((Date)value);
+            cal.setTimeInMillis(((Date)value).getTime());
             return cal;
         }
 
@@ -194,9 +194,17 @@ public final class DateConverter implements Converter {
             throw new ConversionException("Failed to parse date: " + value);
         }
     }
+    
+    Calendar getCalendar() {
+        return Calendar.getInstance(this.timeZone);
+    }
+    
+    Calendar getNAValueCalendar() {
+        return NACalendarValue.getInstance();
+    }
 
     /* Helper function to produce all the patterns that DL supports */
-    private static List<String> getSupportedPatterns(boolean europeanDates) {
+    static List<String> getSupportedPatterns(boolean europeanDates) {
 
         List<String> basePatterns = new ArrayList<String>();
 

--- a/src/main/java/com/salesforce/dataloader/dyna/DateOnlyConverter.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/DateOnlyConverter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2015, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.dataloader.dyna;
+
+import java.util.*;
+
+import com.salesforce.dataloader.util.DateOnlyCalendar;
+import com.salesforce.dataloader.model.NADateOnlyCalendarValue;
+import org.apache.commons.beanutils.Converter;
+
+public class DateOnlyConverter extends DateConverter implements Converter {
+
+    public DateOnlyConverter(TimeZone tz) {
+        super(tz);
+    }
+
+    public DateOnlyConverter(TimeZone tz, boolean useEuroDateFormat) {
+        super(tz, useEuroDateFormat);
+    }
+
+    public DateOnlyConverter(TimeZone tz, Object defaultValue, boolean useEuroDateFormat) {
+        super(tz, defaultValue, useEuroDateFormat);
+    }
+
+    public DateOnlyConverter(TimeZone tz, Object defaultValue) {
+       super(tz, defaultValue);
+    }
+    
+    Calendar getCalendar() {
+        return DateOnlyCalendar.getInstance(this.timeZone);
+    }
+    
+    Calendar getNAValueCalendar() {
+        return NADateOnlyCalendarValue.getInstance();
+    }
+}

--- a/src/main/java/com/salesforce/dataloader/dyna/SforceDynaBean.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/SforceDynaBean.java
@@ -28,6 +28,7 @@ package com.salesforce.dataloader.dyna;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
+import com.salesforce.dataloader.util.DateOnlyCalendar;
 import com.salesforce.dataloader.model.Row;
 import org.apache.commons.beanutils.*;
 import org.apache.logging.log4j.Logger;
@@ -174,7 +175,7 @@ public class SforceDynaBean {
             classType = Boolean.class;
             break;
         case date:
-            classType = Calendar.class;
+            classType = DateOnlyCalendar.class;
             break;
         case base64Binary:
             classType = byte[].class;
@@ -313,6 +314,7 @@ public class SforceDynaBean {
         final TimeZone tz = cfg.getTimeZone();
         // Register DynaBean type conversions
         ConvertUtils.register(new DateConverter(tz, useEuroDates), Calendar.class);
+        ConvertUtils.register(new DateOnlyConverter(tz, useEuroDates), DateOnlyCalendar.class);
         ConvertUtils.register(new DoubleConverter(), Double.class);
         ConvertUtils.register(new IntegerConverter(null), Integer.class);
         ConvertUtils.register(new BooleanConverter(), Boolean.class);

--- a/src/main/java/com/salesforce/dataloader/model/NADateOnlyCalendarValue.java
+++ b/src/main/java/com/salesforce/dataloader/model/NADateOnlyCalendarValue.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2015, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.dataloader.model;
+
+import com.salesforce.dataloader.util.DateOnlyCalendar;
+
+public class NADateOnlyCalendarValue  extends DateOnlyCalendar {
+
+    private static final NADateOnlyCalendarValue INSTANCE = new NADateOnlyCalendarValue();
+    private static final String NA_VALUE = "#N/A";
+
+    private NADateOnlyCalendarValue() {
+        super();
+    }
+
+    public static NADateOnlyCalendarValue getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+
+        return NA_VALUE.equals(obj.toString());
+    }
+
+    @Override
+    public int hashCode() {
+        return NA_VALUE.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return NA_VALUE;
+    }
+}

--- a/src/main/java/com/salesforce/dataloader/util/DateOnlyCalendar.java
+++ b/src/main/java/com/salesforce/dataloader/util/DateOnlyCalendar.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.dataloader.util;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import com.salesforce.dataloader.config.Config;
+import com.salesforce.dataloader.controller.Controller;
+
+public class DateOnlyCalendar extends GregorianCalendar {
+
+    public DateOnlyCalendar() {
+        super();
+    }
+    
+    private DateOnlyCalendar(TimeZone tz) {
+        // Use the timezone param to update the date by 1 in setDate()
+        super(tz);
+    }
+    
+    public void setTimeInMillis(long specifiedTimeInMilliSeconds) {
+        TimeZone myTimeZone = super.getTimeZone();
+        Calendar cal = Calendar.getInstance(myTimeZone);
+        cal.setTimeInMillis(specifiedTimeInMilliSeconds);
+        boolean adjustDateValueForTZ = true;
+        Controller controller = Controller.getAnInstanceAcrossAllThreads();
+        if (controller != null) {
+            Config config = controller.getConfig();
+            adjustDateValueForTZ = config.getBoolean(Config.ADJUST_DATE_VALUE_FOR_TIMEZONE);
+        }
+        TimeZone gmt = TimeZone.getTimeZone("GMT");
+        if (adjustDateValueForTZ && myTimeZone != null) {
+            int timeZoneDifference = myTimeZone.getRawOffset() - gmt.getRawOffset() + myTimeZone.getDSTSavings() - gmt.getDSTSavings();
+            if (timeZoneDifference > 0) {
+                // timezone is ahead of GMT, add 1 day to the specified time in milliseconds
+                cal.add(Calendar.DATE, 1);
+            }
+        }
+        super.setTimeInMillis(cal.getTimeInMillis());
+    }
+    
+    public static DateOnlyCalendar getInstance(TimeZone timeZone) {
+        return new DateOnlyCalendar(timeZone);
+    }
+}

--- a/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
+++ b/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
@@ -627,24 +627,71 @@ public class DateConverterTest {
 
     @Test
     public void testUserSpecifiedTimeZoneIsUsed() throws Exception {
-        DateConverter dateConverter = new DateConverter(TimeZone.getTimeZone("Asia/Tokyo"));
+        DateConverter AsianTZDateConverter = new DateConverter(TimeZone.getTimeZone("Asia/Tokyo"));
+        DateConverter USTZDateConverter = new DateConverter(TimeZone.getTimeZone("America/Los_Angeles"));
+        DateConverter GMTTZDateConverter = new DateConverter(TimeZone.getTimeZone("GMT"));
+        DateOnlyConverter AsianTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("Asia/Tokyo"));
+        DateOnlyConverter USTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("America/Los_Angeles"));
+        DateOnlyConverter GMTTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("GMT"));
 
-        Calendar result = (Calendar) dateConverter.convert(null, "6/7/2012");
+        // DateConverter should always return the Calendar in GMT.
+        Calendar result = (Calendar) AsianTZDateConverter.convert(null, "6/7/2012");
         assertEquals(6, result.get(Calendar.MONTH) + 1);
         assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
         assertEquals(TimeZone.getTimeZone("Asia/Tokyo"), result.getTimeZone());
 
-        result = (Calendar) dateConverter.convert(null, "6/7/2012 0:00");
+        result = (Calendar) USTZDateConverter.convert(null, "6/7/2012");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+
+        result = (Calendar) GMTTZDateConverter.convert(null, "6/7/2012");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("GMT"), result.getTimeZone());
+
+        // DateConverter should always return the Calendar in GMT.
+        result = (Calendar) AsianTZDateOnlyConverter.convert(null, "6/7/2012");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        
+        // subtract 1 from the result to compensate for the fact that
+        // DateConverter adds 1 day for date values that do not contain
+        // hours and for the timezones that are ahead of
+        // GMT.
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH) - 1);
+        assertEquals(TimeZone.getTimeZone("Asia/Tokyo"), result.getTimeZone());
+
+        result = (Calendar) USTZDateOnlyConverter.convert(null, "6/7/2012");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+
+        result = (Calendar) GMTTZDateOnlyConverter.convert(null, "6/7/2012");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("GMT"), result.getTimeZone());
+
+        result = (Calendar) AsianTZDateConverter.convert(null, "6/7/2012 0:00");
         assertEquals(6, result.get(Calendar.MONTH) + 1);
         assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
         assertEquals(TimeZone.getTimeZone("Asia/Tokyo"), result.getTimeZone());
 
-        result = (Calendar) dateConverter.convert(null, "2012-06-07 00:00:00JST");
+        result = (Calendar) USTZDateConverter.convert(null, "6/7/2012 0:00");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+
+        result = (Calendar) AsianTZDateConverter.convert(null, "2012-06-07 00:00:00JST");
         assertEquals(6, result.get(Calendar.MONTH) + 1);
         assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
         assertEquals(TimeZone.getTimeZone("Asia/Tokyo"), result.getTimeZone());
 
-        result = (Calendar) dateConverter.convert(null, "2012-06-07 00:00:00JST");
+        result = (Calendar) USTZDateConverter.convert(null, "2012-06-07 00:00:00PST");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+
+        result = (Calendar) AsianTZDateConverter.convert(null, "2012-06-07 00:00:00JST");
         assertEquals(6, result.get(Calendar.MONTH) + 1);
         assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
         assertEquals(TimeZone.getTimeZone("Asia/Tokyo"), result.getTimeZone());


### PR DESCRIPTION
Fix for #280 (Dates automatically go back one day after the update) by mapping xsd:date to DateOnlyCalendar which adjusts for timezones ahead of GMT.