### PR TITLE
plugin for dependency management and related updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ local-proj-repo/com/
 local-proj-repo/junit/
 local-proj-repo/org/
 pom.xml.save
+pom.xml.versionsBackup

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         </exclusion>
       </exclusions>
     </dependency>
-    
+
 <!-- Testing dependencies -->
 <!-- https://mvnrepository.com/artifact/com.h2database/h2 -->
     <dependency>
@@ -190,7 +190,72 @@
       </testResource>
     </testResources>
 
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.8.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
+<!-- plugins inherited from parent whose version needs to be specified
+     to clear mvn versions:display-plugin-updates
+ -->
+<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-clean-plugin -->
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-clean-plugin</artifactId>
+      <version>3.1.0</version>
+    </plugin>
+<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-deploy-plugin -->
+	<plugin>
+	  <groupId>org.apache.maven.plugins</groupId>
+	  <artifactId>maven-deploy-plugin</artifactId>
+	  <version>3.0.0-M1</version>
+	</plugin>
+<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-install-plugin -->
+	<plugin>
+	  <groupId>org.apache.maven.plugins</groupId>
+	  <artifactId>maven-install-plugin</artifactId>
+	  <version>3.0.0-M1</version>
+	</plugin>
+<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-jar-plugin -->
+	<plugin>
+	  <groupId>org.apache.maven.plugins</groupId>
+	  <artifactId>maven-jar-plugin</artifactId>
+   <version>3.2.0</version>
+	</plugin>
+<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-site-plugin -->
+	<plugin>
+	  <groupId>org.apache.maven.plugins</groupId>
+	  <artifactId>maven-site-plugin</artifactId>
+	  <version>3.9.1</version>
+	</plugin>
+
+<!-- plugins explicitly included in the project -->
+<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-enforcer-plugin -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.6</version>
+                </requireMavenVersion>
+              </rules>    
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-resources-plugin -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- versions-maven-plugin to do dependency and plugin version management (checks and updates). Run "mvn versions:use-latest-releases" to update dependencies to the latest version. Run "mvn versions:display-dependency-updates" to see which dependencies need an update.

- maven-enforcer-plugin to make sure that the maven version used supports the plugin and dependency versions specified in the pom.xml file.

- Added plugins to fix the warnings generated by "mvn versions:display-plugin-updates" command.