### PR TITLE
fix for issue #279 - support parent lookup during upsert using idLookup attribute of a field

### DIFF
--- a/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
+++ b/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
@@ -686,7 +686,7 @@ public class PartnerClient extends ClientBase<PartnerConnection> {
                         Field[] refObjectFields = describeSObject(refEntityName).getFields();
                         Map<String, Field> refFieldInfo = new HashMap<String, Field>();
                         for (Field refField : refObjectFields) {
-                            if (refField.isExternalId()) {
+                            if (refField.isExternalId() || refField.isIdLookup()) {
                                 refField.setCreateable(entityField.isCreateable());
                                 refField.setUpdateable(entityField.isUpdateable());
                                 refFieldInfo.put(refField.getName(), refField);


### PR DESCRIPTION
Upsert supports parent lookup through any field whose "idLookup" attribute is true. This includes all fields whose "externalId" attribute is true, salesforce id field, and name field of all custom objects. Consequently, added a check to include all fields whose "idLookup" attribute is true in the possible list of fields to use for parent lookup during upsert operation.