### PR TITLE
fix for issue #334

### DIFF
--- a/release/configs/config.properties
+++ b/release/configs/config.properties
@@ -26,7 +26,6 @@ sfdc.bulkApiSerialMode=false
 sfdc.bulkApiZipContent=false
 sfdc.bulkApiCheckStatusInterval=5000
 sfdc.wireOutput=false
-sfdc.timezone=America/Los_Angeles
 sfdcInternal=false
 sfdcInternal.isSessionIdLogin=false
 sfdc.oauth.server=https\://login.salesforce.com


### PR DESCRIPTION
Data Loader's default properties file should not contain a timezone entry. Removing this entry from the properties file enables data loader code to use desktop's timezone as the default value.