### PR TITLE
fix issue with creating desktop shortcut link

### DIFF
--- a/release/win/install.bat
+++ b/release/win/install.bat
@@ -98,17 +98,18 @@ IF EXIST %INSTALLATION_DIR% (
 :CreateDesktopShortcut
     echo.
     set /p REPLY=Would you like to create a desktop icon? [Yes/No]
-    if /I "%REPLY%"=="Y" goto StartMenuShortCutYes
-    if /I "%REPLY%"=="Yes" goto StartMenuShortCutYes
-    if /I "%REPLY%"=="N" goto StartMenuShortCutNo
-    if /I "%REPLY%"=="No" goto StartMenuShortCutNo
+    if /I "%REPLY%"=="Y" goto DesktopShortCutYes
+    if /I "%REPLY%"=="Yes" goto DesktopShortCutYes
+    if /I "%REPLY%"=="N" goto DesktopShortCutNo
+    if /I "%REPLY%"=="No" goto DesktopShortCutNo
     echo Type Yes or No.
     goto CreateDesktopShortcut
-:StartMenuShortCutNo
+:DesktopShortCutNo
     goto Exit
-:StartMenuShortCutYes
+:DesktopShortCutYes
     powershell -Command "$WshShell = New-Object -comObject WScript.Shell; $Shortcut = $WshShell.CreateShortcut(""""$Home\Desktop\Dataloader.lnk""""); $Shortcut.WorkingDirectory = """"$env:INSTALLATION_DIR""""; $Shortcut.TargetPath = """"$env:INSTALLATION_DIR\dataloader.bat""""; $Shortcut.IconLocation = """"$env:INSTALLATION_DIR\dataloader.ico""""; $Shortcut.WindowStyle=7; $Shortcut.Save()"
-    move "%USERPROFILE%\Desktop\Dataloader.lnk" "%USERPROFILE%\Desktop\Dataloader %DATALOADER_VERSION%.lnk" >nul
+    for /f "usebackq tokens=3*" %%D IN (`reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v Desktop`) do set DESKTOP_DIR=%%D
+    move "%USERPROFILE%\Desktop\Dataloader.lnk" "%DESKTOP_DIR%\Dataloader %DATALOADER_VERSION%.lnk" >nul
 
 :Exit
     echo.


### PR DESCRIPTION
Desktop shortcut link is created in %USERPROFILE%\Desktop folder, which is the case for most desktops. However, sometimes Desktop folder is configured in a different location, which results in the missing desktop shortcut link. Fix is to look up the registry to figure out the location of Desktop folder and create the link.