### PR TITLE
simplify bat and shell scripts to launch data loader

### DIFF
--- a/release/linux/dataloader.sh
+++ b/release/linux/dataloader.sh
@@ -29,6 +29,5 @@ then
     echo "Java JRE ${MIN_JAVA_VERSION} or later is not installed. For example, download and install Zulu OpenJDK ${MIN_JAVA_VERSION} or later JRE from https://www.azul.com/downloads/zulu/zulu-mac/"
 else
     cd `dirname $0`
-    SWTDIR=`java -cp ${DATALOADER_UBER_JAR_NAME} com.salesforce.dataloader.process.GetSWTDir`
-    java -Djava.library.path=${SWTDIR} -javaagent:${DATALOADER_UBER_JAR_NAME} -jar ${DATALOADER_UBER_JAR_NAME} $@
+    java -jar ${DATALOADER_UBER_JAR_NAME} $@
 fi

--- a/release/mac/dataloader.app/Contents/MacOS/dataloader
+++ b/release/mac/dataloader.app/Contents/MacOS/dataloader
@@ -29,6 +29,5 @@ then
     echo "Java JRE ${MIN_JAVA_VERSION} or later is not installed. For example, download and install Zulu OpenJDK ${MIN_JAVA_VERSION} or later JRE for macOS from https://www.azul.com/downloads/zulu/zulu-mac/"
 else
     cd `dirname $0`/../../../
-    SWTDIR=`java -cp ${DATALOADER_UBER_JAR_NAME} com.salesforce.dataloader.process.GetSWTDir`
-    java -XstartOnFirstThread -Djava.library.path=${SWTDIR} -javaagent:${DATALOADER_UBER_JAR_NAME} -jar ${DATALOADER_UBER_JAR_NAME} $@
+    java -jar ${DATALOADER_UBER_JAR_NAME} $@
 fi

--- a/release/win/dataloader.bat
+++ b/release/win/dataloader.bat
@@ -50,11 +50,7 @@ echo.
 
 :Run
     
-    set GET_SWT_DIR_CMD="java -cp %DATALOADER_UBER_JAR_NAME% com.salesforce.dataloader.process.GetSWTDir"
-    FOR /F "tokens=* USEBACKQ" %%F IN (`%GET_SWT_DIR_CMD%`) DO (
-        SET SWT_DIR=%%F
-    )
-    java -Djava.library.path=%SWT_DIR% -D"org.eclipse.swt.browser.IEVersion=12001" -javaagent:%DATALOADER_UBER_JAR_NAME% -jar %DATALOADER_UBER_JAR_NAME% %*
+    java -D"org.eclipse.swt.browser.IEVersion=12001" -jar %DATALOADER_UBER_JAR_NAME% %*
     goto SuccessExit
 
 :SuccessExit


### PR DESCRIPTION
Move complexities of setting the correct JVM options and java.lib.path env variable to the dir containing SWT native libs to Java code.