### PR TITLE
minor cleanup

### DIFF
--- a/dlbuilder.sh
+++ b/dlbuilder.sh
@@ -19,7 +19,7 @@ usage() {
   echo "Usage: "
   echo "$0 -u"
   echo "$0 <keystore password> <PKCS11 config file> <signature algorithm, e.g. RSA1024, RSA2048, ECCP256, ECCP384> <TSA URL> <certchain file> <keystore alias>"
-  echo "$0 -n macos_x86_64 | macos_arm_64 | windows_x86_64 | linux_x86_64"
+  echo "$0 -n mac_x86_64 | mac_aarch64 | win32_x86_64 | linux_x86_64"
   exit 1
 }
 
@@ -35,19 +35,19 @@ run_mvn() {
 # $9 - keystore alias
 
   osSuffix=""
-  if [ "$2" = macos_x86_64 ]
+  if [ "$2" = mac_x86_64 ]
   then
     osSuffix="mac"
     zipdir="target/${osSuffix}"
     from="${zipdir}/dataloader_${osSuffix}.zip"
     to=./dataloader_${osSuffix}.zip
-  elif [ "$2" = macos_arm_64 ] 
+  elif [ "$2" = mac_aarch64 ] 
   then
     osSuffix="mac"
     zipdir="target/${osSuffix}"
     from="${zipdir}/dataloader_${osSuffix}.zip"
     to=./dataloader_${osSuffix}_arm64.zip
-  elif [ "$2" = windows_x86_64 ] 
+  elif [ "$2" = win32_x86_64 ] 
   then
     osSuffix="win"
     zipdir="target/${osSuffix}"
@@ -125,9 +125,9 @@ if [ ${unsignedArtifacts} = false ]; then
 fi
 
 if [ ${doZip} = true ]; then
-  run_mvn "${unsignedArtifacts}" "macos_x86_64" ${doZip} "$1" "$2" "$3" "$4" "$5" "$6"
-  run_mvn "${unsignedArtifacts}" "windows_x86_64" ${doZip} "$1" "$2" "$3" "$4" "$5" "$6"
-#  run_mvn "${unsignedArtifacts}" "macos_arm_64" ${doZip} "$1" "$2" "$3" "$4" "$5" "$6"
+  run_mvn "${unsignedArtifacts}" "mac_x86_64" ${doZip} "$1" "$2" "$3" "$4" "$5" "$6"
+  run_mvn "${unsignedArtifacts}" "win32_x86_64" ${doZip} "$1" "$2" "$3" "$4" "$5" "$6"
+#  run_mvn "${unsignedArtifacts}" "mac_aarch64" ${doZip} "$1" "$2" "$3" "$4" "$5" "$6"
 #  run_mvn "${unsignedArtifacts}" "linux_x86_64" ${doZip} "$1" "$2" "$3" "$4" "$5" "$6"
 else
   run_mvn "${unsignedArtifacts}" "${targetOS}" ${doZip} "$1" "$2" "$3" "$4" "$5" "$6"

--- a/pom.xml
+++ b/pom.xml
@@ -436,11 +436,11 @@
 
   <profiles>
     <profile>
-      <id>macos_x86_64</id>
+      <id>mac_x86_64</id>
       <activation>
         <property>
           <name>targetOS</name>
-          <value>macos_x86_64</value>
+          <value>mac_x86_64</value>
         </property>
       </activation>
       <dependencies>
@@ -456,11 +456,11 @@
     </profile>
 
     <profile>
-      <id>macos_arm_64</id>
+      <id>mac_aarch64</id>
       <activation>
         <property>
           <name>targetOS</name>
-          <value>macos_arm_64</value>
+          <value>mac_aarch64</value>
         </property>
       </activation>
       <dependencies>
@@ -476,11 +476,11 @@
     </profile>
 
     <profile>
-      <id>windows_x86_64</id>
+      <id>win32_x86_64</id>
       <activation>
         <property>
           <name>targetOS</name>
-          <value>windows_x86_64</value>
+          <value>win32_x86_64</value>
         </property>
       </activation>
       <dependencies>

--- a/src/main/assembly/uber.xml
+++ b/src/main/assembly/uber.xml
@@ -12,10 +12,7 @@
       <unpack>true</unpack>
       <scope>runtime</scope>
       <excludes>      
-        <exclude>local.swt:swtmac_aarch64:</exclude>
-        <exclude>local.swt:swtmac_x86_64:</exclude>
-        <exclude>local.swt:swtwin32_x86_64:</exclude>
-        <exclude>local.swt:swtlinux_x86_64:</exclude>
+        <exclude>local.swt:swt${targetOS}:</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>

--- a/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
@@ -55,9 +55,8 @@ public class DataLoaderRunner extends Thread {
     private static final String RUN_MODE = "run.mode";
     private static final String RUN_MODE_BATCH = "batch";
     private static final String GMT_FOR_DATE_FIELD_VALUE = "datefield.usegmt";
-    private static final String SWT_JAR_NAME = "swt.jar.name";
     private static final String SWT_NATIVE_LIB_IN_JAVA_LIB_PATH = "swt.nativelib.inpath";
-    private static final String BUILD_DIR = "./target/";
+    private static final String BUILD_DIR = "target/";
     private static boolean useGMTForDateFieldValue = true;
     private static Map<String, String> argNameValuePair;
 
@@ -109,13 +108,6 @@ public class DataLoaderRunner extends Thread {
                       + System.getProperty("os.arch") + " not supported.");
                     System.err.println("Try JRE for the supported platform in emulation mode.");
                     System.exit(-1);
-                }
-                String swtJarName = buildNameFromOSAndArch("swt", ".jar");
-                if (argNameValuePair.containsKey(SWT_JAR_NAME)) {
-                    String jarname = argNameValuePair.get(swtJarName);
-                    if (jarname != null && !jarname.isEmpty()) {
-                        swtJarName = jarname;
-                    }
                 }
                 Controller controller = Controller.getInstance(UI, false, args);
                 controller.createAndShowGUI();


### PR DESCRIPTION
- remove unused code in DataLoaderRunner.java
- Make targetOS names consistent with SWT jar package names
- Use targetOS property to exclude specific SWT jar from the uber jar, thereby avoiding warning messages for untriggered exclusion patterns.