### PR TITLE
remove unnecessary checkbox to escape formula values in extractions

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -147,7 +147,6 @@ public class Config {
     public static final String CSV_DELIMETER_TAB = "loader.csvTab";
     public static final String CSV_DELIMETER_OTHER = "loader.csvOther";
     public static final String CSV_DELIMETER_OTHER_VALUE = "loader.csvOtherValue";
-    public static final String CSV_ESCAPE_FORMULA_IN_FIELD_VALUE = "loader.csvEscapeFormulaInFieldValue";
     public static final String BUFFER_UNPROCESSED_BULK_QUERY_RESULTS = "loader.bufferUnprocessedBulkQueryResults";
 
     //Special Internal Configs
@@ -431,7 +430,6 @@ public class Config {
         setDefaultValue(BUFFER_UNPROCESSED_BULK_QUERY_RESULTS, false);
         setDefaultValue(BULKV2_API_ENABLED, false);
         setDefaultValue(OAUTH_LOGIN_FROM_BROWSER, false);
-        setDefaultValue(CSV_ESCAPE_FORMULA_IN_FIELD_VALUE, true);
     }
 
     /**

--- a/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileWriter.java
+++ b/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileWriter.java
@@ -74,13 +74,11 @@ public class CSVFileWriter implements DataWriter {
      * If <code>capitalizedHeadings</code> is true, output header row in caps
      */
     private final boolean capitalizedHeadings;
-    private final boolean escapeFormulaValue;
 
     public CSVFileWriter(String fileName, Config config) {
         this.fileName = fileName;
         this.capitalizedHeadings = true;
         encoding = config.getCsvWriteEncoding();
-        this.escapeFormulaValue = config.getBoolean(Config.CSV_ESCAPE_FORMULA_IN_FIELD_VALUE);
         logger.debug(this.getClass().getName(), "encoding used to write to CSV file is " + encoding);
     }
 
@@ -139,7 +137,7 @@ public class CSVFileWriter implements DataWriter {
     }
 
     private void writeHeaderRow() throws DataAccessObjectInitializationException {
-        CSVColumnVisitor visitor = new CSVColumnVisitor(fileOut, this.escapeFormulaValue);
+        CSVColumnVisitor visitor = new CSVColumnVisitor(fileOut, false);
         try {
             visitHeaderColumns(this.columnNames, visitor);
             fileOut.newLine();
@@ -157,7 +155,7 @@ public class CSVFileWriter implements DataWriter {
      */
     @Override
     public boolean writeRow(Row row) throws DataAccessObjectException {
-        CSVColumnVisitor visitor = new CSVColumnVisitor(fileOut, this.escapeFormulaValue);
+        CSVColumnVisitor visitor = new CSVColumnVisitor(fileOut, false);
         try {
             visitColumns(columnNames, row, visitor);
             fileOut.newLine();

--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -103,7 +103,6 @@ public class AdvancedSettingsDialog extends Dialog {
     private Button buttonCsvComma;
     private Button buttonCsvTab;
     private Button buttonCsvOther;
-    private Button buttonCsvEscapeFormulaValue;
     private Button buttonLoginFromBrowser;
 
     /**
@@ -468,14 +467,6 @@ public class AdvancedSettingsDialog extends Dialog {
         data.widthHint = 25;
         textSplitterValue.setLayoutData(data);
         
-        Label labelEscapeFormulaInFieldValue = new Label(restComp, SWT.RIGHT | SWT.WRAP);
-        labelEscapeFormulaInFieldValue.setText(Labels.getString("AdvancedSettingsDialog.escapeFormulaInFieldValue"));
-        data = new GridData(GridData.HORIZONTAL_ALIGN_END);
-        labelEscapeFormulaInFieldValue.setLayoutData(data);
-        buttonCsvEscapeFormulaValue = new Button(restComp, SWT.CHECK);
-        buttonCsvEscapeFormulaValue.setSelection(config.getBoolean(Config.CSV_ESCAPE_FORMULA_IN_FIELD_VALUE));
-
-
         // Enable Bulk API Setting
         Label labelUseBulkApi = new Label(restComp, SWT.RIGHT | SWT.WRAP);
         labelUseBulkApi.setText(Labels.getString("AdvancedSettingsDialog.useBulkApi")); //$NON-NLS-1$
@@ -726,7 +717,6 @@ public class AdvancedSettingsDialog extends Dialog {
                         || textSplitterValue.getText().length() == 0)) {
                     return;
                 }
-                config.setValue(Config.CSV_ESCAPE_FORMULA_IN_FIELD_VALUE, buttonCsvEscapeFormulaValue.getSelection());
                 config.setValue(Config.CSV_DELIMETER_OTHER_VALUE, textSplitterValue.getText());
                 config.setValue(Config.CSV_DELIMETER_COMMA, buttonCsvComma.getSelection());
                 config.setValue(Config.CSV_DELIMETER_TAB, buttonCsvTab.getSelection());


### PR DESCRIPTION
Data Loader extraction already contains double quotes around all values including formulas, thereby escaping them. No need to give users an additional choice to insert a single quote in addition to double quotes surrounding a formula value.