### PR TITLE
minor tweak to the fix for #370

### DIFF
--- a/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
@@ -203,8 +203,7 @@ public class DataLoaderRunner extends Thread {
         String osNameStr = getOSName();
         String archStr = System.getProperty("os.arch");
 
-        if ((osNameStr.equalsIgnoreCase("win32")|| osNameStr.equalsIgnoreCase("linux"))
-             && archStr.toLowerCase().contains("amd")) {
+        if (archStr.toLowerCase().contains("amd")) {
             archStr = "x86_64";
         }
         String pathStr = prefix 


### PR DESCRIPTION
minor tweak - if architecture is amd, use the string "x86_64" when searching for SWT jar file.