### PR TITLE
cleanup initialization and preserve java.library.path values across i…

### DIFF
--- a/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
@@ -295,40 +295,33 @@ public class ProcessRunner implements InitializingBean, Runnable {
      * @throws ProcessInitializationException
      */
     public static synchronized ProcessRunner getInstance(Map<String, String> argMap) throws ProcessInitializationException {
-        ProcessRunner runner;
-        Controller.setConfigDir(argMap);
-        try {
-            Controller.initLog();
-        } catch (ControllerInitializationException e) {
-            System.err.println("ProcessRunner: log not configured" + e );
-            throw new RuntimeException(e.getMessage());
-        }
         logger = LogManager.getLogger(ProcessRunner.class);
         
-            // get a controller instance to load the properties except for the
-            // runtime properties stored in XXX_lastRun.properties file.
-            Controller controller = Controller.getInstance("", true, null);
-            logger.info(Messages.getString("Process.initializingEngine")); //$NON-NLS-1$
-            Config config = controller.getConfig();
-            // load parameter overrides (from command line or caller context)
-            logger.info(Messages.getString("Process.loadingParameters")); //$NON-NLS-1$
-            config.loadParameterOverrides(argMap);
-            String processName = config.getString(PROCESS_NAME);
-            logger.debug("process name is " + processName);
-            if (processName == null || processName.isEmpty()) {
-                logger.info(PROCESS_NAME + "is not set in the command line or config.properties file.");
-                // operation and other process params are specified through properties
-                validateConfigProperties(config);
-                runner = new ProcessRunner();
-                runner.setName(config.getString(Config.OPERATION));
-                runner.setConfigOverrideMap(argMap);
-            } else {
-                // process DynaBean name specified.
-                runner = ProcessConfig.getProcessInstance(processName);
-                runner.getConfigOverrideMap().putAll(argMap);
-            }
+        // get a controller instance to load the properties except for the
+        // runtime properties stored in XXX_lastRun.properties file.
+        Controller controller = Controller.getInstance("", true, null);
+        logger.info(Messages.getString("Process.initializingEngine")); //$NON-NLS-1$
+        Config config = controller.getConfig();
         
-                
+        // load parameter overrides (from command line or caller context)
+        logger.info(Messages.getString("Process.loadingParameters")); //$NON-NLS-1$
+        config.loadParameterOverrides(argMap);
+        String processName = config.getString(PROCESS_NAME);
+        logger.debug("process name is " + processName);
+        
+        ProcessRunner runner;
+        if (processName == null || processName.isEmpty()) {
+            logger.info(PROCESS_NAME + "is not set in the command line or config.properties file.");
+            // operation and other process params are specified through properties
+            validateConfigProperties(config);
+            runner = new ProcessRunner();
+            runner.setName(config.getString(Config.OPERATION));
+            runner.setConfigOverrideMap(argMap);
+        } else {
+            // process DynaBean name specified.
+            runner = ProcessConfig.getProcessInstance(processName);
+            runner.getConfigOverrideMap().putAll(argMap);
+        }
         return runner;
     }
 

--- a/src/test/java/com/salesforce/dataloader/TestBase.java
+++ b/src/test/java/com/salesforce/dataloader/TestBase.java
@@ -105,13 +105,8 @@ public abstract class TestBase {
         TEST_STATUS_DIR = TEST_FILES_DIR + File.separator + "status";
         DEFAULT_ACCOUNT_EXT_ID_FIELD = getProperty("test.account.extid");
         
-        try {
-            String logConfFilePath = Paths.get(getTestConfDir(), Controller.LOG_CONF_DEFAULT).toString();
-            System.setProperty(Controller.SYS_PROP_LOG_CONFIG_FILE, logConfFilePath);
-            Controller.initLog();
-        } catch (ControllerInitializationException ex) {
-            System.out.println(ex.getMessage());
-        }
+        String logConfFilePath = Paths.get(getTestConfDir(), Controller.LOG_CONF_DEFAULT).toString();
+        System.setProperty(Controller.SYS_PROP_LOG_CONFIG_FILE, logConfFilePath);
         logger = LogManager.getLogger(TestBase.class);
     }
 


### PR DESCRIPTION
…nvocations


- Simplify initialization of config dir and logging to make sure config dir is always set before logging is initialized.
- Preserve java.library.path values across invocations by prepending SWT directory location to existing java.library.path.
- Construct SWT directory location from the location of the jar file containing Data Loader classes.