### PR TITLE
specify data loader app version instead of WSC API version in clientName

### DIFF
--- a/src/main/java/com/salesforce/dataloader/client/ClientBase.java
+++ b/src/main/java/com/salesforce/dataloader/client/ClientBase.java
@@ -96,7 +96,9 @@ public abstract class ClientBase<ClientType> {
         final String apiType = cfg.isBulkAPIEnabled() ? BULK_API_CLIENT_TYPE : PARTNER_API_CLIENT_TYPE;
         final String interfaceType = cfg.isBatchMode() ? BATCH_CLIENT_STRING : UI_CLIENT_STRING;
         return new StringBuilder(32).append(BASE_CLIENT_NAME).append(apiType).append(interfaceType)
-                .append("/").append(Controller.API_VERSION).toString(); //$NON-NLS-1$
+                .append("/")
+                .append(Controller.APP_VERSION)
+                .toString(); //$NON-NLS-1$
     }
 
     protected ConnectorConfig getConnectorConfig() {


### PR DESCRIPTION
Specify data loader app version instead of WSC API version in clientName. Doing so makes it easier for customers to identify which data loader patch version their users are using.