### PR TITLE
code cleanup to separate CLI options from config properties

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -58,6 +58,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.StringJoiner;
 import java.util.TimeZone;
 
@@ -318,6 +319,20 @@ public class Config {
      * communications with bulk api always use UTF8
      */
     public static final String BULK_API_ENCODING = "UTF-8";
+    
+    /*
+     * command line options. Not stored in config.properties file.
+     * ************
+     * Option names MUST start with the prefix "CLI_OPTION_"
+     * ************
+     */
+    public static final String CLI_OPTION_RUN_MODE = "run.mode";
+    public static final String RUN_MODE_UI_VAL = "ui";
+    public static final String RUN_MODE_BATCH_VAL = "batch";
+    public static final String CLI_OPTION_GMT_FOR_DATE_FIELD_VALUE = "datefield.usegmt";
+    public static final String CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH = "swt.nativelib.inpath";
+    public static final String CLI_OPTION_CONFIG_DIR_PROP = "salesforce.config.dir";
+    public static final String CONFIG_DIR_DEFAULT_VALUE = "configs";
 
     /**
      * Creates an empty config that loads from and saves to the a file. <p> Use the methods
@@ -925,6 +940,7 @@ public class Config {
         
         skipSaveOfUnsupportedProperties();
         skipSaveOfDecryptedProperties();
+        skipSaveOfCLIOptions();
 
         FileOutputStream out = null;
         try {
@@ -955,6 +971,15 @@ public class Config {
         this.properties.remove(PROXY_PASSWORD + DECRYPTED_SUFFIX);
         this.properties.remove(OAUTH_ACCESSTOKEN + DECRYPTED_SUFFIX);
         this.properties.remove(OAUTH_REFRESHTOKEN + DECRYPTED_SUFFIX);
+    }
+    
+    private void skipSaveOfCLIOptions() {
+        Set<String> keys = this.properties.stringPropertyNames();
+        for (String key : keys) {
+            if (key.startsWith("CLI_OPTION_")) {
+                this.properties.remove(key);
+            }
+        }
     }
     
     /**

--- a/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
@@ -57,14 +57,10 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
 import com.salesforce.dataloader.client.HttpClientTransport;
+import com.salesforce.dataloader.config.Config;
 
 public class DataLoaderRunner extends Thread {
 
-    private static final String UI = "ui";
-    private static final String RUN_MODE = "run.mode";
-    private static final String RUN_MODE_BATCH = "batch";
-    private static final String GMT_FOR_DATE_FIELD_VALUE = "datefield.usegmt";
-    private static final String SWT_NATIVE_LIB_IN_JAVA_LIB_PATH = "swt.nativelib.inpath";
     private static final String LOCAL_SWT_DIR = "target/";
     private static final String PATH_SEPARATOR = System.getProperty("path.separator");
     private static final String FILE_SEPARATOR = System.getProperty("file.separator");
@@ -73,8 +69,8 @@ public class DataLoaderRunner extends Thread {
     private static Logger logger;
 
     private static boolean isBatchMode() {        
-        return argNameValuePair.containsKey(RUN_MODE) ?
-                RUN_MODE_BATCH.equalsIgnoreCase(argNameValuePair.get(RUN_MODE)) : false;
+        return argNameValuePair.containsKey(Config.CLI_OPTION_RUN_MODE) ?
+                Config.RUN_MODE_BATCH_VAL.equalsIgnoreCase(argNameValuePair.get(Config.CLI_OPTION_RUN_MODE)) : false;
     }
     
     public static boolean doUseGMTForDateFieldValue() {
@@ -82,8 +78,8 @@ public class DataLoaderRunner extends Thread {
     }
     
     private static void setUseGMTForDateFieldValue() {
-        if (argNameValuePair.containsKey(GMT_FOR_DATE_FIELD_VALUE)) {
-            if ("false".equalsIgnoreCase(argNameValuePair.get(GMT_FOR_DATE_FIELD_VALUE))) {
+        if (argNameValuePair.containsKey(Config.CLI_OPTION_GMT_FOR_DATE_FIELD_VALUE)) {
+            if ("false".equalsIgnoreCase(argNameValuePair.get(Config.CLI_OPTION_GMT_FOR_DATE_FIELD_VALUE))) {
                 useGMTForDateFieldValue = false;
             }
         }
@@ -99,18 +95,18 @@ public class DataLoaderRunner extends Thread {
     }
 
     public static void main(String[] args) {
-        Controller.initializeConfigDirAndLog(args);
-        Runtime.getRuntime().addShutdownHook(new DataLoaderRunner());
         argNameValuePair = Controller.getArgMapFromArgArray(args);
+        Controller.initializeConfigDirAndLog(argNameValuePair);
+        Runtime.getRuntime().addShutdownHook(new DataLoaderRunner());
         logger = LogManager.getLogger(DataLoaderRunner.class);
         setUseGMTForDateFieldValue();
         if (isBatchMode()) {
             ProcessRunner.runBatchMode(args);
-        } else if (argNameValuePair.containsKey(SWT_NATIVE_LIB_IN_JAVA_LIB_PATH) 
-                && "true".equalsIgnoreCase(argNameValuePair.get(SWT_NATIVE_LIB_IN_JAVA_LIB_PATH))){
+        } else if (argNameValuePair.containsKey(Config.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH) 
+                && "true".equalsIgnoreCase(argNameValuePair.get(Config.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH))){
             /* Run in the UI mode, get the controller instance with batchMode == false */
             try {
-                Controller controller = Controller.getInstance(UI, false, args);
+                Controller controller = Controller.getInstance(Config.RUN_MODE_UI_VAL, false, args);
                 controller.createAndShowGUI();
             } catch (ControllerInitializationException e) {
                 UIUtils.errorMessageBox(new Shell(new Display()), e);
@@ -182,8 +178,8 @@ public class DataLoaderRunner extends Thread {
         }
         
         // add the argument to indicate that JAVA_LIB_PATH has the directory containing SWT native libraries
-        jvmArgs.add(SWT_NATIVE_LIB_IN_JAVA_LIB_PATH + "=true");
-        logger.debug("    " + SWT_NATIVE_LIB_IN_JAVA_LIB_PATH + "=true");
+        jvmArgs.add(Config.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH + "=true");
+        logger.debug("    " + Config.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH + "=true");
         ProcessBuilder processBuilder = new ProcessBuilder(jvmArgs);
         processBuilder.redirectErrorStream(true);
         try {

--- a/src/test/java/com/salesforce/dataloader/TestBase.java
+++ b/src/test/java/com/salesforce/dataloader/TestBase.java
@@ -173,12 +173,12 @@ public abstract class TestBase {
 
     protected void setupController() {
         // configure the Controller to point to our testing config
-        if (!System.getProperties().contains(Controller.CONFIG_DIR_PROP))
-            System.setProperty(Controller.CONFIG_DIR_PROP, getTestConfDir());
+        if (!System.getProperties().contains(Config.CLI_OPTION_CONFIG_DIR_PROP))
+            System.setProperty(Config.CLI_OPTION_CONFIG_DIR_PROP, getTestConfDir());
 
         if (controller == null) {
             try {
-                controller = Controller.getInstance(testName.getMethodName(), true, null);
+                controller = Controller.getInstance(testName.getMethodName(), true, (String[])null);
             } catch (ControllerInitializationException e) {
                 fail("While initializing controller instance", e);
             }


### PR DESCRIPTION
- Do not instantiate Controller when calling ProcessRunner.getInstance().
- Remove old code that assumed packaging prior to JDK 11 upgrade (v45) to figure out default config directory.
- Set config overrides in Controller.initConfig().