### PR TITLE
cleanup of DateOnlyProcessTest

### DIFF
--- a/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
+++ b/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
@@ -662,6 +662,7 @@ public class DateConverterTest {
         result = (Calendar) USTZDateOnlyConverter.convert(null, "6/22/2012");
         assertEquals(6, result.get(Calendar.MONTH) + 1);
         assertEquals(22, result.get(Calendar.DAY_OF_MONTH));
+        DataLoaderRunner.setUseGMTForDateFieldValue(false);
 
         result = (Calendar) GMTTZDateOnlyConverter.convert(null, "6/22/2012");
         assertEquals(6, result.get(Calendar.MONTH) + 1);

--- a/src/test/resources/testfiles/data/dateOnlyWithTimeZone.csv
+++ b/src/test/resources/testfiles/data/dateOnlyWithTimeZone.csv
@@ -1,0 +1,3 @@
+NAME,TYPE,PHONE,ACCOUNTNUMBER__C,WEBSITE,ANNUALREVENUE,ORACLE_ID__C,DATE_ONLY
+account insert #0,Account,415-555-0000,ACCT_0,http://www.accountInsert0.com,0,1-00000,2010-10-14T00:00:00.000Z
+account insert #1,Account,415-555-0000,ACCT_1,http://www.accountInsert1.com,0,1-00001,2010-10-14T00:00:00.000

--- a/src/test/resources/testfiles/data/dateOnlyWithTimeZoneMap.sdl
+++ b/src/test/resources/testfiles/data/dateOnlyWithTimeZoneMap.sdl
@@ -1,0 +1,10 @@
+#Mapping values
+#Tue Jun 20 18:59:17 PDT 2006
+ACCOUNTNUMBER__C=AccountNumber__c
+NAME=Name
+WEBSITE=Website
+TYPE=Type
+ANNUALREVENUE=AnnualRevenue
+PHONE=Phone
+ORACLE_ID__C=Oracle_Id__c
+DATE_ONLY=CustomDateOnly__c


### PR DESCRIPTION
Removed unnecessary tests and unused fields. Also, fixed the issue that it failed when it ran as part of integration test suite but passed when ran in isolation.