### PR TITLE
Change IE compat value in the windows batch file to a valid value

### DIFF
--- a/release/win/dataloader.bat
+++ b/release/win/dataloader.bat
@@ -54,7 +54,7 @@ IF NOT "%DATALOADER_JAVA_HOME%" == "" (
 
 :Run
     
-    java -D"org.eclipse.swt.browser.IEVersion=12001" -jar %DATALOADER_UBER_JAR_NAME% %*
+    java -D"org.eclipse.swt.browser.IEVersion=11001" -jar %DATALOADER_UBER_JAR_NAME% %*
     goto SuccessExit
 
 :SuccessExit


### PR DESCRIPTION
Fixes: https://github.com/forcedotcom/dataloader/issues/410

According to [this part of the docs](https://www.eclipse.org/swt/faq.php#:~:text=Additionally%2C%20the%20Browser%27s,mode%20by%20default.) the value set for this option is one of the values listed [here](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/general-info/ee330730(v=vs.85)?redirectedfrom=MSDN#browser_emulation)

I've found multiple references online to 12001 being the correct value for ie11 edge mode, but no reliable source that would actually confirm this