### PR TITLE
fix for issue #410 - skip setting IEVersion if already specified

### DIFF
--- a/release/win/dataloader.bat
+++ b/release/win/dataloader.bat
@@ -53,20 +53,7 @@ IF NOT "%DATALOADER_JAVA_HOME%" == "" (
     )
 
 :Run
-
-:loop
-    IF NOT "%1"=="" (
-        IF "%1"=="-skipieversion" (
-            set SKIP_IE_VERSION=true
-        )
-        SHIFT
-        goto :loop
-    )
-    IF "%SKIP_IE_VERSION%"=="" (
-        java -D"org.eclipse.swt.browser.IEVersion=12001" -jar %DATALOADER_UBER_JAR_NAME% %*
-    ) ELSE (
-        java -jar %DATALOADER_UBER_JAR_NAME% %*
-    )
+    java -jar %DATALOADER_UBER_JAR_NAME% %*
     goto SuccessExit
 
 :SuccessExit

--- a/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
@@ -111,6 +111,14 @@ public class DataLoaderRunner extends Thread {
                 && "true".equalsIgnoreCase(argNameValuePair.get(Config.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH))){
             /* Run in the UI mode, get the controller instance with batchMode == false */
             try {
+                if ("win32".equalsIgnoreCase(getOSName())) {
+                    String ieVersion = System.getProperty("org.eclipse.swt.browser.IEVersion");
+                    if (ieVersion == null) {
+                        logger.debug("org.eclipse.swt.browser.IEVersion not set for UI mode on Windows");
+                    } else {
+                        logger.debug("org.eclipse.swt.browser.IEVersion set to " + ieVersion + " for UI mode on Windows");
+                    }
+                }
                 Controller controller = Controller.getInstance(Config.RUN_MODE_UI_VAL, false, args);
                 controller.createAndShowGUI();
             } catch (ControllerInitializationException e) {
@@ -158,16 +166,20 @@ public class DataLoaderRunner extends Thread {
         }
         jvmArgs.add("-Djava.library.path=" + librarypath);
         logger.debug("set java.library.path=" + librarypath);
-        jvmArgs.addAll(ManagementFactory.getRuntimeMXBean().getInputArguments());
         
         if ("win32".equalsIgnoreCase(getOSName())) {
             String ieVersion = System.getProperty("org.eclipse.swt.browser.IEVersion");
             if (ieVersion == null) {
-                logger.debug("org.eclipse.swt.browser.IEVersion is not set");
+                logger.debug("setting org.eclipse.swt.browser.IEVersion=12001");
+                jvmArgs.add("-Dorg.eclipse.swt.browser.IEVersion=12001");
             } else {
                 logger.debug("org.eclipse.swt.browser.IEVersion is set to " + ieVersion);
             }
         }
+        
+        // add JVM arguments specified in the command line
+        jvmArgs.addAll(ManagementFactory.getRuntimeMXBean().getInputArguments());
+
         // set classpath
         String classpath = System.getProperty("java.class.path");
         if (classpath != null && !classpath.isBlank()) {


### PR DESCRIPTION
fix for issue #410 - skip setting IEVersion system property if already specified in the java system property "org.eclipse.swt.browser.IEVersion".