### PR TITLE
minor cleanup of process.bat file

### DIFF
--- a/release/win/bin/process.bat
+++ b/release/win/bin/process.bat
@@ -1,12 +1,12 @@
 @echo off
 if not [%1]==[] goto run
 echo.
-echo Usage: process ^<configuration directory^> ^[process bean id^]
+echo Usage: process ^<configuration directory^> ^[batch process bean id^]
 echo.
 echo      configuration directory -- directory that contains configuration files,
 echo          i.e. config.properties, process-conf.xml, database-conf.xml
 echo.
-echo      process bean id -- optional bean id of a batch process bean in process-conf.xml,
+echo      batch process bean id -- optional bean id of a batch process bean in process-conf.xml,
 echo          for example:
 echo.
 echo              process ../myconfigdir AccountInsert
@@ -24,8 +24,8 @@ goto end
 set EXE_PATH=%~dp0
 set DATALOADER_VERSION=@@FULL_VERSION@@
 
-set PROCESS_BEAN_ID_OPTION=
-if not [%2]==[] set PROCESS_BEAN_ID_OPTION=process.name=%2
+set BATCH_PROCESS_BEAN_ID_OPTION=
+if not [%2]==[] set BATCH_PROCESS_BEAN_ID_OPTION=process.name=%2
 
 IF NOT "%DATALOADER_JAVA_HOME%" == "" (
     set JAVA_HOME="%DATALOADER_JAVA_HOME%"
@@ -37,7 +37,7 @@ IF "%JAVA_HOME%" == "" (
     IF NOT EXIST "%JAVA_HOME%" (
         echo We couldn't find the Java Runtime Environment ^(JRE^) in directory "%JAVA_HOME%". To run process.bat, set the JAVA_HOME environment variable to the directory where the JRE is installed.
     ) ELSE (
-        "%JAVA_HOME%\bin\java" -jar "%EXE_PATH%\..\dataloader-%DATALOADER_VERSION%-uber.jar" run.mode=batch salesforce.config.dir=%1 %PROCESS_BEAN_ID_OPTION%
+        "%JAVA_HOME%\bin\java" -jar "%EXE_PATH%\..\dataloader-%DATALOADER_VERSION%-uber.jar" run.mode=batch salesforce.config.dir=%1 %BATCH_PROCESS_BEAN_ID_OPTION%
     )
 )
 

--- a/release/win/bin/process.bat
+++ b/release/win/bin/process.bat
@@ -3,10 +3,10 @@ if not [%1]==[] goto run
 echo.
 echo Usage: process ^<configuration directory^> ^[batch process bean id^]
 echo.
-echo      configuration directory -- directory that contains configuration files,
+echo      configuration directory -- required -- directory that contains configuration files,
 echo          i.e. config.properties, process-conf.xml, database-conf.xml
 echo.
-echo      batch process bean id -- optional bean id of a batch process bean in process-conf.xml,
+echo      batch process bean id -- optional -- id of a batch process bean in process-conf.xml,
 echo          for example:
 echo.
 echo              process ../myconfigdir AccountInsert

--- a/release/win/bin/process.bat
+++ b/release/win/bin/process.bat
@@ -1,12 +1,12 @@
 @echo off
 if not [%1]==[] goto run
 echo.
-echo Usage: process ^<configuration directory^> ^[process name^]
+echo Usage: process ^<configuration directory^> ^[process bean id^]
 echo.
 echo      configuration directory -- directory that contains configuration files,
 echo          i.e. config.properties, process-conf.xml, database-conf.xml
 echo.
-echo      process name -- optional name of a batch process bean in process-conf.xml,
+echo      process bean id -- optional bean id of a batch process bean in process-conf.xml,
 echo          for example:
 echo.
 echo              process ../myconfigdir AccountInsert

--- a/release/win/bin/process.bat
+++ b/release/win/bin/process.bat
@@ -11,7 +11,7 @@ echo          for example:
 echo.
 echo              process ../myconfigdir AccountInsert
 echo.
-echo          If process name is not specified, the parameter values from config.properties
+echo          If process bean id is not specified, the value of the property process.name in config.properties
 echo          will be used to run the process instead of process-conf.xml,
 echo          for example:
 echo.
@@ -24,8 +24,8 @@ goto end
 set EXE_PATH=%~dp0
 set DATALOADER_VERSION=@@FULL_VERSION@@
 
-set PROCESS_OPTION=
-if not [%2]==[] set PROCESS_OPTION=process.name=%2
+set PROCESS_BEAN_ID_OPTION=
+if not [%2]==[] set PROCESS_BEAN_ID_OPTION=process.name=%2
 
 IF NOT "%DATALOADER_JAVA_HOME%" == "" (
     set JAVA_HOME="%DATALOADER_JAVA_HOME%"
@@ -37,7 +37,7 @@ IF "%JAVA_HOME%" == "" (
     IF NOT EXIST "%JAVA_HOME%" (
         echo We couldn't find the Java Runtime Environment ^(JRE^) in directory "%JAVA_HOME%". To run process.bat, set the JAVA_HOME environment variable to the directory where the JRE is installed.
     ) ELSE (
-        "%JAVA_HOME%\bin\java" -cp "%EXE_PATH%\..\dataloader-%DATALOADER_VERSION%-uber.jar" com.salesforce.dataloader.process.DataLoaderRunner salesforce.config.dir=%1 run.mode=batch %PROCESS_OPTION%
+        "%JAVA_HOME%\bin\java" -jar "%EXE_PATH%\..\dataloader-%DATALOADER_VERSION%-uber.jar" run.mode=batch salesforce.config.dir=%1 %PROCESS_BEAN_ID_OPTION%
     )
 )
 


### PR DESCRIPTION
- use -jar instead of -cp
- use the term "batch process bean id" in the help message and variable names instead of "process name" or something else.