### PR TITLE
place java_home\bin in path before existing path

### DIFF
--- a/release/win/dataloader.bat
+++ b/release/win/dataloader.bat
@@ -33,7 +33,7 @@ IF NOT "%DATALOADER_JAVA_HOME%" == "" (
 :CheckMinJRE
     echo Data Loader requires Java JRE %MIN_JAVA_VERSION% or later. Checking if it is installed...
 
-    PATH=%PATH%;%JAVA_HOME%\bin\;
+    PATH=%JAVA_HOME%\bin\;%PATH%;
 
     java -version 1>nul 2>nul || (
         goto NoJavaErrorExit


### PR DESCRIPTION
minor fix - make sure that JRE located in java_home\bin takes precedence over JRE in pre-existing path.