### PR TITLE
fix for issue #431

### DIFF
--- a/release/win/bin/process.bat
+++ b/release/win/bin/process.bat
@@ -27,19 +27,7 @@ set DATALOADER_VERSION=@@FULL_VERSION@@
 set BATCH_PROCESS_BEAN_ID_OPTION=
 if not [%2]==[] set BATCH_PROCESS_BEAN_ID_OPTION=process.name=%2
 
-IF NOT "%DATALOADER_JAVA_HOME%" == "" (
-    set JAVA_HOME="%DATALOADER_JAVA_HOME%"
-)
-
-IF "%JAVA_HOME%" == "" (
-    echo To run process.bat, set the JAVA_HOME environment variable to the directory where the Java Runtime Environment ^(JRE^) is installed.
-) ELSE (
-    IF NOT EXIST "%JAVA_HOME%" (
-        echo We couldn't find the Java Runtime Environment ^(JRE^) in directory "%JAVA_HOME%". To run process.bat, set the JAVA_HOME environment variable to the directory where the JRE is installed.
-    ) ELSE (
-        "%JAVA_HOME%\bin\java" -jar "%EXE_PATH%\..\dataloader-%DATALOADER_VERSION%-uber.jar" run.mode=batch salesforce.config.dir=%1 %BATCH_PROCESS_BEAN_ID_OPTION%
-    )
-)
+CALL ..\dataloader.bat -skipbanner run.mode=batch salesforce.config.dir=%1 %BATCH_PROCESS_BEAN_ID_OPTION%
 
 :end
 exit /b %errorlevel%

--- a/release/win/dataloader.bat
+++ b/release/win/dataloader.bat
@@ -5,8 +5,15 @@ set DATALOADER_VERSION=@@FULL_VERSION@@
 for /f "tokens=1 delims=." %%a in ("%DATALOADER_VERSION%") do (
   set DATALOADER_SHORT_VERSION=%%a
 )
-set DATALOADER_UBER_JAR_NAME=dataloader-%DATALOADER_VERSION%-uber.jar
+set DATALOADER_UBER_JAR_NAME=%~dp0\dataloader-%DATALOADER_VERSION%-uber.jar
 set MIN_JAVA_VERSION=@@MIN_JAVA_VERSION@@
+
+IF NOT "%~1"=="" (
+    IF "%~1"=="-skipbanner" (
+        SHIFT
+        GOTO AFTER_BANNER
+    )
+)
 
 echo.
 echo *************************************************************************
@@ -25,6 +32,8 @@ echo **       https://help.salesforce.com/articleView?id=data_loader.htm    **
 echo **                                                                     **
 echo *************************************************************************
 echo.
+
+:AFTER_BANNER
  
 IF NOT "%DATALOADER_JAVA_HOME%" == "" (
     set JAVA_HOME="%DATALOADER_JAVA_HOME%"
@@ -33,7 +42,7 @@ IF NOT "%DATALOADER_JAVA_HOME%" == "" (
 :CheckMinJRE
     echo Data Loader requires Java JRE %MIN_JAVA_VERSION% or later. Checking if it is installed...
 
-    PATH=%JAVA_HOME%\bin\;%PATH%;
+    PATH="%JAVA_HOME%"\bin\;%PATH%;
 
     java -version 1>nul 2>nul || (
         goto NoJavaErrorExit


### PR DESCRIPTION
Added double-quote around JAVA_HOME environment variable to escape whitespace characters in JVM's absolute path.

Also, process.bat invokes dataloader.bat to  increase execution code between interactive and batch modes.