### PR TITLE
minor encrypt.bat and process.bat fixes

### DIFF
--- a/release/win/bin/encrypt.bat
+++ b/release/win/bin/encrypt.bat
@@ -1,20 +1,16 @@
 @echo off
+setlocal
 
 set EXE_PATH=%~dp0
 set DATALOADER_VERSION=@@FULL_VERSION@@
 
-IF "%JAVA_HOME%" == "" (
-    echo To run encrypt.bat, set the JAVA_HOME environment variable to the directory where the Java Runtime Environment ^(JRE^) is installed.
-) ELSE (
-    IF NOT EXIST "%JAVA_HOME%" (
-        echo We couldn't find the Java Runtime Environment ^(JRE^) in directory "%JAVA_HOME%". To run process.bat, set the JAVA_HOME environment variable to the directory where the JRE is installed.
-    ) ELSE (
-        "%JAVA_HOME%\bin\java"  -cp "%EXE_PATH%\..\dataloader-%DATALOADER_VERSION%-uber.jar" com.salesforce.dataloader.security.EncryptionUtil %*
-
-    )
+IF NOT "%DATALOADER_JAVA_HOME%" == "" (
+    set JAVA_HOME="%DATALOADER_JAVA_HOME%"
 )
 
-
-
-
-
+IF [%JAVA_HOME%] == [] (
+    echo To run encrypt.bat, set the JAVA_HOME environment variable to the directory where the Java Runtime Environment ^(JRE^) is installed.
+) ELSE (
+    PATH="%JAVA_HOME%"\bin\;%PATH%;
+    java -cp "%EXE_PATH%\..\dataloader-%DATALOADER_VERSION%-uber.jar" com.salesforce.dataloader.security.EncryptionUtil %*
+)

--- a/release/win/bin/process.bat
+++ b/release/win/bin/process.bat
@@ -1,4 +1,6 @@
 @echo off
+setlocal
+
 if not [%1]==[] goto run
 echo.
 echo Usage: process ^<configuration directory^> ^[batch process bean id^]
@@ -23,11 +25,31 @@ goto end
 :run
 set EXE_PATH=%~dp0
 set DATALOADER_VERSION=@@FULL_VERSION@@
+set CONFIG_DIR_OPTION=salesforce.config.dir=%1
+set SKIP_COUNT=1
 
 set BATCH_PROCESS_BEAN_ID_OPTION=
-if not [%2]==[] set BATCH_PROCESS_BEAN_ID_OPTION=process.name=%2
+if not [%2]==[] (
+    set BATCH_PROCESS_BEAN_ID_OPTION=process.name=%2
+    set SKIP_COUNT=2
+)
 
-CALL ..\dataloader.bat -skipbanner run.mode=batch salesforce.config.dir=%1 %BATCH_PROCESS_BEAN_ID_OPTION%
+set args=
+shift
+if %SKIP_COUNT% == 2 shift
+:start
+    if [%1] == [] goto done
+    if "%args%" == "" (
+        set args=%1=%2
+    ) else (
+        set args=%args% %1=%2
+    )
+    shift
+    shift
+    goto start
+:done
+
+CALL %EXE_PATH%\..\dataloader.bat -skipbanner run.mode=batch %CONFIG_DIR_OPTION% %BATCH_PROCESS_BEAN_ID_OPTION% %args%
 
 :end
 exit /b %errorlevel%


### PR DESCRIPTION
- encrypt.bat uses DATALOADER_JAVA_HOME environment variable if set.

- process.bat accepts process bean properties as command line arguments.