### PR TITLE
Switching to using RollingFileAppender as it was used in previous rel…

### DIFF
--- a/src/main/resources/log-conf.xml
+++ b/src/main/resources/log-conf.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <appenders>
-    <File name="fileAppender" fileName="${sys:java.io.tmpdir}/sdl.log" append="true">
-      <PatternLayout pattern="%d %-5p [%t] %C{2} %M (%F:%L) - %m%n"/>
-    </File>
+    <RollingFile name="fileAppender" fileName="${sys:java.io.tmpdir}/sdl.log"
+                 filePattern="${sys:java.io.tmpdir}/sdl-%d{yyyy-MM-dd}.log"
+                 ignoreExceptions="false">
+      <PatternLayout>
+          <Pattern>"%d %-5p [%t] %C{2} %M (%F:%L) - %m%n"</Pattern>
+      </PatternLayout>
+      <Policies>
+          <SizeBasedTriggeringPolicy size="100KB" />
+      </Policies>
+      <DefaultRolloverStrategy max="1" />
+    </RollingFile>
     <CONSOLE name="STDOUT" target="SYSTEM_OUT">
       <PatternLayout pattern="%d %-5p [%t] %C{2} %M (%F:%L) - %m%n"/>
     </CONSOLE>


### PR DESCRIPTION
…eases

Issue #439 showed that RollingFileAppender was used in previous releases that used log4j 1.x. This fix re-introduces use of RollingFileAppender with the same attributes as before.