### PR TITLE
Fix to support datefield.usegmt command line option

### DIFF
--- a/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
@@ -79,8 +79,8 @@ public class DataLoaderRunner extends Thread {
     
     private static void setUseGMTForDateFieldValue() {
         if (argNameValuePair.containsKey(Config.CLI_OPTION_GMT_FOR_DATE_FIELD_VALUE)) {
-            if ("false".equalsIgnoreCase(argNameValuePair.get(Config.CLI_OPTION_GMT_FOR_DATE_FIELD_VALUE))) {
-                useGMTForDateFieldValue = false;
+            if ("true".equalsIgnoreCase(argNameValuePair.get(Config.CLI_OPTION_GMT_FOR_DATE_FIELD_VALUE))) {
+                useGMTForDateFieldValue = true;
             }
         }
     }


### PR DESCRIPTION
correctly support datefield.usegmt command line option for date-only fields. If set to true when invoking data loader, date-only field values will not be adjusted (1 day added) in case user's timezone is ahead of GMT. In other words, setting datefield.usegmt may result in added/modified date-only field value to be 1 day behind the value specified in CSV file depending on the value format and user's timezone.