### PR TITLE
Fix and Additional tests for date-only field processing

### DIFF
--- a/src/main/java/com/salesforce/dataloader/util/DateOnlyCalendar.java
+++ b/src/main/java/com/salesforce/dataloader/util/DateOnlyCalendar.java
@@ -64,19 +64,19 @@ public class DateOnlyCalendar extends GregorianCalendar {
         Calendar cal = Calendar.getInstance(myTimeZone);
         cal.setTimeInMillis(specifiedTimeInMilliSeconds);
 
-        // Set hour, minute, second, and millisec to 0 (12:00AM) as it is date-only value
-        cal.set(Calendar.HOUR, 0);
-        cal.set(Calendar.MINUTE, 0);
-        cal.set(Calendar.SECOND, 0);
-        cal.set(Calendar.MILLISECOND, 0);
-        cal.set(Calendar.AM_PM, Calendar.AM);
-
-        TimeZone gmt = TimeZone.getTimeZone("GMT");
         if (!DataLoaderRunner.doUseGMTForDateFieldValue() && myTimeZone != null) {
+            // Set hour, minute, second, and millisec to 0 (12:00AM) as it is date-only value
+            cal.set(Calendar.HOUR, 0);
+            cal.set(Calendar.MINUTE, 0);
+            cal.set(Calendar.SECOND, 0);
+            cal.set(Calendar.MILLISECOND, 0);
+            cal.set(Calendar.AM_PM, Calendar.AM);
+            
+            TimeZone gmt = TimeZone.getTimeZone("GMT");
             int timeZoneDifference = myTimeZone.getRawOffset() - gmt.getRawOffset() + myTimeZone.getDSTSavings() - gmt.getDSTSavings();
             if (timeZoneDifference > 0) {
-                // timezone is ahead of GMT, add 1 day to the specified time in milliseconds
-                cal.add(Calendar.DATE, 1);
+                // timezone is ahead of GMT, compensate for it as server-side thinks it is in GMT.
+                cal.setTimeInMillis(cal.getTimeInMillis() + timeZoneDifference);
             }
         }
         super.setTimeInMillis(cal.getTimeInMillis());

--- a/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
+++ b/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
@@ -656,13 +656,49 @@ public class DateConverterTest {
         // DateConverter should always return the Calendar in GMT.
         result = (Calendar) AsianTZDateOnlyConverter.convert(null, "6/22/2012");
         assertEquals(6, result.get(Calendar.MONTH) + 1);
-        assertEquals(23, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(22, result.get(Calendar.DAY_OF_MONTH));
 
         DataLoaderRunner.setUseGMTForDateFieldValue(true);
+        AsianTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("Asia/Tokyo"), false);
+        USTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("America/Los_Angeles"), false);
         result = (Calendar) USTZDateOnlyConverter.convert(null, "6/22/2012");
         assertEquals(6, result.get(Calendar.MONTH) + 1);
         assertEquals(22, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("GMT"), result.getTimeZone());
+
+        AsianTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("Asia/Tokyo"), false);
+        USTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("America/Los_Angeles"), false);
+        result = (Calendar) AsianTZDateOnlyConverter.convert(null, "6/7/2012 0:00");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH) + 1);
+        assertEquals(TimeZone.getTimeZone("GMT"), result.getTimeZone());
+
+        AsianTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("Asia/Tokyo"), false);
+        USTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("America/Los_Angeles"), false);
+        result = (Calendar) AsianTZDateOnlyConverter.convert(null, "6/7/2012 02:00");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH) + 1);
+        assertEquals(TimeZone.getTimeZone("GMT"), result.getTimeZone());
+        
+        // JST is 9 hours ahead of GMT
+        // Any time after 9am in Japan is the same day in GMT
+        AsianTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("Asia/Tokyo"), false);
+        USTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("America/Los_Angeles"), false);
+        result = (Calendar) AsianTZDateOnlyConverter.convert(null, "6/7/2012 11:00");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("GMT"), result.getTimeZone());
+
+        AsianTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("Asia/Tokyo"), false);
+        USTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("America/Los_Angeles"), false);
+        result = (Calendar) AsianTZDateOnlyConverter.convert(null, "6/7/2012 23:00");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("GMT"), result.getTimeZone());
+        
         DataLoaderRunner.setUseGMTForDateFieldValue(false);
+        AsianTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("Asia/Tokyo"), false);
+        USTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("America/Los_Angeles"), false);
 
         result = (Calendar) GMTTZDateOnlyConverter.convert(null, "6/22/2012");
         assertEquals(6, result.get(Calendar.MONTH) + 1);
@@ -672,17 +708,52 @@ public class DateConverterTest {
         assertEquals(6, result.get(Calendar.MONTH) + 1);
         assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
         assertEquals(TimeZone.getTimeZone("Asia/Tokyo"), result.getTimeZone());
-
+        
+        result = (Calendar) AsianTZDateOnlyConverter.convert(null, "6/7/2012 04:00");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("Asia/Tokyo"), result.getTimeZone());
+        
+        result = (Calendar) AsianTZDateOnlyConverter.convert(null, "6/7/2012 11:00");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("Asia/Tokyo"), result.getTimeZone());
+        
+        result = (Calendar) AsianTZDateOnlyConverter.convert(null, "6/7/2012 17:00");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("Asia/Tokyo"), result.getTimeZone());
+        
         result = (Calendar) USTZDateConverter.convert(null, "6/7/2012 0:00");
         assertEquals(6, result.get(Calendar.MONTH) + 1);
         assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
         assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
 
+        result = (Calendar) USTZDateOnlyConverter.convert(null, "6/7/2012 11:00");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+        
+        result = (Calendar) USTZDateOnlyConverter.convert(null, "6/7/2012 23:00");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+        
         result = (Calendar) AsianTZDateConverter.convert(null, "2012-06-07 00:00:00JST");
         assertEquals(6, result.get(Calendar.MONTH) + 1);
         assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
         assertEquals(TimeZone.getTimeZone("Asia/Tokyo"), result.getTimeZone());
 
+        result = (Calendar) AsianTZDateOnlyConverter.convert(null, "2012-06-07 10:00:00JST");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("Asia/Tokyo"), result.getTimeZone());
+        
+        result = (Calendar) AsianTZDateOnlyConverter.convert(null, "2012-06-07 22:00:00JST");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("Asia/Tokyo"), result.getTimeZone());
+        
         result = (Calendar) USTZDateConverter.convert(null, "2012-06-07 00:00:00PST");
         assertEquals(6, result.get(Calendar.MONTH) + 1);
         assertEquals(7, result.get(Calendar.DAY_OF_MONTH));


### PR DESCRIPTION
fix and Additional tests for date-only field processing.

Fix - set hour, minute, second, and millisec to 0 only if datefield.usegmt is not set to True (if set to true, revert to old behavior, i.e. do not set time to 12AM in local time).

Also, do not increment day by 1. Just add the offset between GMT and local timezone if local timezone is ahead of GMT.