### PR TITLE
OAuth flow - use java AWT for browser launch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>5.3.19</version>
+      <version>5.3.20</version>
     </dependency>
 <!-- https://mvnrepository.com/artifact/org.eclipse.platform/org.eclipse.jface --> 
     <dependency>
@@ -149,7 +149,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
-      <version>5.3.19</version>
+      <version>5.3.20</version>
       <scope>test</scope>
     </dependency>
 <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->

--- a/src/main/java/com/salesforce/dataloader/ui/OAuthBrowserListener.java
+++ b/src/main/java/com/salesforce/dataloader/ui/OAuthBrowserListener.java
@@ -39,6 +39,7 @@ import org.eclipse.swt.widgets.Shell;
  * The common class for listening to browser events use in oauth flows.
  */
 public abstract class OAuthBrowserListener implements ProgressListener {
+    private static Logger logger = LogManager.getLogger(Config.class);
     protected final Browser browser;
     protected final Shell shell;
     protected final Config config;
@@ -55,8 +56,12 @@ public abstract class OAuthBrowserListener implements ProgressListener {
     @Override
     public abstract void changed(ProgressEvent progressEvent);
 
-    @Override
-    public abstract void completed(ProgressEvent progressEvent);
+    public void completed(ProgressEvent progressEvent) {
+        logger.debug("SWT Browser engine is " + 
+            browser.evaluate("var ua = navigator.userAgent, tem, M = ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\\/))\\/?\\s*(\\d+)/i) || []; if (/trident/i.test(M[1])) { tem = /\\brv[ :]+(\\d+)/g.exec(ua) || []; return 'IE ' + (tem[1] || ''); } if (M[1] === 'Chrome') { tem = ua.match(/\\b(OPR|Edge)\\/(\\d+)/); if (tem != null) return tem.slice(1).join(' ').replace('OPR', 'Opera'); } M = M[2] ? [M[1], M[2]] : [navigator.appName, navigator.appVersion, '-?']; if ((tem = ua.match(/version\\/(\\d+)/i)) != null) M.splice(1, 1, tem[1]); return M.join(' ');"));
+        logger.debug("SWT Browser engine's userAgent property is " + 
+                browser.evaluate("return navigator.userAgent;"));
+    }
 
     public String getReasonPhrase() {
         return reasonPhrase;

--- a/src/main/java/com/salesforce/dataloader/ui/OAuthSecretFlow.java
+++ b/src/main/java/com/salesforce/dataloader/ui/OAuthSecretFlow.java
@@ -86,6 +86,7 @@ public class OAuthSecretFlow extends OAuthFlow {
 
         @Override
         public void completed(ProgressEvent progressEvent) {
+            super.completed(progressEvent);
             String url = browser.getUrl();
             try {
                 String code = handleInitialUrl(url);

--- a/src/main/java/com/salesforce/dataloader/ui/OAuthTokenFlow.java
+++ b/src/main/java/com/salesforce/dataloader/ui/OAuthTokenFlow.java
@@ -79,6 +79,7 @@ public class OAuthTokenFlow extends OAuthFlow {
 
         @Override
         public void completed(ProgressEvent progressEvent) {
+            super.completed(progressEvent);
             try {
                 boolean handled = handleCompletedUrl(browser.getUrl(), config);
                 if (handled) {


### PR DESCRIPTION
Minor robustness and troubleshooting enhancements for OAuth flow:
- Try launching system browser using AWT Desktop before using native command.
- Additional troubleshooting info in debug mode to determine the browser engine used by SWT Browser widget.

Upgrade of Spring JDBC and Spring Context from 5.3.19 to 5.3.20.