### PR TITLE
decouple partner api jar version from  salesforce api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 
   <properties>
     <force.wsc.version>55.1.0</force.wsc.version>
+    <salesforce.api.version>55.0</salesforce.api.version>
     <force.partner.api.version>${force.wsc.version}</force.partner.api.version>
     <build.year>2022</build.year>
     <java.compile.version>11</java.compile.version>

--- a/src/main/resources/com/salesforce/dataloader/version.properties
+++ b/src/main/resources/com/salesforce/dataloader/version.properties
@@ -1,4 +1,4 @@
 dataloader.name = ${project.name}
 dataloader.version = ${project.version}
 dataloader.vendor = ${organization.name}
-dataloader.apiversion = ${force.partner.api.version}
+dataloader.apiversion = ${salesforce.api.version}


### PR DESCRIPTION
Fix for Partner API packaging version causing "unknown version" issue when invoking Salesforce Bulk API by decoupling partner api jar version from  salesforce api version.