### PR TITLE
make sort of sobject field names optional in SoQL generation dialog

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -211,6 +211,7 @@ public class Config {
     public static final String EXTERNAL_ID_FIELD = "sfdc.externalIdField"; //$NON-NLS-1$
     public static final String EXTRACT_REQUEST_SIZE = "sfdc.extractionRequestSize"; //$NON-NLS-1$
     public static final String EXTRACT_SOQL = "sfdc.extractionSOQL"; //$NON-NLS-1$
+    public static final String SORT_EXTRACT_FIELDS = "sfdc.sortExtractionFields"; //$NON-NLS-1$
 
     //
     // process configuration (action parameters)
@@ -400,6 +401,7 @@ public class Config {
         setDefaultValue(ENABLE_LAST_RUN_OUTPUT, true);
         setDefaultValue(RESET_URL_ON_LOGIN, true);
         setDefaultValue(EXTRACT_REQUEST_SIZE, DEFAULT_EXTRACT_REQUEST_SIZE);
+        setDefaultValue(SORT_EXTRACT_FIELDS, true);
         setDefaultValue(DAO_WRITE_BATCH_SIZE, DEFAULT_DAO_WRITE_BATCH_SIZE);
         setDefaultValue(DAO_READ_BATCH_SIZE, DEFAULT_DAO_READ_BATCH_SIZE);
         setDefaultValue(TRUNCATE_FIELDS, true);

--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -38,6 +38,8 @@ import org.apache.logging.log4j.LogManager;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
+import org.eclipse.swt.events.ControlAdapter;
+import org.eclipse.swt.events.ControlEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.VerifyEvent;
@@ -46,6 +48,7 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -94,6 +97,7 @@ public class AdvancedSettingsDialog extends Dialog {
     private final Logger logger = LogManager.getLogger(AdvancedSettingsDialog.class);
     private Button buttonHideWelcomeScreen;
     private Button buttonOutputExtractStatus;
+    private Button buttonSortExtractFields;
     private Button buttonReadUtf8;
     private Button buttonWriteUtf8;
     private Button buttonEuroDates;
@@ -395,6 +399,15 @@ public class AdvancedSettingsDialog extends Dialog {
         textQueryBatch.setTextLimit(4);
         data.widthHint = 4 * textSize.x;
         textQueryBatch.setLayoutData(data);
+
+        // enable/disable sort of fields to extract
+        Label labelSortExtractFields = new Label(restComp, SWT.RIGHT | SWT.WRAP);
+        labelSortExtractFields.setText(Labels.getString("AdvancedSettingsDialog.sortQueryFieldsInExtraction")); //$NON-NLS-1$
+        data = new GridData(GridData.HORIZONTAL_ALIGN_END);
+        labelSortExtractFields.setLayoutData(data);
+
+        buttonSortExtractFields = new Button(restComp, SWT.CHECK);
+        buttonSortExtractFields.setSelection(config.getBoolean(Config.SORT_EXTRACT_FIELDS));
 
         //enable/disable output of success file for extracts
         Label labelOutputExtractStatus = new Label(restComp, SWT.RIGHT | SWT.WRAP);
@@ -727,6 +740,7 @@ public class AdvancedSettingsDialog extends Dialog {
                 config.setValue(Config.NO_COMPRESSION, buttonCompression.getSelection());
                 config.setValue(Config.TRUNCATE_FIELDS, buttonTruncateFields.getSelection());
                 config.setValue(Config.TIMEOUT_SECS, textTimeout.getText());
+                config.setValue(Config.SORT_EXTRACT_FIELDS, buttonSortExtractFields.getSelection());
                 config.setValue(Config.ENABLE_EXTRACT_STATUS_OUTPUT, buttonOutputExtractStatus.getSelection());
                 config.setValue(Config.READ_UTF8, buttonReadUtf8.getSelection());
                 config.setValue(Config.WRITE_UTF8, buttonWriteUtf8.getSelection());
@@ -791,7 +805,12 @@ public class AdvancedSettingsDialog extends Dialog {
         sc.setContent(container);
 
         // Set the minimum size
-        sc.setMinSize(600, 1124);
+        sc.addControlListener(new ControlAdapter() {
+            public void controlResized(ControlEvent e) {
+              Rectangle r = sc.getClientArea();
+              sc.setMinSize(container.computeSize(r.width, SWT.DEFAULT));
+            }
+          });
         sc.setAlwaysShowScrollBars(true);
 
         // Expand both horizontally and vertically

--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionSOQLPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionSOQLPage.java
@@ -534,14 +534,15 @@ public class ExtractionSOQLPage extends ExtractionPage {
 
         DescribeSObjectResult result = controller.getFieldTypes();
         fields = result.getFields();
-        Arrays.sort(fields, new Comparator<Field>(){
-            @Override
-            public int compare(Field f1, Field f2)
-            {
-                return f1.getName().compareTo(f2.getName());
-            }
-        });
-
+        if (config.getBoolean(Config.SORT_EXTRACT_FIELDS)) {
+            Arrays.sort(fields, new Comparator<Field>(){
+                @Override
+                public int compare(Field f1, Field f2)
+                {
+                    return f1.getName().compareTo(f2.getName());
+                }
+            });
+        }
         fieldViewer.setInput(fields);
         updateFieldComboList(null);
         builderComp.layout();

--- a/src/main/resources/labels.properties
+++ b/src/main/resources/labels.properties
@@ -85,6 +85,7 @@ AdvancedSettingsDialog.proxyNtlmDomain=Proxy NTLM domain:
 AdvancedSettingsDialog.proxyUser=Proxy username:
 AdvancedSettingsDialog.lastBatch=The last batch finished at {0}. Use {0} to continue from your last location.
 
+AdvancedSettingsDialog.sortQueryFieldsInExtraction=Sort Salesforce object field names \nwhen editing SoQL for Export:
 AdvancedSettingsDialog.outputExtractStatus=Generate status files for exports:
 AdvancedSettingsDialog.readUTF8=Read all CSVs with UTF-8 encoding:
 AdvancedSettingsDialog.writeUTF8=Write all CSVs with UTF-8 encoding:


### PR DESCRIPTION
make sort of sobject field names optional in SoQL generation dialog as requested at https://ideas.salesforce.com/s/idea/a0B8W00000GdbLvUAJ/sort-order-after-data-loader-45