### PR TITLE
fix to keep "Edit SOQL" dialog open if incorrect SoQL syntax

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/progress/SWTProgressAdapter.java
+++ b/src/main/java/com/salesforce/dataloader/action/progress/SWTProgressAdapter.java
@@ -68,7 +68,7 @@ public class SWTProgressAdapter implements ILoaderProgress {
     @Override
     public void doneSuccess(String message) {
         monitor.done();
-
+        controller.setLastOperationSuccessful(true);
         dispMessage = message;
         Display.getDefault().syncExec(new Thread() {
             @Override
@@ -92,6 +92,7 @@ public class SWTProgressAdapter implements ILoaderProgress {
     @Override
     public void doneError(String message) {
         monitor.done();
+        controller.setLastOperationSuccessful(false);
         dispMessage = message;
         Display.getDefault().syncExec(new Thread() {
             @Override

--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -123,6 +123,7 @@ public class Controller {
     private BulkV2Client bulkV2Client;
     private PartnerClient partnerClient;
     private LoaderWindow loaderWindow;
+    private boolean lastOperationSuccessful = true;
 
     // logger
     private static Logger logger;
@@ -710,5 +711,13 @@ public class Controller {
 
     public void clearMapper() {
         this.mapper = null;
+    }
+    
+    public void setLastOperationSuccessful(boolean successful) {
+        this.lastOperationSuccessful = successful;
+    }
+    
+    public boolean isLastOperationSuccessful() {
+        return this.lastOperationSuccessful;
     }
 }

--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionWizard.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionWizard.java
@@ -148,7 +148,7 @@ public class ExtractionWizard extends BaseWizard {
             return false;
         }
 
-        return true;
+        return getController().isLastOperationSuccessful();
     }
 
     @Override


### PR DESCRIPTION
Fix for the issue reported at https://ideas.salesforce.com/s/idea/a0B8W00000GdikRUAR/data-loader-should-let-you-edit-your-soql-query-if-there-is-a-formatting-error