### PR TITLE
show field type and length in edit SOQL step

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/LoaderWizardDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/LoaderWizardDialog.java
@@ -230,6 +230,7 @@ public class LoaderWizardDialog extends LoaderTitleAreaDialog implements IWizard
         buttons = new HashMap<>();
         setShellStyle(SWT.CLOSE | SWT.TITLE | SWT.BORDER | SWT.APPLICATION_MODAL | SWT.RESIZE);
         setWizard(newWizard);
+        setShellStyle(getShellStyle() | SWT.RESIZE);
         // since VAJava can't initialize an instance var with an anonymous
         // class outside a constructor we do it here:
         cancelListener = new SelectionAdapter() {
@@ -1067,6 +1068,8 @@ public class LoaderWizardDialog extends LoaderTitleAreaDialog implements IWizard
         updateTitleBar();
         // Update the buttons
         updateButtons();
+        // update size
+        updateSize();
     }
 
     /*

--- a/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
@@ -473,7 +473,7 @@ public class MappingDialog extends Dialog {
         });
 
         //  Add the third column - type
-        tc = new TableColumn(sforceTable, SWT.RIGHT);
+        tc = new TableColumn(sforceTable, SWT.LEFT);
         tc.setText(Labels.getString("MappingDialog.sforceType")); //$NON-NLS-1$
         tc.addSelectionListener(new SelectionAdapter() {
             @Override

--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtrFieldLabelProvider.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtrFieldLabelProvider.java
@@ -26,36 +26,22 @@
 
 package com.salesforce.dataloader.ui.extraction;
 
+import org.eclipse.jface.viewers.CellLabelProvider;
 import org.eclipse.jface.viewers.ILabelProviderListener;
-import org.eclipse.jface.viewers.ITableLabelProvider;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.viewers.ViewerCell;
+import org.eclipse.swt.widgets.Control;
 
 import com.sforce.soap.partner.Field;
 
 /**
  * 
  */
-public class ExtrFieldLabelProvider implements ITableLabelProvider {
+public class ExtrFieldLabelProvider extends CellLabelProvider {
 
     public ExtrFieldLabelProvider() {
     }
 
-    @Override
-    public Image getColumnImage(Object arg0, int arg1) {
-        return null;
-    }
-
-
-    /**
-     * Gets the text for the specified column
-     * 
-     * @return String
-     */
-    @Override
-    public String getColumnText(Object arg0, int arg1) {
-        return ((Field) arg0).getName();
-    }
-
+   
     /**
      * Adds a listener
      * 
@@ -64,6 +50,7 @@ public class ExtrFieldLabelProvider implements ITableLabelProvider {
     @Override
     public void addListener(ILabelProviderListener arg0) {
         // Throw it away
+        ILabelProviderListener listener = arg0;
     }
 
     /**
@@ -92,5 +79,36 @@ public class ExtrFieldLabelProvider implements ITableLabelProvider {
     @Override
     public void removeListener(ILabelProviderListener arg0) {
         // Do nothing
+    }
+
+    @Override
+    public void update(ViewerCell cell) {
+        Field field = (Field)cell.getElement();
+        String fieldTypeStr = getFieldTypeStr(field);
+        cell.setText(field.getName() + " (" + fieldTypeStr + ")");
+        String tooltipStr = field.getInlineHelpText();
+        if (tooltipStr == null) {
+            tooltipStr = fieldTypeStr;
+        } else {
+            tooltipStr = fieldTypeStr + "\n" + tooltipStr;
+        }
+        Control control = cell.getControl();
+        control.getParent().setToolTipText(tooltipStr);
+        for (Control child : control.getParent().getChildren()) {
+            child.setToolTipText(tooltipStr);
+        }
+    }
+    
+    private String getFieldTypeStr(Field field) {
+        String fieldTypeStr = field.getType().toString();
+        if (fieldTypeStr.startsWith("_")) {
+            fieldTypeStr = fieldTypeStr.substring(1);
+        }
+        if ("string".equalsIgnoreCase(fieldTypeStr) || "textarea".equalsIgnoreCase(fieldTypeStr)) {
+            fieldTypeStr = fieldTypeStr
+                    + ", "
+                    + field.getLength();
+        }
+        return fieldTypeStr;
     }
 }

--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionSOQLPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionSOQLPage.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.LogManager;
 import org.eclipse.jface.viewers.*;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CCombo;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
@@ -45,7 +46,6 @@ import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.ui.Labels;
 import com.salesforce.dataloader.ui.UIUtils;
-import com.salesforce.dataloader.ui.entitySelection.EntityFilter;
 import com.sforce.soap.partner.*;
 
 /**
@@ -68,7 +68,7 @@ public class ExtractionSOQLPage extends ExtractionPage {
             "less than or equals", "greater than or equals" }; //$NON-NLS-1$ //$NON-NLS-2$
     private final String[] operationsDisplayMulti = { "equals", "not equals", "includes", "excludes" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
     private HashMap<String, String> operationMap;
-    private Combo fieldCombo;
+    private CCombo fieldCombo;
     private Composite whereComp;
     private Composite builderComp;
     private boolean isPickListField;
@@ -144,8 +144,6 @@ public class ExtractionSOQLPage extends ExtractionPage {
 
         builderComp = new Composite(comp, SWT.NONE);
         data = new GridData(SWT.FILL, SWT.FILL, true, true);
-        //data.heightHint = 170;
-        //data.widthHint = 650;
         builderComp.setLayoutData(data);
         gridLayout = new GridLayout(2, false);
         gridLayout.horizontalSpacing = 25;
@@ -168,6 +166,7 @@ public class ExtractionSOQLPage extends ExtractionPage {
         fieldComp.setLayoutData(data);
 
         fieldViewer = CheckboxTableViewer.newCheckList(fieldComp, SWT.BORDER);
+        ColumnViewerToolTipSupport.enableFor(fieldViewer);
         fieldViewer.setLabelProvider(new ExtrFieldLabelProvider());
         fieldViewer.setContentProvider(new ExtrFieldContentProvider());
         data = new GridData(GridData.FILL_HORIZONTAL);
@@ -211,7 +210,7 @@ public class ExtractionSOQLPage extends ExtractionPage {
         Label valLabel = new Label(whereComp, SWT.CENTER);
         valLabel.setText(Labels.getString("ExtractionSOQLPage.value")); //$NON-NLS-1$
 
-        fieldCombo = new Combo(whereComp, SWT.DROP_DOWN);
+        fieldCombo = new CCombo(whereComp, SWT.DROP_DOWN | SWT.V_SCROLL);
         operCombo = new Combo(whereComp, SWT.DROP_DOWN);
         operCombo.setItems(operationsDisplayNormal);
         fieldCombo.addSelectionListener(new SelectionListener() {
@@ -456,8 +455,6 @@ public class ExtractionSOQLPage extends ExtractionPage {
         soqlText = new Text(comp, SWT.MULTI | SWT.WRAP | SWT.BORDER | SWT.V_SCROLL);
         data = new GridData(GridData.FILL_BOTH);
         data.heightHint = 80;
-        data.widthHint = 250;
-
         soqlText.setLayoutData(data);
 
         setControl(comp);
@@ -560,7 +557,7 @@ public class ExtractionSOQLPage extends ExtractionPage {
             if(FieldType.encryptedstring != fields[i].getType()) {
                 if (filterStr == null 
                         || filterStr.isEmpty() 
-                        || name.contains(filterStr)) {
+                        || name.contains(filterStr.toLowerCase())) {
                     fieldNames.add(fields[i].getName());
                 }
             }

--- a/src/main/java/com/salesforce/dataloader/ui/mapping/SforceLabelProvider.java
+++ b/src/main/java/com/salesforce/dataloader/ui/mapping/SforceLabelProvider.java
@@ -72,6 +72,12 @@ public class SforceLabelProvider implements ITableLabelProvider {
             break;
         case MappingDialog.FIELD_TYPE:
             text = field.getType().toString();
+            if ("string".equalsIgnoreCase(text) || "textarea".equalsIgnoreCase(text)) {
+                text = text
+                        + "("
+                        + field.getLength()
+                        +")";
+            }
             break;
         }
         return text;


### PR DESCRIPTION
Address part of the issue reported at https://ideas.salesforce.com/s/idea/a0B8W00000GddQ8UAJ/help-text-field-info-on-data-loader by displaying field type and length along with field name in edit SOQL step.