### PR TITLE
skip resize because BaseDialog handles it

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/DataSelectionPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/DataSelectionPage.java
@@ -160,14 +160,6 @@ public class DataSelectionPage extends LoadPage {
                 }
             }
         });
-        
-        // Set the size
-        comp.addControlListener(new ControlAdapter() {
-            public void controlResized(ControlEvent e) {
-              Rectangle r = comp.getParent().getClientArea();
-              comp.setSize(comp.getParent().computeSize(r.width, SWT.DEFAULT));
-            }
-        });
 
         setControl(comp);
     }


### PR DESCRIPTION
skip resize because BaseDialog handles it.