### PR TITLE
fix for issue #483

### DIFF
--- a/release/mac/dataloader.app/Contents/MacOS/dataloader
+++ b/release/mac/dataloader.app/Contents/MacOS/dataloader
@@ -25,9 +25,9 @@ echo ""
 if [ ! -z "${DATALOADER_JAVA_HOME}" ]
 then
     JAVA_HOME=${DATALOADER_JAVA_HOME}
-    PATH=${JAVA_HOME}/bin:${PATH}
 fi
 
+PATH=${JAVA_HOME}/bin:${PATH}
 JAVA_VERSION=$(java -version 2>&1 | grep -i version | cut -d'"' -f 2 | cut -d'.' -f 1)
 
 if [ -z "${JAVA_VERSION}" ] | [ ${JAVA_VERSION} \< ${MIN_JAVA_VERSION} ]

--- a/release/win/dataloader.bat
+++ b/release/win/dataloader.bat
@@ -36,13 +36,13 @@ echo.
 :AFTER_BANNER
  
 IF NOT "%DATALOADER_JAVA_HOME%" == "" (
-    set JAVA_HOME="%DATALOADER_JAVA_HOME%"
+    set JAVA_HOME=%DATALOADER_JAVA_HOME%
 )
 
 :CheckMinJRE
     echo Data Loader requires Java JRE %MIN_JAVA_VERSION% or later. Checking if it is installed...
 
-    PATH="%JAVA_HOME%"\bin\;%PATH%;
+    PATH=%JAVA_HOME%\bin\;%PATH%;
 
     java -version 1>nul 2>nul || (
         goto NoJavaErrorExit


### PR DESCRIPTION
Fix for issue #483 by removing double-quotes around env variable use in dataloader.bat.

Also, set PATH in the command shell script on mac at the same place as setting it in windows bat script.