### PR TITLE
use previous API version if the API version in WSC fails

### DIFF
--- a/src/main/java/com/salesforce/dataloader/client/BulkClient.java
+++ b/src/main/java/com/salesforce/dataloader/client/BulkClient.java
@@ -71,12 +71,16 @@ public class BulkClient extends ClientBase<BulkConnection> {
     }
 
     @Override
-    protected synchronized ConnectorConfig getConnectorConfig() {
+    protected synchronized ConnectorConfig getConnectorConfig(String apiVersion) {
         if (this.connectorConfig == null || !this.config.getBoolean(Config.REUSE_CLIENT_CONNECTION)) {
-            this.connectorConfig = super.getConnectorConfig();
+            this.connectorConfig = super.getConnectorConfig(apiVersion);
             this.connectorConfig.setTraceMessage(config.getBoolean(Config.WIRE_OUTPUT));
         }
         return this.connectorConfig;
+    }
+    
+    protected static String getServicePathForAPIVersion(String apiVersionStr) {
+        return ClientBase.getServicePathForAPIVersion(BULKV1_ENDPOINT_PATH, apiVersionStr);
     }
 
 }

--- a/src/main/java/com/salesforce/dataloader/client/BulkV2Client.java
+++ b/src/main/java/com/salesforce/dataloader/client/BulkV2Client.java
@@ -63,17 +63,27 @@ public class BulkV2Client extends ClientBase<BulkV2Connection> {
         return true;
     }
 
-    protected synchronized ConnectorConfig getConnectorConfig() {
+    protected synchronized ConnectorConfig getConnectorConfig(String apiVersion) {
         if (this.connectorConfig == null || !this.config.getBoolean(Config.REUSE_CLIENT_CONNECTION)) {
-            this.connectorConfig = super.getConnectorConfig();
+            this.connectorConfig = super.getConnectorConfig(apiVersion);
             
             // override the restEndpoint value set in the superclass
             String server = getSession().getServer();
             if (server != null) {
-                this.connectorConfig.setRestEndpoint(server + BULKV2_ENDPOINT);
+                this.connectorConfig.setRestEndpoint(server + getServicePathForAPIVersion(apiVersion));
             }
             this.connectorConfig.setTraceMessage(config.getBoolean(Config.WIRE_OUTPUT));
         }
         return this.connectorConfig;
+    }
+    
+    protected static String getServicePathForAPIVersion(String apiVersionStr) {
+        String[] pathPartArray = BULKV2_ENDPOINT_PATH.split("\\/");
+        pathPartArray[pathPartArray.length-2] = "v" + apiVersionStr;
+        StringBuffer buf = new StringBuffer();
+        for (int i = 0; i < pathPartArray.length; i++) {
+            buf.append(pathPartArray[i] + "/");
+        }
+        return buf.toString();
     }
 }

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -181,6 +181,7 @@ public class Config {
     public static final String BULK_API_ZIP_CONTENT = "sfdc.bulkApiZipContent";
     public static final String WIRE_OUTPUT = "sfdc.wireOutput";
     public static final String TIMEZONE = "sfdc.timezone";
+    public static final String SERVICE_API_VERSION="sfdc.apiVersion";
 
     public static final String OAUTH_PREFIX = "sfdc.oauth.";
     public static final String OAUTH_PARTIAL_BULK = "bulk";
@@ -300,7 +301,7 @@ public class Config {
     private boolean isBatchMode = false;
 
     private final String configDir;
-
+    
     /**
      * <code>dateFormatter</code> will be used for getting dates in/out of the configuration
      * file(s)
@@ -344,12 +345,14 @@ public class Config {
      * @see #load()
      * @see #save()
      */
-    public Config(String configDir, String filename, String lastRunFileName) throws ConfigInitializationException {
+    public Config(String configDir, String filename, String lastRunFileName) throws ConfigInitializationException, IOException {
         properties = new LinkedProperties();
         this.configDir = configDir;
         this.filename = filename;
         // last run gets initialized a little later since config params are needed for that
         this.lastRun = new LastRun(lastRunFileName);
+        this.load();
+        this.setDefaults();
     }
 
     /**
@@ -450,6 +453,7 @@ public class Config {
         setDefaultValue(BULKV2_API_ENABLED, false);
         setDefaultValue(OAUTH_LOGIN_FROM_BROWSER, true);
         setDefaultValue(LOAD_PRESERVE_WHITESPACE_IN_RICH_TEXT, true);
+        setOAuthEnvironment(getString(OAUTH_ENVIRONMENT));
     }
 
     /**

--- a/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
@@ -343,9 +343,6 @@ public class ProcessRunner implements InitializingBean {
     }
     
     private void doLoginFromBrowser(Config config) throws OAuthBrowserLoginRunnerException {
-        if (config.getString(Config.OAUTH_CLIENTID) == null || config.getString(Config.OAUTH_CLIENTID).isEmpty()) {
-            throw new OAuthBrowserLoginRunnerException("Specify Connected App Client ID");
-        }
         final String verificationURLStr;
         final OAuthBrowserLoginRunner loginRunner;
         try {

--- a/src/main/java/com/salesforce/dataloader/util/OAuthBrowserLoginRunner.java
+++ b/src/main/java/com/salesforce/dataloader/util/OAuthBrowserLoginRunner.java
@@ -66,6 +66,7 @@ public class OAuthBrowserLoginRunner {
     public OAuthBrowserLoginRunner(Config config, boolean skipUserCodePage) throws IOException, ParameterLoadException, OAuthBrowserLoginRunnerException {
         setLoginStatus(LoginStatus.WAIT);
         this.config = config;
+        config.setOAuthEnvironment(config.getString(Config.OAUTH_ENVIRONMENT));
         oAuthTokenURLStr = config.getString(Config.OAUTH_SERVER) + "/services/oauth2/token";
         SimplePost client = SimplePostFactory.getInstance(config, oAuthTokenURLStr,
                new BasicNameValuePair("response_type", "device_code"),

--- a/src/test/java/com/salesforce/dataloader/TestBase.java
+++ b/src/test/java/com/salesforce/dataloader/TestBase.java
@@ -225,7 +225,7 @@ public abstract class TestBase {
                 serverPath = new URI(Connector.END_POINT).getPath();
                 bindingConfig.setAuthEndpoint(configEndpoint + serverPath);
                 bindingConfig.setServiceEndpoint(configEndpoint + serverPath);
-                bindingConfig.setRestEndpoint(configEndpoint + ClientBase.BULKV1_ENDPOINT);
+                bindingConfig.setRestEndpoint(configEndpoint + ClientBase.BULKV1_ENDPOINT_PATH);
                 bindingConfig.setManualLogin(true);
                 // set long timeout for tests with larger data sets
                 bindingConfig.setReadTimeout(5 * 60 * 1000);

--- a/src/test/resources/testfiles/conf/config.properties
+++ b/src/test/resources/testfiles/conf/config.properties
@@ -15,3 +15,4 @@ sfdc.bulkApiCheckStatusInterval=500
 # default setting for test
 loader.csvComma=true
 loader.csvTab=true
+sfdc.oauth.loginfrombrowser=false


### PR DESCRIPTION
Data Loader should be able to handle the staggered rollout of a Salesforce release by switching to the API version of the previous API release if the API version specified in WSC does not work.

Also made minor code refactoring in Controller.java and Config.java.