### PR TITLE
fix for the bug : local database access in CLI mode fails when Encryp…

### DIFF
--- a/src/main/java/com/salesforce/dataloader/dao/EncryptedDataSource.java
+++ b/src/main/java/com/salesforce/dataloader/dao/EncryptedDataSource.java
@@ -61,7 +61,7 @@ public class EncryptedDataSource extends org.apache.commons.dbcp2.BasicDataSourc
     }
 
     public synchronized void setPassword(String encodedPassword) {
-    	setPassword(decode(encodedPassword));
+    	super.setPassword(decode(encodedPassword));
     }
     
     private String decode(String password) {


### PR DESCRIPTION
…tedDataSource is used

The bug was introduced in v53 when doing the major version upgrade of DBCP2, which made the field "password" in  "org.apache.commons.dbcp2.BasicDataSource" private. The fix introduced a recursion in the call "setPassword(String)", that causes the bug.