### PR TITLE
Use the charset specified in file.encoding system property for CSV re…

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -1197,8 +1197,31 @@ public class Config {
 
     private static final Charset UTF8 = Charset.forName("UTF-8");
 
-    public String getCsvWriteEncoding() {
-        if (Charset.defaultCharset().equals(UTF8) || getBoolean(WRITE_UTF8)) return UTF8.name();
+    public String getCsvEncoding(boolean isWrite) {
+        // charset is for CSV read unless isWrite is set to true
+        String configProperty = READ_UTF8;
+        if (isWrite) {
+            configProperty = WRITE_UTF8;
+        }
+        if (getBoolean(configProperty)) {
+            logger.debug("Using UTF8 charset because '" 
+                    +  configProperty
+                    +"' is set to true");
+            return UTF8.name();
+        }        
+        String fileEncodingStr = System.getProperty("file.encoding");
+        if (fileEncodingStr != null && !fileEncodingStr.isBlank()) {
+            for (String charsetName : Charset.availableCharsets().keySet()) {
+                if (fileEncodingStr.equalsIgnoreCase(charsetName)) {
+                    logger.debug("Using charset specified in file.encoding system property: " + fileEncodingStr);
+                    return charsetName;
+                }
+            }
+            logger.debug("Unable to find the charset '"
+                    + fileEncodingStr
+                    + "' specified in file.encoding system property among available charsets for the Java VM." );
+        }
+        logger.debug("Using the system default charset: " + Charset.defaultCharset().name());
         return Charset.defaultCharset().name();
     }
 

--- a/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileReader.java
@@ -70,6 +70,7 @@ public class CSVFileReader implements DataReader {
     private List<String> headerRow;
     private boolean isOpen;
     private char[] csvDelimiters;
+    private Config config;
 
     public CSVFileReader(Config config) {
         this(new File(config.getString(Config.DAO_NAME)), config, true);
@@ -90,6 +91,7 @@ public class CSVFileReader implements DataReader {
 
     public CSVFileReader(File file, Config config, boolean custDelimiter) {
         this.file = file;
+        this.config = config;
         forceUTF8 = config.getBoolean(Config.READ_UTF8);
         StringBuilder separator = new StringBuilder();
         if (custDelimiter) {
@@ -299,8 +301,9 @@ public class CSVFileReader implements DataReader {
                 BOMInputStream bomInputStream = new BOMInputStream(input);
                 csvReader = new CSVReader(bomInputStream, "UTF-8", csvDelimiters);
             } else {
-                csvReader = new CSVReader(input, csvDelimiters);
-                LOGGER.debug(this.getClass().getName(), "encoding used to write to CSV file is " + Charset.defaultCharset().name());
+                String encoding = this.config.getCsvEncoding(false);
+                csvReader = new CSVReader(input, encoding, csvDelimiters);
+                LOGGER.debug(this.getClass().getName(), "encoding used to read from CSV file is " + encoding);
             }
             csvReader.setMaxRowsInFile(Integer.MAX_VALUE);
             csvReader.setMaxCharsInFile(Integer.MAX_VALUE);

--- a/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileWriter.java
+++ b/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileWriter.java
@@ -78,7 +78,7 @@ public class CSVFileWriter implements DataWriter {
     public CSVFileWriter(String fileName, Config config) {
         this.fileName = fileName;
         this.capitalizedHeadings = true;
-        encoding = config.getCsvWriteEncoding();
+        encoding = config.getCsvEncoding(true);
         logger.debug(this.getClass().getName(), "encoding used to write to CSV file is " + encoding);
     }
 


### PR DESCRIPTION
…ad and write

Explicitly use the value of "file.encoding" system property for charset when reading from or writing to a CSV file instead of relying on JVM to set the default charset to the value specified in "file.encoding" system property.

Add more debugging around selection of the charset.

Use the same code to select the charset for both CSV read and CSV write.

This change is based on issue #502 .