### PR TITLE
remove ui package dependency from OAuthBrowserLoginRunner

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/OAuthFlow.java
+++ b/src/main/java/com/salesforce/dataloader/ui/OAuthFlow.java
@@ -114,23 +114,4 @@ public abstract class OAuthFlow extends Dialog {
         new URIBuilder(url).getQueryParams().stream().forEach(kvp -> params.put(kvp.getName(), kvp.getValue()));
         return params;
     }
-    
-    public static void processSuccessfulLogin(InputStream httpResponseInputStream, Config config) throws IOException {
-
-        StringBuilder builder = new StringBuilder();
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(httpResponseInputStream, "UTF-8"));
-        for (int c = bufferedReader.read(); c != -1; c = bufferedReader.read()) {
-            builder.append((char) c);
-        }
-
-        String jsonTokenResult = builder.toString();
-        Gson gson = new GsonBuilder()
-                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                .create();
-        OAuthToken token = gson.fromJson(jsonTokenResult, OAuthToken.class);
-        config.setValue(Config.OAUTH_ACCESSTOKEN, token.getAccessToken());
-        config.setValue(Config.OAUTH_REFRESHTOKEN, token.getRefreshToken());
-        config.setValue(Config.ENDPOINT, token.getInstanceUrl());
-    }
-
 }

--- a/src/main/java/com/salesforce/dataloader/ui/OAuthSecretFlow.java
+++ b/src/main/java/com/salesforce/dataloader/ui/OAuthSecretFlow.java
@@ -29,6 +29,8 @@ import com.salesforce.dataloader.client.SimplePost;
 import com.salesforce.dataloader.client.SimplePostFactory;
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.exception.ParameterLoadException;
+import com.salesforce.dataloader.util.OAuthBrowserLoginRunner;
+
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
@@ -115,7 +117,7 @@ public class OAuthSecretFlow extends OAuthFlow {
             );
             client.post();
             if (client.isSuccessful()) {
-            	processSuccessfulLogin(client.getInput(), config);
+                OAuthBrowserLoginRunner.processSuccessfulLogin(client.getInput(), config);
             }
             return client;
         }


### PR DESCRIPTION
A class in util package such as OAuthBrowserLoginRunner should not depend on a class in UI package because util is used by batch mode and batch mode does not load SWT packages, on which UI package depends.

Fixed the issue by moving processSuccessfulLogin() static method from OAuthFlow class in UI package to OAuthBrowserLoginRunner class in util.