### PR TITLE
test code cleanup and related changes

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/progress/ILoaderProgress.java
+++ b/src/main/java/com/salesforce/dataloader/action/progress/ILoaderProgress.java
@@ -34,5 +34,8 @@ public interface ILoaderProgress {
     void worked(int worked);
     void setSubTask(String name);
     boolean isCanceled();
+    boolean isSuccess();
+    String getMessage();
     void setNumberBatchesTotal(int numberBatchesTotal);
+    int getNumberBatchesTotal();
 }

--- a/src/main/java/com/salesforce/dataloader/action/progress/NihilistProgressAdapter.java
+++ b/src/main/java/com/salesforce/dataloader/action/progress/NihilistProgressAdapter.java
@@ -53,13 +53,16 @@ public enum NihilistProgressAdapter implements ILoaderProgress {
 
     }
 
+    boolean success = false;
     @Override
     public void doneError(String msgs) {
+        success = false;
         logger.error(msgs);
     }
 
     @Override
     public void doneSuccess(String msg) {
+        success = true;
         logger.info(msg);
 
     }
@@ -83,9 +86,25 @@ public enum NihilistProgressAdapter implements ILoaderProgress {
         return false;
     }
 
+    private int numberBatchesTotal = 0;
     @Override
     public void setNumberBatchesTotal(int numberBatchesTotal) {
-        // nothing
+        this.numberBatchesTotal = numberBatchesTotal;
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return this.success;
+    }
+
+    @Override
+    public String getMessage() {
+        return "";
+    }
+
+    @Override
+    public int getNumberBatchesTotal() {
+        return this.numberBatchesTotal;
     }
 
 }

--- a/src/main/java/com/salesforce/dataloader/action/progress/SWTProgressAdapter.java
+++ b/src/main/java/com/salesforce/dataloader/action/progress/SWTProgressAdapter.java
@@ -42,6 +42,7 @@ public class SWTProgressAdapter implements ILoaderProgress {
     private IProgressMonitor monitor = null;
     private String dispMessage;
     private final Controller controller;
+    private boolean success = false;
 
     public SWTProgressAdapter(IProgressMonitor monitor_, Controller controller) {
         monitor = monitor_;
@@ -67,6 +68,7 @@ public class SWTProgressAdapter implements ILoaderProgress {
      */
     @Override
     public void doneSuccess(String message) {
+        success = true;
         monitor.done();
         controller.setLastOperationSuccessful(true);
         dispMessage = message;
@@ -91,6 +93,7 @@ public class SWTProgressAdapter implements ILoaderProgress {
 
     @Override
     public void doneError(String message) {
+        success = false;
         monitor.done();
         controller.setLastOperationSuccessful(false);
         dispMessage = message;
@@ -101,7 +104,15 @@ public class SWTProgressAdapter implements ILoaderProgress {
             }
         });
     }
-
+    
+    public boolean isSuccess() {
+        return this.success;
+    }
+    
+    public String getMessage() {
+        return this.dispMessage;
+    }
+ 
     /*
      * (non-Javadoc)
      *
@@ -141,9 +152,15 @@ public class SWTProgressAdapter implements ILoaderProgress {
         return monitor.isCanceled();
     }
 
+    private int numberBatchesTotal = 0;
     @Override
     public void setNumberBatchesTotal(int numberBatchesTotal) {
-        // nothing
+        this.numberBatchesTotal = numberBatchesTotal;
+    }
+
+    @Override
+    public int getNumberBatchesTotal() {
+        return this.numberBatchesTotal;
     }
 
 }

--- a/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
@@ -308,8 +308,6 @@ public class DataLoaderRunner extends Thread {
                         return dirStr;
                     }
                 }
-            } else {
-                return null;
             }
         }
         return null;

--- a/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
@@ -97,6 +97,8 @@ public class ProcessRunner implements InitializingBean {
 
     private Controller controller;
     
+    private ILoaderProgress monitor;
+    
     private static final String PROP_NAME_ARRAY[] = {
             Config.OPERATION,
             Config.ENDPOINT,
@@ -117,6 +119,7 @@ public class ProcessRunner implements InitializingBean {
         if (monitor == null) {
             monitor = NihilistProgressAdapter.get();
         }
+        this.monitor = monitor;
         final String oldName = Thread.currentThread().getName();
         String name = getName();
 
@@ -187,6 +190,10 @@ public class ProcessRunner implements InitializingBean {
             // restore original thread name
             setThreadName(oldName);
         }
+    }
+    
+    public ILoaderProgress getMonitor() {
+        return this.monitor;
     }
 
     private void setThreadName(final String name) {

--- a/src/test/java/com/salesforce/dataloader/TestBase.java
+++ b/src/test/java/com/salesforce/dataloader/TestBase.java
@@ -175,6 +175,7 @@ public abstract class TestBase {
 
     protected void setupController(Map<String, String> configOverrideMap) {
         // configure the Controller to point to our testing config
+        configOverrideMap.put(Config.CLI_OPTION_READ_ONLY_CONFIG_PROPERTIES, Boolean.TRUE.toString());
         if (!System.getProperties().contains(Config.CLI_OPTION_CONFIG_DIR_PROP))
             System.setProperty(Config.CLI_OPTION_CONFIG_DIR_PROP, getTestConfDir());
 

--- a/src/test/java/com/salesforce/dataloader/process/BulkCsvProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/BulkCsvProcessTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 
 import com.salesforce.dataloader.TestProgressMontitor;
 import com.salesforce.dataloader.action.OperationInfo;
+import com.salesforce.dataloader.action.progress.ILoaderProgress;
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.dao.csv.CSVFileWriter;
@@ -82,7 +83,7 @@ public class BulkCsvProcessTest extends ProcessTestBase {
     public void testBatchSizes() throws Exception {
         writeCsv(validRow, validRow);
         argMap.put(Config.LOAD_BATCH_SIZE, "1");
-        TestProgressMontitor monitor = runProcess(argMap, 2, 0, 0, false);
+        ILoaderProgress monitor = runProcess(argMap, 2, 0, 0, false);
         assertEquals("Inserting 2 rows with batch size of 1 should have produced 2 batches", 2, monitor.getNumberBatchesTotal());
     }
 
@@ -90,16 +91,14 @@ public class BulkCsvProcessTest extends ProcessTestBase {
     public void testBatchSizesNotAlteredByInvalidData() throws Exception {
         writeCsv(validRow, invalidRow, validRow);
         argMap.put(Config.LOAD_BATCH_SIZE, "2");
-        TestProgressMontitor monitor = runProcess(argMap, 2, 0, 1, false);
+        ILoaderProgress monitor = runProcess(argMap, 2, 0, 1, false);
         assertEquals("Even though middle row contains invalid data only 1 batch should have been created", 1, monitor.getNumberBatchesTotal());
     }
 
-    private TestProgressMontitor runProcess(Map<String, String> argMap, int numInserts, int numUpdates, int numFailures, boolean emptyId) throws Exception {
+    private ILoaderProgress runProcess(Map<String, String> argMap, int numInserts, int numUpdates, int numFailures, boolean emptyId) throws Exception {
 
-        argMap.put(ProcessRunner.PROCESS_THREAD_NAME, baseName);
-        final TestProgressMontitor monitor = new TestProgressMontitor();
-        final ProcessRunner runner = ProcessRunner.runBatchMode(argMap, monitor);
-
+        final ProcessRunner runner = this.runBatchProcess(argMap);
+        ILoaderProgress monitor = runner.getMonitor();
         Controller controller = runner.getController();
 
         assertTrue("Process failed", monitor.isSuccess());

--- a/src/test/java/com/salesforce/dataloader/process/CsvProcessAttachmentTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvProcessAttachmentTest.java
@@ -30,6 +30,7 @@ import com.salesforce.dataloader.TestProgressMontitor;
 import com.salesforce.dataloader.TestSetting;
 import com.salesforce.dataloader.TestVariant;
 import com.salesforce.dataloader.action.OperationInfo;
+import com.salesforce.dataloader.action.progress.ILoaderProgress;
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.exception.DataAccessObjectException;
@@ -144,17 +145,12 @@ public class CsvProcessAttachmentTest extends ProcessTestBase {
                                                         AttachmentTemplateListener myAttachmentTemplateListener, String... files)
             throws ProcessInitializationException, DataAccessObjectException, ConnectionException, IOException {
 
-        if (argMap == null) argMap = getTestConfig();
-        argMap.put(ProcessRunner.PROCESS_THREAD_NAME, this.baseName);
-
-        final TestProgressMontitor monitor = new TestProgressMontitor();
-        final ProcessRunner runner = ProcessRunner.runBatchMode(argMap, monitor);
-
+        final ProcessRunner runner = this.runBatchProcess(argMap);
+        ILoaderProgress monitor = runner.getMonitor();
         Controller controller = runner.getController();
 
         // verify process completed as expected
         if (expectProcessSuccess) {
-
             verifyInsertCorrectByContent(controller, createAttachmentFileMap(files), myAttachmentTemplateListener);
             // this should also still work
             assertTrue("Process failed: " + monitor.getMessage(), monitor.isSuccess());

--- a/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
@@ -39,6 +39,7 @@ import org.junit.Before;
 
 import com.salesforce.dataloader.*;
 import com.salesforce.dataloader.action.OperationInfo;
+import com.salesforce.dataloader.action.progress.ILoaderProgress;
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.dao.DataAccessObjectFactory;
@@ -710,17 +711,20 @@ public abstract class ProcessTestBase extends ConfigTestBase {
             throws ProcessInitializationException, DataAccessObjectException {
         return runProcess(args, false, failureMessage, 0, 0, 0, false);
     }
+    
+    protected ProcessRunner runBatchProcess(Map<String, String> argMap) {
+        if (argMap == null) argMap = getTestConfig();
+        argMap.put(ProcessRunner.PROCESS_THREAD_NAME, this.baseName);
+        argMap.put(Config.CLI_OPTION_READ_ONLY_CONFIG_PROPERTIES, Boolean.TRUE.toString());
+        final TestProgressMontitor monitor = new TestProgressMontitor();        
+        return ProcessRunner.runBatchMode(argMap, monitor);
+    }
 
     protected Controller runProcess(Map<String, String> argMap, boolean expectProcessSuccess, String failMessage,
             int numInserts, int numUpdates, int numFailures, boolean emptyId) throws ProcessInitializationException,
             DataAccessObjectException {
-
-        if (argMap == null) argMap = getTestConfig();
-        argMap.put(ProcessRunner.PROCESS_THREAD_NAME, this.baseName);
-        
-        final TestProgressMontitor monitor = new TestProgressMontitor();
-        final ProcessRunner runner = ProcessRunner.runBatchMode(argMap, monitor);
-
+        ProcessRunner runner = runBatchProcess(argMap);
+        ILoaderProgress monitor = runner.getMonitor();
         Controller controller = runner.getController();
 
         // verify process completed as expected


### PR DESCRIPTION
A recent refactoring and modularization of Config and Controller code exposed a latent bug in test code where test properties set during a test run can affect subsequent tests. The fix is to do the following:
- properties such as password, if set in config.properties, should be preserved.
- if the command line option to treat config.properties as read-only is set to true, do not save properties to config.properties. This is needed when running tests to ensure that the initial config.properties value are preserved across tests.

Refactored Process tests to create ProcessRunner after specifying that properties from config.properties are read-only.

Modified ILoaderProgress and its implementations to provider getters for status, message, and batchTotal.