### PR TITLE
fix for issue #514

### DIFF
--- a/src/main/java/com/salesforce/dataloader/util/OAuthBrowserLoginRunner.java
+++ b/src/main/java/com/salesforce/dataloader/util/OAuthBrowserLoginRunner.java
@@ -163,7 +163,7 @@ public class OAuthBrowserLoginRunner {
            try {
                logger.debug("trying to use desktop.browse() method");
                desktop.browse(new URI(url));
-           } catch (IOException | URISyntaxException e) {
+           } catch (Exception e) {
                logger.debug(e.getMessage());
                openURLUsingNativeCommand(url);
            }


### PR DESCRIPTION
Catch all exceptions in desktop.browse() call and try native methods to launch browser for OAuth.