### PR TITLE
minor cleanup of batch scripts

### DIFF
--- a/release/win/bin/encrypt.bat
+++ b/release/win/bin/encrypt.bat
@@ -5,12 +5,13 @@ set EXE_PATH=%~dp0
 set DATALOADER_VERSION=@@FULL_VERSION@@
 
 IF NOT "%DATALOADER_JAVA_HOME%" == "" (
-    set JAVA_HOME="%DATALOADER_JAVA_HOME%"
+    set JAVA_HOME=%DATALOADER_JAVA_HOME%
 )
 
-IF [%JAVA_HOME%] == [] (
+IF "%JAVA_HOME%" == "" (
     echo To run encrypt.bat, set the JAVA_HOME environment variable to the directory where the Java Runtime Environment ^(JRE^) is installed.
 ) ELSE (
-    PATH="%JAVA_HOME%"\bin\;%PATH%;
+    PATH=%JAVA_HOME%\bin\;%PATH%;
     java -cp "%EXE_PATH%\..\dataloader-%DATALOADER_VERSION%-uber.jar" com.salesforce.dataloader.security.EncryptionUtil %*
 )
+endlocal

--- a/release/win/bin/process.bat
+++ b/release/win/bin/process.bat
@@ -52,4 +52,5 @@ if %SKIP_COUNT% == 2 shift
 CALL %EXE_PATH%\..\dataloader.bat -skipbanner run.mode=batch %CONFIG_DIR_OPTION% %BATCH_PROCESS_BEAN_ID_OPTION% %args%
 
 :end
+endlocal
 exit /b %errorlevel%


### PR DESCRIPTION
- call endlocal at end of the script.
- remove double-quotes when setting a variable with value of another variable.