### PR TITLE
A couple of minor fixes

### DIFF
--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -257,8 +257,6 @@ public class Controller {
     private void createDao(String daoTypeStr, String daoNameStr) throws DataAccessObjectInitializationException {
         config.setValue(Config.DAO_NAME, daoNameStr);
         config.setValue(Config.DAO_TYPE, daoTypeStr);
-        this.saveConfig();
-
         try {
             config.getStringRequired(Config.DAO_NAME); // verify required param exists: dao name
             dao = daoFactory.getDaoInstance(config.getStringRequired(Config.DAO_TYPE), config);
@@ -277,7 +275,6 @@ public class Controller {
             throw new MappingInitializationException(e.getMessage());
         }
         config.setValue(Config.ENTITY, sObjectName);
-        this.saveConfig();
         try {
             this.setFieldTypes();
             this.setReferenceDescribes();

--- a/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
@@ -136,7 +136,8 @@ public class ProcessRunner implements InitializingBean {
         try {
             logger.info(Messages.getString("Process.initializingEngine")); //$NON-NLS-1$
             Config config = controller.getConfig();
-            if (config.getBoolean(Config.OAUTH_LOGIN_FROM_BROWSER)) {
+            if (!(config.contains(Config.USERNAME) && config.contains(Config.PASSWORD))
+                    && config.getBoolean(Config.OAUTH_LOGIN_FROM_BROWSER)) {
                 doLoginFromBrowser(config);
             }
             // Make sure that the required properties are specified.


### PR DESCRIPTION
- Fix for the issue described at https://github.com/forcedotcom/dataloader/issues/506#issuecomment-1196830697

- Avoid properties loaded through command line or process-conf from getting written in config.properties.

- Do not call saveConfig() when DAO is configured or entity is set.