### PR TITLE
simplify batch mode wrapper script - process.bat

### DIFF
--- a/release/win/bin/process.bat
+++ b/release/win/bin/process.bat
@@ -1,58 +1,9 @@
 @echo off
 SETLOCAL
 
-IF NOT "%1"=="" GOTO :run
-echo.
-echo Usage: process ^<configuration directory^> ^[batch process bean id^]
-echo.
-echo      configuration directory -- required -- directory that contains configuration files,
-echo          i.e. config.properties, process-conf.xml, database-conf.xml
-echo.
-echo      batch process bean id -- optional -- id of a batch process bean in process-conf.xml,
-echo          for example:
-echo.
-echo              process ../myconfigdir AccountInsert
-echo.
-echo          If process bean id is not specified, the value of the property process.name in config.properties
-echo          will be used to run the process instead of process-conf.xml,
-echo          for example:
-echo.
-echo              process ../myconfigdir
-echo.
-GOTO :exit
-
-:run
-SET DATALOADER_VERSION=@@FULL_VERSION@@
-SET "CONFIG_DIR_OPTION=salesforce.config.dir=%1"
-SET SKIP_ARGS_COUNT=1
-
-SET BATCH_PROCESS_BEAN_ID_OPTION=
-IF NOT "%2"=="" (
-    set BATCH_PROCESS_BEAN_ID_OPTION=process.name=%2
-    set SKIP_ARGS_COUNT=2
-)
-
-REM first argument is mandatory. Skip it because it is handled differently from other args.
-SHIFT
-
-REM skip the second argument if provided because it is handled differently from other args.
-IF "%SKIP_ARGS_COUNT%" == "2" SHIFT
-
-REM preserve rest of the command line arguments in ARGS variable
-SET ARGS=
-:preserveNextArg
-    IF "%1" == "" GOTO :afterPreserveArgs
-    IF "%ARGS%" == "" (
-        SET ARGS=%1=%2
-    ) ELSE (
-        SET ARGS=%ARGS% %1=%2
-    )
-    SHIFT
-    SHIFT
-    GOTO :preserveNextArg
-
-:afterPreserveArgs
-CALL %~dp0..\dataloader.bat -skipbanner run.mode=batch %CONFIG_DIR_OPTION% %BATCH_PROCESS_BEAN_ID_OPTION% %ARGS%
+CALL %~dp0..\util\util.bat checkJavaVersion
+IF "%ERRORLEVEL%" NEQ "0" GOTO :exit
+java -jar "%~dp0..\dataloader-%DATALOADER_VERSION%-uber.jar" %* run.mode=batch
 
 :exit
 ENDLOCAL

--- a/release/win/dataloader.bat
+++ b/release/win/dataloader.bat
@@ -1,13 +1,9 @@
 @echo off
 SETLOCAL
 
-IF NOT "%~1"=="-skipbanner" (
-        CALL %~dp0\util\util.bat showBanner
-    )
-)
-CALL %~dp0\util\util.bat checkJavaVersion
+CALL %~dp0\util\util.bat showBanner
+CALL %~dp0util\util.bat checkJavaVersion
 IF "%ERRORLEVEL%" NEQ "0" GOTO :exit
-
 java -jar "%~dp0dataloader-%DATALOADER_VERSION%-uber.jar" %*
 
 :exit

--- a/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
@@ -91,34 +91,31 @@ public class DataLoaderRunner extends Thread {
 
     public static void main(String[] args) {
         argNameValuePair = Controller.getArgMapFromArgArray(args);
-        Controller.initializeLog(argNameValuePair);
         Runtime.getRuntime().addShutdownHook(new DataLoaderRunner());
-        logger = LogManager.getLogger(DataLoaderRunner.class);
-        if (args != null) {
-            for (String arg : args) {
-                logger.debug(arg);
-            }
-        }
         setUseGMTForDateFieldValue();
         if (isBatchMode()) {
             ProcessRunner.runBatchMode(args);
-        } else if (argNameValuePair.containsKey(Config.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH) 
-                && "true".equalsIgnoreCase(argNameValuePair.get(Config.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH))){
+        } else {
             /* Run in the UI mode, get the controller instance with batchMode == false */
-            try {
-                String defaultBrowser = System.getProperty("org.eclipse.swt.browser.DefaultType");
-                if (defaultBrowser == null) {
-                    logger.debug("org.eclipse.swt.browser.DefaultType not set for UI mode on Windows");
-                } else {
-                    logger.debug("org.eclipse.swt.browser.DefaultType set to " + defaultBrowser + " for UI mode on Windows");
+            Controller.initializeLog(argNameValuePair);
+            logger = LogManager.getLogger(DataLoaderRunner.class);
+            if (argNameValuePair.containsKey(Config.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH) 
+                && "true".equalsIgnoreCase(argNameValuePair.get(Config.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH))){
+                try {
+                    String defaultBrowser = System.getProperty("org.eclipse.swt.browser.DefaultType");
+                    if (defaultBrowser == null) {
+                        logger.debug("org.eclipse.swt.browser.DefaultType not set for UI mode on Windows");
+                    } else {
+                        logger.debug("org.eclipse.swt.browser.DefaultType set to " + defaultBrowser + " for UI mode on Windows");
+                    }
+                    Controller controller = Controller.getInstance(Config.RUN_MODE_UI_VAL, args);
+                    controller.createAndShowGUI();
+                } catch (ControllerInitializationException e) {
+                    UIUtils.errorMessageBox(new Shell(new Display()), e);
                 }
-                Controller controller = Controller.getInstance(Config.RUN_MODE_UI_VAL, args);
-                controller.createAndShowGUI();
-            } catch (ControllerInitializationException e) {
-                UIUtils.errorMessageBox(new Shell(new Display()), e);
+            } else { // SWT_NATIVE_LIB_IN_JAVA_LIB_PATH not set
+                rerunWithSWTNativeLib(args);
             }
-        } else { // SWT_NATIVE_LIB_IN_JAVA_LIB_PATH not set
-            rerunWithSWTNativeLib(args);
         }
     }
     


### PR DESCRIPTION
Move command line argument check to Java code, thereby simplifying process.bat and dataloader.bat scripts.