### PR TITLE
configuration properties cleanup and increase test coverage

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -269,6 +269,9 @@ public class Config {
     //
     // process configuration (action parameters)
     //
+    // process.name is used to load the DynaBean from process-conf.xml file 
+    // with the same id as the value of process.name property.
+    public static final String PROCESS_NAME = "process.name";
     public static final String OPERATION = "process.operation"; //$NON-NLS-1$
     public static final String MAPPING_FILE = "process.mappingFile"; //$NON-NLS-1$
     public static final String EURO_DATES = "process.useEuropeanDates"; //$NON-NLS-1$
@@ -284,6 +287,7 @@ public class Config {
     public static final String LOAD_ROW_TO_START_AT = "process.loadRowToStartAt"; //$NON-NLS-1$
     public static final String INITIAL_LAST_RUN_DATE = "process.initialLastRunDate";
     public static final String ENCRYPTION_KEY_FILE = "process.encryptionKeyFile"; //$NON-NLS-1$
+    public static final String PROCESS_THREAD_NAME = "process.thread.name";
 
     // data access configuration (e.g., for CSV file, database, etc).
     public static final String DAO_TYPE = "dataAccess.type"; //$NON-NLS-1$
@@ -408,9 +412,30 @@ public class Config {
             DAO_TYPE,
             ENTITY,
             OPERATION,
-            DEBUG_MESSAGES_FILE
+            DEBUG_MESSAGES_FILE,
+            PROCESS_THREAD_NAME
     };
     
+    private static boolean useGMTForDateFieldValue;
+    public static boolean isUseGMTForDateFieldValue() {
+        return useGMTForDateFieldValue;
+    }
+    
+    public static void initializeStaticVariables(Map<String, String> argMap) {
+        setUseGMTForDateFieldValue(argMap);
+    }
+    
+    private static void setUseGMTForDateFieldValue(Map<String, String> argMap) {
+        if (argMap.containsKey(Config.CLI_OPTION_GMT_FOR_DATE_FIELD_VALUE)) {
+            if ("true".equalsIgnoreCase(argMap.get(Config.CLI_OPTION_GMT_FOR_DATE_FIELD_VALUE))) {
+                useGMTForDateFieldValue = true;
+            }
+        }
+    }
+    
+    public static void setUseGMTForDateFieldValue(boolean val) {
+        useGMTForDateFieldValue = val;
+    }
     /**
      * Creates an empty config that loads from and saves to the a file. <p> Use the methods
      * <code>load()</code> and <code>save()</code> to load and store this preference store. </p>

--- a/src/main/java/com/salesforce/dataloader/process/ProcessConfig.java
+++ b/src/main/java/com/salesforce/dataloader/process/ProcessConfig.java
@@ -58,7 +58,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
 import com.salesforce.dataloader.config.Messages;
-import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.exception.ProcessInitializationException;
 import com.salesforce.dataloader.util.AppUtil;
 

--- a/src/main/java/com/salesforce/dataloader/util/DateOnlyCalendar.java
+++ b/src/main/java/com/salesforce/dataloader/util/DateOnlyCalendar.java
@@ -33,10 +33,15 @@ import java.util.TimeZone;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.salesforce.dataloader.process.DataLoaderRunner;
+import com.salesforce.dataloader.config.Config;
+
 
 
 public class DateOnlyCalendar extends GregorianCalendar {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
     static final TimeZone GMT_TZ = TimeZone.getTimeZone("GMT");
     static final Logger logger;
     
@@ -64,7 +69,7 @@ public class DateOnlyCalendar extends GregorianCalendar {
         Calendar cal = Calendar.getInstance(myTimeZone);
         cal.setTimeInMillis(specifiedTimeInMilliSeconds);
 
-        if (!DataLoaderRunner.doUseGMTForDateFieldValue() && myTimeZone != null) {
+        if (!Config.isUseGMTForDateFieldValue() && myTimeZone != null) {
             // Set hour, minute, second, and millisec to 0 (12:00AM) as it is date-only value
             cal.set(Calendar.HOUR, 0);
             cal.set(Calendar.MINUTE, 0);
@@ -83,7 +88,7 @@ public class DateOnlyCalendar extends GregorianCalendar {
     }
 
     public static DateOnlyCalendar getInstance(TimeZone timeZone) {
-        if (DataLoaderRunner.doUseGMTForDateFieldValue()) {
+        if (Config.isUseGMTForDateFieldValue()) {
             timeZone = GMT_TZ;
         } 
         return new DateOnlyCalendar(timeZone);

--- a/src/test/java/com/salesforce/dataloader/ConfigTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/ConfigTestBase.java
@@ -65,10 +65,10 @@ public abstract class ConfigTestBase extends TestBase {
         }
     }
 
-    private final Map<String, String> testConfig;
+    private final Map<String, String> baseConfig;
 
     protected Map<String, String> getTestConfig() {
-        final HashMap<String, String> configBase = new HashMap<String, String>(this.testConfig);
+        final HashMap<String, String> configBase = new HashMap<String, String>(this.baseConfig);
         configBase.put(Config.LAST_RUN_OUTPUT_DIR, getTestStatusDir());
         for (TestProperties prop : getDefaultTestPropertiesSet()) {
             prop.putConfigSetting(configBase);
@@ -91,7 +91,7 @@ public abstract class ConfigTestBase extends TestBase {
         if (testConfig == null) {
             testConfig = new HashMap<String, String>();
         }
-        this.testConfig = testConfig;
+        this.baseConfig = testConfig;
     }
 
     @Before

--- a/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
+++ b/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
@@ -28,9 +28,8 @@ package com.salesforce.dataloader.dyna;
 import org.apache.commons.beanutils.ConversionException;
 import org.junit.Assert;
 import org.junit.Test;
-import org.springframework.dao.EmptyResultDataAccessException;
 
-import com.salesforce.dataloader.process.DataLoaderRunner;
+import com.salesforce.dataloader.config.Config;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -658,7 +657,7 @@ public class DateConverterTest {
         assertEquals(6, result.get(Calendar.MONTH) + 1);
         assertEquals(22, result.get(Calendar.DAY_OF_MONTH));
 
-        DataLoaderRunner.setUseGMTForDateFieldValue(true);
+        Config.setUseGMTForDateFieldValue(true);
         AsianTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("Asia/Tokyo"), false);
         USTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("America/Los_Angeles"), false);
         result = (Calendar) USTZDateOnlyConverter.convert(null, "6/22/2012");
@@ -696,7 +695,7 @@ public class DateConverterTest {
         assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
         assertEquals(TimeZone.getTimeZone("GMT"), result.getTimeZone());
         
-        DataLoaderRunner.setUseGMTForDateFieldValue(false);
+        Config.setUseGMTForDateFieldValue(false);
         AsianTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("Asia/Tokyo"), false);
         USTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("America/Los_Angeles"), false);
 

--- a/src/test/java/com/salesforce/dataloader/process/CsvHardDeleteTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvHardDeleteTest.java
@@ -153,7 +153,7 @@ public class CsvHardDeleteTest extends ProcessTestBase {
             Assert.fail("hard delete should not succeed if bulk api is turned off");
         } catch (Exception e) {
             final String msg = e.getMessage();
-            final String expected = "java.lang.UnsupportedOperationException: Error instantiating operation hard_delete: could not instantiate class: null.";
+            final String expected = "Error instantiating operation hard_delete: could not instantiate class: null.";
             assertEquals("Wrong exception thrown when attempting to do hard delete with bulk api off : ", expected, msg);
         }
 

--- a/src/test/java/com/salesforce/dataloader/process/DatabaseProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/DatabaseProcessTest.java
@@ -143,7 +143,7 @@ public class DatabaseProcessTest extends ProcessTestBase {
 
         // specify the name of the configured process and select appropriate database access type
         if (args == null) args = getTestConfig();
-        args.put(ProcessRunner.DYNABEAN_ID, processName);
+        args.put(Config.PROCESS_NAME, processName);
         Config.DATE_FORMATTER.parse(startTime);
         args.put(LastRun.LAST_RUN_DATE, startTime);
         args.put(Config.OPERATION, OperationInfo.upsert.name());
@@ -176,7 +176,7 @@ public class DatabaseProcessTest extends ProcessTestBase {
         OperationInfo op = isInsert ? OperationInfo.insert : OperationInfo.update;
         Map<String, String> argMap = getTestConfig();
         argMap.put(Config.OPERATION, OperationInfo.extract.name());
-        argMap.put(ProcessRunner.DYNABEAN_ID, processName);
+        argMap.put(Config.PROCESS_NAME, processName);
         argMap.put(Config.DAO_NAME, op.name() + "Account");
         argMap.put(Config.OUTPUT_SUCCESS, new File(getTestStatusDir(), baseName + op.name() + "Success.csv")
         .getAbsolutePath());

--- a/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
@@ -714,10 +714,23 @@ public abstract class ProcessTestBase extends ConfigTestBase {
     
     protected ProcessRunner runBatchProcess(Map<String, String> argMap) {
         if (argMap == null) argMap = getTestConfig();
-        argMap.put(ProcessRunner.PROCESS_THREAD_NAME, this.baseName);
+        argMap.put(Config.PROCESS_THREAD_NAME, this.baseName);
         argMap.put(Config.CLI_OPTION_READ_ONLY_CONFIG_PROPERTIES, Boolean.TRUE.toString());
+
+        // emulate invocation through process.bat script
+        String[] args = new String[argMap.size()+1];
+        args[0] = getTestConfDir();
+        int i = 1;
+        if (argMap.containsKey(Config.PROCESS_NAME)) {
+            args[i++] = argMap.get(Config.PROCESS_NAME);
+            argMap.remove(Config.PROCESS_NAME);
+        }
+        for (Map.Entry<String, String> entry: argMap.entrySet())
+        {
+            args[i++] = entry.getKey() + "=" + entry.getValue();
+        }
         final TestProgressMontitor monitor = new TestProgressMontitor();        
-        return ProcessRunner.runBatchMode(argMap, monitor);
+        return ProcessRunner.runBatchMode(args, monitor);
     }
 
     protected Controller runProcess(Map<String, String> argMap, boolean expectProcessSuccess, String failMessage,


### PR DESCRIPTION
- Move all config properties to Config class (PROCESS_NAME, PROCESS_THREAD_NAME, CLI_OPTION_GMT_FOR_DATE_FIELD_VALUE)

- DataLoaderRunner and ProcessTestBase invoke the same method - ProcessRunner.runBatchMode(args, monitor)
Doing so increases test coverage.