### PR TITLE
support for "keep account team" and api version in config.properties

### DIFF
--- a/src/main/java/com/salesforce/dataloader/client/ClientBase.java
+++ b/src/main/java/com/salesforce/dataloader/client/ClientBase.java
@@ -81,7 +81,7 @@ public abstract class ClientBase<ClientType> {
         this.controller = controller;
         this.config = controller.getConfig();
         this.logger = logger;
-        String apiVersionStr = config.getString(Config.CLI_OPTION_API_VERSION);
+        String apiVersionStr = config.getString(Config.API_VERSION_PROP);
         if (apiVersionStr != null && !apiVersionStr.isEmpty()) {
             apiVersionForTheSession = apiVersionStr;
         }

--- a/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
+++ b/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
@@ -50,6 +50,8 @@ import com.sforce.soap.partner.FieldType;
 import com.sforce.soap.partner.LimitInfo;
 import com.sforce.soap.partner.LimitInfoHeader_element;
 import com.sforce.soap.partner.LoginResult;
+import com.sforce.soap.partner.OwnerChangeOption;
+import com.sforce.soap.partner.OwnerChangeOptionType;
 import com.sforce.soap.partner.PartnerConnection;
 import com.sforce.soap.partner.QueryResult;
 import com.sforce.soap.partner.SaveResult;
@@ -551,6 +553,14 @@ public class PartnerClient extends ClientBase<PartnerConnection> {
         PartnerConnection conn = Connector.newConnection(cc);
         // identify the client as dataloader
         conn.setCallOptions(ClientBase.getClientName(this.config), null);
+        
+        // Support for Keeping Account keepAccountTeam during Account ownership change
+        // More details at https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_header_ownerchangeoptions.htm
+        OwnerChangeOption keepAccountTeamOption = new OwnerChangeOption();
+        keepAccountTeamOption.setExecute(this.config.getBoolean(Config.PROCESS_KEEP_ACCOUNT_TEAM));
+        keepAccountTeamOption.setType(OwnerChangeOptionType.KeepAccountTeam); // Transfer Open opportunities owned by the account's owner
+        OwnerChangeOption[] ownerChangeOptionArray = new OwnerChangeOption[] {keepAccountTeamOption};
+        conn.setOwnerChangeOptions(ownerChangeOptionArray);
 
         String oauthAccessToken = config.getString(Config.OAUTH_ACCESSTOKEN);
         if (oauthAccessToken != null && oauthAccessToken.trim().length() > 0) {

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -288,6 +288,7 @@ public class Config {
     public static final String INITIAL_LAST_RUN_DATE = "process.initialLastRunDate";
     public static final String ENCRYPTION_KEY_FILE = "process.encryptionKeyFile"; //$NON-NLS-1$
     public static final String PROCESS_THREAD_NAME = "process.thread.name";
+    public static final String PROCESS_KEEP_ACCOUNT_TEAM = "process.keepAccountTeam";
 
     // data access configuration (e.g., for CSV file, database, etc).
     public static final String DAO_TYPE = "dataAccess.type"; //$NON-NLS-1$
@@ -303,6 +304,9 @@ public class Config {
      */
     public static final String READ_UTF8 = "dataAccess.readUTF8"; //$NON-NLS-1$
     public static final String WRITE_UTF8 = "dataAccess.writeUTF8"; //$NON-NLS-1$
+    
+    public static final String API_VERSION_PROP="salesforce.api.version";
+
     
     /**
      *  ===============  PILOT config properties ========
@@ -389,7 +393,6 @@ public class Config {
     public static final String CLI_OPTION_GMT_FOR_DATE_FIELD_VALUE = "datefield.usegmt";
     public static final String CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH = "swt.nativelib.inpath";
     public static final String CLI_OPTION_CONFIG_DIR_PROP = "salesforce.config.dir";
-    public static final String CLI_OPTION_API_VERSION="salesforce.api.version";
     public static final String CLI_OPTION_READ_ONLY_CONFIG_PROPERTIES = "config.properties.readonly";
     public static final String CONFIG_DIR_DEFAULT_VALUE = "configs";
     
@@ -416,7 +419,8 @@ public class Config {
             DEBUG_MESSAGES_FILE,
             PROCESS_THREAD_NAME,
             PROCESS_BULK_CACHE_DATA_FROM_DAO,
-            SAVE_BULK_SERVER_LOAD_AND_RAW_RESULTS_IN_CSV
+            SAVE_BULK_SERVER_LOAD_AND_RAW_RESULTS_IN_CSV,
+            API_VERSION_PROP
     };
     
     private static boolean useGMTForDateFieldValue;
@@ -578,6 +582,7 @@ public class Config {
         setDefaultValue(Config.CLI_OPTION_RUN_MODE, Config.RUN_MODE_UI_VAL);
         setDefaultValue(SAVE_BULK_SERVER_LOAD_AND_RAW_RESULTS_IN_CSV, false);
         setDefaultValue(PROCESS_BULK_CACHE_DATA_FROM_DAO, false);
+        setDefaultValue(PROCESS_KEEP_ACCOUNT_TEAM, false);
     }
 
     /**


### PR DESCRIPTION
- Added process.keepAccountTeam property for SOAP Partner operations per ask at https://ideas.salesforce.com/s/idea/a0B8W00000GdYyxUAF/dataloader-account-owner-change-keep-account-team-data-loader-45-and-above

- Added "salesforce.api.version" property, which can be set in config.properties to specify an API version that is different than WSC version.