### PR TITLE
add data loader version string to the zip file name.

### DIFF
--- a/dlbuilder.sh
+++ b/dlbuilder.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -f
+#!/bin/sh 
 # script parameters
 # $1 - password for the java key store containing code-signing cert
 # $2 - PKCS11 config file (see example below)
@@ -56,15 +56,15 @@ run_mvn() {
 
   if [ $2 = true ]
   then
-    echo "packaging dataloader_mac.zip"
-    mvn package -DskipTests -Duberjar.skip -Pzip,mac_x86_64,!win32_x86_64,!linux_x86_64
-    cp target/mac/dataloader_mac.zip .
-    echo "packaging dataloader_win.zip"
+    echo "packaging dataloader_mac_<version>.zip"
+     mvn package -DskipTests -Duberjar.skip -Pzip,mac_x86_64,!win32_x86_64,!linux_x86_64
+    cp target/mac/*.zip .
+    echo "packaging dataloader_win_<version>.zip"
     mvn package -DskipTests -Duberjar.skip -Pzip,!mac_x86_64,win32_x86_64,!linux_x86_64
-    cp target/win/dataloader_win.zip .
-    echo "packaging dataloader_linux.zip"
+    cp target/win/dataloader_win_v*.zip .
+    echo "packaging dataloader_linux_<version>.zip"
     mvn package -DskipTests -Duberjar.skip -Pzip,!mac_x86_64,!win32_x86_64,linux_x86_64
-    cp target/linux/dataloader_linux.zip .
+    cp target/linux/dataloader_linux_v*.zip .
   fi
 
   if [ $1 = true ]; then

--- a/pom.xml
+++ b/pom.xml
@@ -544,7 +544,7 @@
                       <fileset dir="${basedir}/target/" includes="swt${OSType}*/*"/>
                     </copy> 
                     <echo>zip OS-specific folder</echo>
-                    <zip update="true" destfile="${basedir}/target/${OSType}/dataloader_${OSType}.zip" >
+                    <zip update="true" destfile="${basedir}/target/${OSType}/dataloader_${OSType}_v${version}.zip" >
                       <zipfileset dirmode="755" filemode="755" 
                         dir="${basedir}/target/${OSType}" />
                      </zip>

--- a/src/main/java/com/salesforce/dataloader/ui/LoaderWindow.java
+++ b/src/main/java/com/salesforce/dataloader/ui/LoaderWindow.java
@@ -143,7 +143,10 @@ public class LoaderWindow extends ApplicationWindow {
         setBlockOnOpen(true);
         open();
 
-        Display.getCurrent().dispose();
+        Display currentDisplay = Display.getCurrent();
+        if (currentDisplay != null) {
+            currentDisplay.dispose();
+        }
     }
     
     public void updateTitle(String suffix) {


### PR DESCRIPTION
- add data loader version string to the zip file name
- avoid NPE when the user closes data loader window by selecting "Quit SWT' from SWT menu.