### PR TITLE
Fix for issue #554

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.force</groupId>
   <artifactId>dataloader</artifactId>
   <packaging>jar</packaging>
-  <version>56.0.0</version>
+  <version>56.0.1</version>
   <name>Data Loader</name>
   <url>https://github.com/forcedotcom/dataloader</url>
   <organization>

--- a/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
+++ b/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
@@ -754,8 +754,8 @@ public class PartnerClient extends ClientBase<PartnerConnection> {
                         Field[] refObjectFields = describeSObject(refEntityName).getFields();
                         Map<String, Field> refFieldInfo = new HashMap<String, Field>();
                         for (Field refField : refObjectFields) {
-                            boolean skipReference = true;
                             if (refField.isExternalId()
+                                || "id".equalsIgnoreCase(refField.getName())
                                 || ((refField.isNameField() ||  refField.getType().equals(FieldType.email)) 
                                     && refField.isIdLookup())) {
                                 // change createable and updateable attributes of a reference field


### PR DESCRIPTION
Issue #554 is caused by the fix for [W-10811419] Name (Auto-Number) field shows up and available for mapping in Data Loader when Self-Relationships field exist

An additional check that the field name is "id" and if so, allowing it as a reference field fixes the issue.