### PR TITLE
fix for exception "INVALID_SOAP_HEADER' exceptionMessage='You can't u…

### DIFF
--- a/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
+++ b/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
@@ -307,7 +307,7 @@ public class PartnerClient extends ClientBase<PartnerConnection> {
     /**
      * @param dynaBeans
      * @return SaveResult array
-     * @throws ConnectionException
+     * @throws ConnectionExceptio
      */
     public SaveResult[] loadInserts(List<DynaBean> dynaBeans) throws ConnectionException {
         return runSaveOperation(dynaBeans, INSERT_OPERATION, true);
@@ -553,14 +553,6 @@ public class PartnerClient extends ClientBase<PartnerConnection> {
         PartnerConnection conn = Connector.newConnection(cc);
         // identify the client as dataloader
         conn.setCallOptions(ClientBase.getClientName(this.config), null);
-        
-        // Support for Keeping Account keepAccountTeam during Account ownership change
-        // More details at https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_header_ownerchangeoptions.htm
-        OwnerChangeOption keepAccountTeamOption = new OwnerChangeOption();
-        keepAccountTeamOption.setExecute(this.config.getBoolean(Config.PROCESS_KEEP_ACCOUNT_TEAM));
-        keepAccountTeamOption.setType(OwnerChangeOptionType.KeepAccountTeam); // Transfer Open opportunities owned by the account's owner
-        OwnerChangeOption[] ownerChangeOptionArray = new OwnerChangeOption[] {keepAccountTeamOption};
-        conn.setOwnerChangeOptions(ownerChangeOptionArray);
 
         String oauthAccessToken = config.getString(Config.OAUTH_ACCESSTOKEN);
         if (oauthAccessToken != null && oauthAccessToken.trim().length() > 0) {


### PR DESCRIPTION
…se KeepAccountTeam to change a Contact's owner."

fix for W-11635112 - exception "INVALID_SOAP_HEADER' exceptionMessage='You can't use KeepAccountTeam to change a Contact's owner."

Introduction of "Keep Account Team" (PR #552) has introduced the issue of KeepAccountTeam being set for insert, delete, upsert, and update operations on all sObjects, including Account. This results in the exception such as the one captured in the Subject line. The fix is to set KeepAccountTeam option of OwnerChangeOptions SOAP header only if the operation is on Account object and clear these headers if the operation is on some other object.