### PR TITLE
fix failure to install data loader in the default folder on Windows

### DIFF
--- a/release/win/install.bat
+++ b/release/win/install.bat
@@ -1,6 +1,7 @@
 @echo off
 setlocal
 
+SET ERRORLEVEL=0
 CALL "%~dp0util\util.bat" showBanner
 
 echo Data Loader installation requires you to provide an installation directory to create a version-specific subdirectory for the installation artifacts.


### PR DESCRIPTION
Fix for W-11828110 - Data Loader installation on Windows exits without successfully installing data loader when user chooses the default installation folder