### PR TITLE
Fix for W-11859516 - Data Loader v56 ignores log-conf.xml settings

### DIFF
--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -406,25 +406,22 @@ public class Controller {
         if (Controller.isInitialized) {
             return;
         }
+        
         try {
-            initStaticVariables();
-        } catch (ControllerInitializationException ex) {
-            System.out.println("Controller.initializeLog(): Unable to initialize Controller static vars: " + ex.getMessage());
-            ex.printStackTrace();
-        }
-        Config.initializeStaticVariables(argMap);
-
-        // Need to initialize the configurations directory before initializing logger
-        // because the default log-conf.xml resides in the configuration directory.
-        AppUtil.setConfigurationsDir(argMap);
-
-        // initialize logger
-        try {
+            // Need to initialize the configurations directory before initializing logger
+            // because the default log-conf.xml resides in the configuration directory.
+            AppUtil.setConfigurationsDir(argMap);
+            
+            // initialize logger
             _doInitializeLog();
-        } catch (FactoryConfigurationError e) {
-            e.printStackTrace();
-        } finally {
+            
+            // initialze Controller and Config static vars
+            initStaticVariables();
+            Config.initializeStaticVariables(argMap);
             Controller.isInitialized = true;
+        } catch (Exception ex) {
+            System.out.println("Controller.initializeStaticVariables(): Unable to initialize Controller static vars: " + ex.getMessage());
+            ex.printStackTrace();
         }
     }
     


### PR DESCRIPTION
Root-cause for the issue: LogManager.getLogger() gets called before Java system property "log4j2.configurationFile" gets set in Controller._doInitializeLog() method.

Fix is to make sure _doInitializeLog() gets called before Config.initializeStaticVariables() gets called.