### PR TITLE
fix for W-11901215 - Unable to connect to DB using ojdbc11.jar from D…

### DIFF
--- a/release/mac/dataloader.app/Contents/MacOS/dataloader
+++ b/release/mac/dataloader.app/Contents/MacOS/dataloader
@@ -34,6 +34,6 @@ if [ -z "${JAVA_VERSION}" ] | [ ${JAVA_VERSION} \< ${MIN_JAVA_VERSION} ]
 then
     echo "Java JRE ${MIN_JAVA_VERSION} or later is not installed. For example, download and install Zulu OpenJDK ${MIN_JAVA_VERSION} or later JRE for macOS from https://www.azul.com/downloads/zulu/zulu-mac/"
 else
-    cd `dirname $0`/../../../
-    java -jar ${DATALOADER_UBER_JAR_NAME} $@
+    DLROOT=`dirname $0`\/..\/..\/..\/
+    java -cp "${DLROOT}/*" com.salesforce.dataloader.process.DataLoaderRunner $@
 fi

--- a/release/win/bin/encrypt.bat
+++ b/release/win/bin/encrypt.bat
@@ -6,7 +6,7 @@ IF "%ERRORLEVEL%" NEQ "0" (
     PAUSE
     GOTO :exit
 )
-java -cp "%~dp0..\dataloader-%DATALOADER_VERSION%-uber.jar" com.salesforce.dataloader.security.EncryptionUtil %*
+java -cp "%~dp0..\*" com.salesforce.dataloader.security.EncryptionUtil %*
 
 :exit
 ENDLOCAL

--- a/release/win/bin/process.bat
+++ b/release/win/bin/process.bat
@@ -6,7 +6,9 @@ IF "%ERRORLEVEL%" NEQ "0" (
     PAUSE
     GOTO :exit
 )
-java -jar "%~dp0..\dataloader-%DATALOADER_VERSION%-uber.jar" %* run.mode=batch
+
+
+java -cp "%~dp0../*;%~dp0*" com.salesforce.dataloader.process.DataLoaderRunner %* run.mode=batch
 
 :exit
 ENDLOCAL

--- a/release/win/dataloader.bat
+++ b/release/win/dataloader.bat
@@ -7,7 +7,7 @@ IF "%ERRORLEVEL%" NEQ "0" (
     PAUSE
     GOTO :exit
 )
-java -jar "%~dp0dataloader-%DATALOADER_VERSION%-uber.jar" %*
+java -cp "%~dp0*" com.salesforce.dataloader.process.DataLoaderRunner %*
 
 :exit
 ENDLOCAL


### PR DESCRIPTION
…ataLoader

Fix for the issue of Unable to connect to DB using ojdbc11.jar from DataLoader, Fix is to set classpath with the directory where dataloader.bat, process.bat, and encrypt.bat are installed . Similar settings are used for the shell script (dataloader) in Mac for consistency.