### PR TITLE
part of fix for W-11906907 - Unable to connect to DB using ojdbc11.ja…

### DIFF
--- a/release/win/bin/encrypt.bat
+++ b/release/win/bin/encrypt.bat
@@ -6,7 +6,7 @@ IF "%ERRORLEVEL%" NEQ "0" (
     PAUSE
     GOTO :exit
 )
-java -cp "%~dp0..\*" com.salesforce.dataloader.security.EncryptionUtil %*
+java -cp "%~dp0../*" com.salesforce.dataloader.security.EncryptionUtil %*
 
 :exit
 ENDLOCAL


### PR DESCRIPTION
…r from DataLoader

consistent use of forward slash in setting classpath in bat scripts.