### PR TITLE
Fix for W-11963182 and minor version upgrades for dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.force</groupId>
   <artifactId>dataloader</artifactId>
   <packaging>jar</packaging>
-  <version>56.0.4</version>
+  <version>56.0.5</version>
   <name>Data Loader</name>
   <url>https://github.com/forcedotcom/dataloader</url>
   <organization>
@@ -13,7 +13,7 @@
   </organization>
 
   <properties>
-    <force.wsc.version>56.0.0</force.wsc.version>
+    <force.wsc.version>56.1.0</force.wsc.version>
     <force.partner.api.version>${force.wsc.version}</force.partner.api.version>
     <build.year>2022</build.year>
     <java.compile.version>11</java.compile.version>
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.9.1</version>
+      <version>2.10</version>
     </dependency>
 <!-- https://mvnrepository.com/artifact/com.force.api/force-wsc -->
     <dependency>
@@ -156,7 +156,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.8.0</version>
+      <version>4.8.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -532,13 +532,11 @@ public class Controller {
         // TODO for unprocessed records
         // config.setValue(Config.OUTPUT_UNPROCESSED_RECORDS, unprocessedRecordsPath);
     }
-    
-    private final Date currentTime = new Date();
-    private final SimpleDateFormat format = new SimpleDateFormat("MMddyyhhmmssSSS"); //$NON-NLS-1$
-    private final String formattedCurrentTimestamp = format.format(currentTime);
-    
+        
     public String getFormattedCurrentTimestamp() {
-        return formattedCurrentTimestamp;
+        Date currentTime = new Date();
+        SimpleDateFormat format = new SimpleDateFormat("MMddyyhhmmssSSS"); //$NON-NLS-1$
+        return format.format(currentTime);
     }
 
     private void validateFile(String filePath) throws IOException {


### PR DESCRIPTION
Fix for W-11963182 - success and error files from the previous operation are overwritten when performing multiple operations in the interactive (GUI) mode.

Minor version upgrades for dependencies:
- gson - 2.9.1 to 2.10
- force.wsc - 56.0.0 to 56.1.0
- mockito-core - 4.8.0 to 4.8.1