### PR TITLE
fix an incorrect comment about UTF8 BOM

### DIFF
--- a/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileReader.java
@@ -155,7 +155,7 @@ public class CSVFileReader implements DataReader {
 
         FileInputStream stream = null;
 
-        // UTF-8 BOM is 0xEE 0xBB OxBf
+        // UTF-8 BOM is 0xEF 0xBB OxBF. Source: https://learn.microsoft.com/en-us/globalization/encoding/byte-order-mark
         // or 239 187 191
 
         try {


### PR DESCRIPTION
The comment incorrectly stated that UTF-8 BOM is 0xEE 0xBB 0xBf. The correct hex value of UTF-8 BOM is 0xEF 0xBB 0xBF.