### PR TITLE
generalize support for BOM (Byte Order Mark) in csv

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/BulkV2Connection.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/BulkV2Connection.java
@@ -144,6 +144,7 @@ import java.io.Serializable;
 import java.io.FileOutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -196,7 +197,7 @@ public class BulkV2Connection  {
     public static final String ZIP_XML_CONTENT_TYPE = "zip/xml";
     public static final String ZIP_CSV_CONTENT_TYPE = "zip/csv";
     public static final String ZIP_JSON_CONTENT_TYPE = "zip/json";
-    public static final String UTF_8 = "UTF-8";
+    public static final String UTF_8 = StandardCharsets.UTF_8.name();
     public static final String INGEST_RESULTS_SUCCESSFUL = "successfulResults";
     public static final String INGEST_RESULTS_UNSUCCESSFUL = "failedResults";
     public static final String INGEST_RECORDS_UNPROCESSED = "unprocessedrecords";

--- a/src/main/java/com/salesforce/dataloader/client/HttpClientTransport.java
+++ b/src/main/java/com/salesforce/dataloader/client/HttpClientTransport.java
@@ -27,6 +27,7 @@ package com.salesforce.dataloader.client;
 
 import java.io.*;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -103,7 +104,7 @@ public class HttpClientTransport implements HttpTransportInterface {
         HashMap<String, String> header = new HashMap<String, String>();
 
         header.put("SOAPAction", "\"" + soapAction + "\"");
-        header.put("Content-Type", "text/xml; charset=UTF-8");
+        header.put("Content-Type", "text/xml; charset=" + StandardCharsets.UTF_8);
         header.put("Accept", "text/xml");
 
         return connect(url, header);

--- a/src/main/java/com/salesforce/dataloader/client/HttpClientTransport.java
+++ b/src/main/java/com/salesforce/dataloader/client/HttpClientTransport.java
@@ -104,7 +104,7 @@ public class HttpClientTransport implements HttpTransportInterface {
         HashMap<String, String> header = new HashMap<String, String>();
 
         header.put("SOAPAction", "\"" + soapAction + "\"");
-        header.put("Content-Type", "text/xml; charset=" + StandardCharsets.UTF_8);
+        header.put("Content-Type", "text/xml; charset=" + StandardCharsets.UTF_8.name());
         header.put("Accept", "text/xml");
 
         return connect(url, header);

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -47,6 +47,7 @@ import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.security.GeneralSecurityException;
@@ -378,7 +379,7 @@ public class Config {
     /**
      * communications with bulk api always use UTF8
      */
-    public static final String BULK_API_ENCODING = "UTF-8";
+    public static final String BULK_API_ENCODING = StandardCharsets.UTF_8.name();
     public static final String CONFIG_FILE = "config.properties"; //$NON-NLS-1$
     
     /*
@@ -1361,8 +1362,6 @@ public class Config {
         return getEnum(OperationInfo.class, OPERATION);
     }
 
-    private static final Charset UTF8 = Charset.forName("UTF-8");
-
     public String getCsvEncoding(boolean isWrite) {
         // charset is for CSV read unless isWrite is set to true
         String configProperty = READ_UTF8;
@@ -1376,7 +1375,7 @@ public class Config {
             logger.debug("Using UTF8 charset because '" 
                     +  configProperty
                     +"' is set to true");
-            return UTF8.name();
+            return StandardCharsets.UTF_8.name();
         }        
         String charset = getDefaultCharsetForCsvReadWrite();
         logger.debug("Using charset " + charset);

--- a/src/main/java/com/salesforce/dataloader/ui/Labels.java
+++ b/src/main/java/com/salesforce/dataloader/ui/Labels.java
@@ -26,6 +26,7 @@
 package com.salesforce.dataloader.ui;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
@@ -46,7 +47,7 @@ public class Labels {
     public static String getString(String key) {
         try {
             //Hmm.. need to test other languages on this at some point
-            return new String(RESOURCE_BUNDLE.getString(key).getBytes("ISO-8859-1"), "UTF-8");//$NON-NLS-2$ //$NON-NLS-1$
+            return new String(RESOURCE_BUNDLE.getString(key).getBytes("ISO-8859-1"), StandardCharsets.UTF_8.name());//$NON-NLS-2$ //$NON-NLS-1$
         } catch (MissingResourceException e) {
             return '!' + key + '!';
         } catch (UnsupportedEncodingException e) {

--- a/src/main/java/com/salesforce/dataloader/ui/OAuthSecretFlow.java
+++ b/src/main/java/com/salesforce/dataloader/ui/OAuthSecretFlow.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -72,7 +73,7 @@ public class OAuthSecretFlow extends OAuthFlow {
         return config.getString(Config.OAUTH_SERVER) +
                 "/services/oauth2/authorize?response_type=code&display=popup&client_id=" +
                 config.getString(Config.OAUTH_CLIENTID) + "&redirect_uri=" +
-                URLEncoder.encode(config.getString(Config.OAUTH_REDIRECTURI), "UTF-8");
+                URLEncoder.encode(config.getString(Config.OAUTH_REDIRECTURI), StandardCharsets.UTF_8.name());
     }
 
     public static class OAuthSecretBrowserListener extends OAuthBrowserListener {

--- a/src/main/java/com/salesforce/dataloader/ui/OAuthTokenFlow.java
+++ b/src/main/java/com/salesforce/dataloader/ui/OAuthTokenFlow.java
@@ -38,6 +38,7 @@ import org.eclipse.swt.widgets.Shell;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -64,7 +65,7 @@ public class OAuthTokenFlow extends OAuthFlow {
         return config.getString(Config.OAUTH_SERVER) +
                 "/services/oauth2/authorize?response_type=token&display=popup&client_id=" +
                 config.getString(Config.OAUTH_CLIENTID) + "&redirect_uri=" +
-                URLEncoder.encode(config.getString(Config.OAUTH_REDIRECTURI), "UTF-8");
+                URLEncoder.encode(config.getString(Config.OAUTH_REDIRECTURI), StandardCharsets.UTF_8.name());
     }
 
     public static class OAuthTokenBrowserLister extends OAuthBrowserListener {

--- a/src/main/java/com/salesforce/dataloader/util/AppUtil.java
+++ b/src/main/java/com/salesforce/dataloader/util/AppUtil.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.CodeSource;
@@ -94,7 +95,7 @@ public class AppUtil {
           String path = aClass.getResource(aClass.getSimpleName() + ".class").getPath();
           String jarFilePath = path.substring(path.indexOf(":") + 1, path.indexOf("!"));
           try {
-              jarFilePath = URLDecoder.decode(jarFilePath, "UTF-8");
+              jarFilePath = URLDecoder.decode(jarFilePath, StandardCharsets.UTF_8.name());
           } catch (UnsupportedEncodingException e) {
               // fail silently;
           }

--- a/src/main/java/com/salesforce/dataloader/util/OAuthBrowserLoginRunner.java
+++ b/src/main/java/com/salesforce/dataloader/util/OAuthBrowserLoginRunner.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -86,7 +87,7 @@ public class OAuthBrowserLoginRunner {
             for (int length; (length = in.read(buffer)) != -1; ) {
                 result.write(buffer, 0, length);
             }
-            String response = result.toString("UTF-8");
+            String response = result.toString(StandardCharsets.UTF_8.name());
             logger.error(response);
             throw new OAuthBrowserLoginRunnerException(response);
         }
@@ -125,7 +126,7 @@ public class OAuthBrowserLoginRunner {
             result.write(buffer, 0, length);
         }
         
-        String response = result.toString("UTF-8");
+        String response = result.toString(StandardCharsets.UTF_8.name());
         if (!client.isSuccessful()) {
             // did not succeed in skipping the page with pre-filled user code, show it
             logger.error(response);
@@ -353,7 +354,7 @@ public class OAuthBrowserLoginRunner {
    public static void processSuccessfulLogin(InputStream httpResponseInputStream, Config config) throws IOException {
 
        StringBuilder builder = new StringBuilder();
-       BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(httpResponseInputStream, "UTF-8"));
+       BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(httpResponseInputStream, StandardCharsets.UTF_8.name()));
        for (int c = bufferedReader.read(); c != -1; c = bufferedReader.read()) {
            builder.append((char) c);
        }

--- a/src/test/java/com/salesforce/dataloader/dao/CsvTest.java
+++ b/src/test/java/com/salesforce/dataloader/dao/CsvTest.java
@@ -26,6 +26,7 @@
 package com.salesforce.dataloader.dao;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -66,10 +67,18 @@ public class CsvTest extends TestBase {
         row2.put("COL2", "row2col2");
         row2.put("COL3", "row2col3");
     }
-
     @Test
     public void testCSVReadBasic() throws Exception {
-        File f = new File(getTestDataDir(), "csvtext.csv");
+        testCSVReadBasic("csvtext.csv");
+    }
+    
+    @Test
+    public void testCSVReadUTF8BOMBasic() throws Exception{
+        testCSVReadBasic("csvtext_BOM_UTF8.csv");
+    }
+    
+    private void testCSVReadBasic(String csvFile) throws Exception {
+        File f = new File(getTestDataDir(), csvFile);
         assertTrue(f.exists());
         assertTrue(f.canRead());
 

--- a/src/test/java/com/salesforce/dataloader/process/CsvEncodingProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvEncodingProcessTest.java
@@ -31,6 +31,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -62,7 +63,6 @@ import static org.junit.Assert.assertEquals;
 @RunWith(Parameterized.class)
 public class CsvEncodingProcessTest extends ProcessTestBase {
 
-    private static final String UTF8 = "UTF-8";
     private static final String JAPANESE = "Shift_JIS";
     private static final String FILE_ENCODING_SYSTEM_PROPERTY = "file.encoding";
     private final Map<String, String> config;
@@ -78,8 +78,8 @@ public class CsvEncodingProcessTest extends ProcessTestBase {
     @Parameterized.Parameters(name = "{0}, {1}")
     public static Collection<Object[]> getParameters() {
         return Arrays.asList(
-                TestVariant.builder().withSettings(TestSetting.BULK_API_ENABLED, TestSetting.WRITE_UTF8_ENABLED, TestSetting.READ_UTF8_ENABLED).withFileEncoding(UTF8).get(),
-                TestVariant.builder().withSettings(TestSetting.BULK_API_ENABLED, TestSetting.WRITE_UTF8_DISABLED, TestSetting.READ_UTF8_DISABLED).withFileEncoding(UTF8).get(),
+                TestVariant.builder().withSettings(TestSetting.BULK_API_ENABLED, TestSetting.WRITE_UTF8_ENABLED, TestSetting.READ_UTF8_ENABLED).withFileEncoding(StandardCharsets.UTF_8.name()).get(),
+                TestVariant.builder().withSettings(TestSetting.BULK_API_ENABLED, TestSetting.WRITE_UTF8_DISABLED, TestSetting.READ_UTF8_DISABLED).withFileEncoding(StandardCharsets.UTF_8.name()).get(),
                 TestVariant.builder().withSettings(TestSetting.BULK_API_ENABLED, TestSetting.WRITE_UTF8_ENABLED, TestSetting.READ_UTF8_ENABLED).withFileEncoding(JAPANESE).get()
 
                 //this one is suspect... how can we support the below condition (UTF8 language sent using disabled UTF8... this should blow up!)
@@ -122,7 +122,7 @@ public class CsvEncodingProcessTest extends ProcessTestBase {
     private void validateExtraction(final String name, final Map<String, String> testConfig) throws IOException {
         FileInputStream fis = new FileInputStream(new File(testConfig.get(Config.DAO_NAME)));
         try {
-            CSVReader rdr = new CSVReader(fis, "UTF-8");
+            CSVReader rdr = new CSVReader(fis, StandardCharsets.UTF_8.name());
             int nameidx = rdr.nextRecord().indexOf("NAME");
             assertEquals(name, rdr.nextRecord().get(nameidx));
         } finally {

--- a/src/test/java/com/salesforce/dataloader/process/CsvExtractAggregateQueryProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvExtractAggregateQueryProcessTest.java
@@ -28,6 +28,7 @@ package com.salesforce.dataloader.process;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
@@ -79,7 +80,7 @@ public class CsvExtractAggregateQueryProcessTest extends ProcessTestBase {
     private void validateAccountNameInOutputFile(final String accountName) throws IOException {
         FileInputStream fis = new FileInputStream(new File(testConfig.get(Config.DAO_NAME)));
         try {
-            CSVReader rdr = new CSVReader(fis, "UTF-8");
+            CSVReader rdr = new CSVReader(fis, StandardCharsets.UTF_8.name());
             int acctNameIndex = rdr.nextRecord().indexOf("ACCOUNT.NAME");
             assertEquals(accountName, rdr.nextRecord().get(acctNameIndex));
         } finally {

--- a/src/test/resources/testfiles/data/csvtext_BOM_utf8.csv
+++ b/src/test/resources/testfiles/data/csvtext_BOM_utf8.csv
@@ -1,0 +1,3 @@
+﻿"column1","column2","column3"
+row1-1,row1-2,row1-3
+row2-1,row2-2,row2-3


### PR DESCRIPTION
Use BOMInputStream if character encoding is UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, or UTF-32LE.

Add test for handling CSV file with BOM and UTF-8 charset and header fields in double quotes.

Use constant for UTF-8 string usage in the code.