### PR TITLE
Fix for W-12442037 - Auto-match fields to columns action on Windows does not refresh display

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/DataSelectionPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/DataSelectionPage.java
@@ -162,9 +162,8 @@ public class DataSelectionPage extends LoadPage {
             }
         }
         lv.setInput(inputDescribes);
-        lv.refresh();
         lv.getControl().getParent().pack();
-
+        lv.refresh();
     }
 
     private boolean checkEntityStatus() {

--- a/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
@@ -73,7 +73,7 @@ public class MappingDialog extends Dialog {
     public static final int MAPPING_SFORCE = 1;
 
     //the current list of fields
-    private Field[] fields;
+    private Field[] sforceFields;
 
     //all the fields
     private Field[] allFields;
@@ -90,8 +90,8 @@ public class MappingDialog extends Dialog {
         this.sforceFieldInfo = sforceFieldInfo;
     }
 
-    public void setFields(Field[] newFields) {
-        this.fields = newFields;
+    public void setSforceFields(Field[] newFields) {
+        this.sforceFields = newFields;
     }
 
     public void setMapper(LoadMapper mapper) {
@@ -373,13 +373,10 @@ public class MappingDialog extends Dialog {
                         String oldSforce = elem.getValue();
                         if (oldSforce != null && oldSforce.length() > 0) {
                             //clear the sforce
-                            replenishField(oldSforce);
-
+                            replenishSforceField(oldSforce);
                             elem.setValue("");
                             mapper.removeMapping(elem.getKey());
-
                             packMappingColumns();
-                            mappingTblViewer.refresh();
                         }
                     }
                 }
@@ -502,7 +499,7 @@ public class MappingDialog extends Dialog {
 
     private void autoMatchFields() {
 
-        LinkedList<Field> fieldList = new LinkedList<Field>(Arrays.asList(fields));
+        LinkedList<Field> fieldList = new LinkedList<Field>(Arrays.asList(sforceFields));
         //first match on name, then label
         ListIterator<Field> iterator = fieldList.listIterator();
         Field field;
@@ -534,16 +531,14 @@ public class MappingDialog extends Dialog {
             }
         }
 
-        fields = fieldList.toArray(new Field[fieldList.size()]);
+        this.sforceFields = fieldList.toArray(new Field[fieldList.size()]);
 
-        sforceTblViewer.setInput(fields);
-        sforceTblViewer.refresh();
-        mappingTblViewer.refresh();
-
+        sforceTblViewer.setInput(this.sforceFields);
+        updateMapping();
         //pack the columns
         packMappingColumns();
         packSforceColumns();
-
+        
     }
 
     public void packMappingColumns() {
@@ -551,8 +546,9 @@ public class MappingDialog extends Dialog {
         //  Pack the columns
         for (int i = 0, n = mappingTable.getColumnCount(); i < n; i++) {
             mappingTable.getColumn(i).pack();
-
         }
+        mappingTblViewer.refresh();
+        mappingTable.redraw();
     }
 
     private void packSforceColumns() {
@@ -561,26 +557,24 @@ public class MappingDialog extends Dialog {
         for (int i = 0, n = sforceTable.getColumnCount(); i < n; i++) {
             sforceTable.getColumn(i).pack();
         }
+        sforceTblViewer.refresh();
+        sforceTable.redraw();
     }
 
-    public void replenishField(String fieldName) {
+    public void replenishSforceField(String fieldName) {
         //find the Field object to add to the current list.
         Field field;
         for (int i = 0; i < allFields.length; i++) {
             field = allFields[i];
             if (field.getName().equals(fieldName)) {
-                ArrayList<Field> fieldArray = new ArrayList<Field>(Arrays.asList(fields));
+                ArrayList<Field> fieldArray = new ArrayList<Field>(Arrays.asList(this.sforceFields));
 
                 //else add the field
                 fieldArray.add(field);
-                fields = fieldArray.toArray(new Field[fieldArray.size()]);
+                this.sforceFields = fieldArray.toArray(new Field[fieldArray.size()]);
 
-                //then refresh
-                sforceTblViewer.setInput(fields);
-                sforceTblViewer.refresh();
-
+                sforceTblViewer.setInput(this.sforceFields);
                 packSforceColumns();
-
                 return;
             }
         }
@@ -645,11 +639,11 @@ public class MappingDialog extends Dialog {
             }
         }
 
-        fields = mappableFieldList.toArray(new Field[mappableFieldList.size()]);
+        this.sforceFields = mappableFieldList.toArray(new Field[mappableFieldList.size()]);
         allFields = allFieldList.toArray(new Field[allFieldList.size()]);
 
         // Set the table viewer's input
-        sforceTblViewer.setInput(fields);
+        sforceTblViewer.setInput(this.sforceFields);
     }
 
     /**
@@ -657,12 +651,12 @@ public class MappingDialog extends Dialog {
      */
     private void clearMapping() {
         mapper.clearMap();
-        // restore the fields that were mapped before
+        // restore the fields in sforceTblViewer that were mapped before
         for(String fieldName : mappedFields) {
-            replenishField(fieldName);
+            replenishSforceField(fieldName);
         }
         mappedFields.clear();
-        mappingTblViewer.refresh();
+        packMappingColumns();
     }
 
     /**

--- a/src/main/java/com/salesforce/dataloader/ui/MappingPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/MappingPage.java
@@ -170,6 +170,7 @@ public class MappingPage extends LoadPage {
                 mappingTable.getColumn(i).pack();
             }
         }
+        refreshMapping();
     }
 
     /**
@@ -191,6 +192,7 @@ public class MappingPage extends LoadPage {
     public void refreshMapping() {
         if (mappingTblViewer != null) {
             mappingTblViewer.refresh();
+            this.getShell().redraw();
         }
     }
 

--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionDataSelectionPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionDataSelectionPage.java
@@ -33,7 +33,6 @@ import java.util.Map.Entry;
 import org.eclipse.jface.viewers.*;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.events.*;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -47,7 +46,6 @@ import com.salesforce.dataloader.ui.EntitySelectionListViewerUtil;
 import com.salesforce.dataloader.ui.Labels;
 import com.salesforce.dataloader.ui.UIUtils;
 import com.sforce.soap.partner.DescribeGlobalSObjectResult;
-import com.sforce.ws.ConnectionException;
 
 /**
  * Describe your class here.
@@ -61,7 +59,6 @@ public class ExtractionDataSelectionPage extends ExtractionPage {
     private ListViewer lv;
     private Text fileText;
     public Composite comp;
-    private boolean success;
 
     public ExtractionDataSelectionPage(Controller controller) {
         super("ExtractionDataSelectionPage", controller); //$NON-NLS-1$ //$NON-NLS-2$
@@ -166,8 +163,8 @@ public class ExtractionDataSelectionPage extends ExtractionPage {
             }
         }
         lv.setInput(inputDescribes);
-        lv.refresh();
         lv.getControl().getParent().pack();
+        lv.refresh();
     }
 
     private boolean checkEntityStatus() {

--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionSOQLPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionSOQLPage.java
@@ -182,15 +182,15 @@ public class ExtractionSOQLPage extends ExtractionPage {
         
         search.addSelectionListener(new SelectionAdapter() {
             public void widgetDefaultSelected(SelectionEvent e) {
-                fieldViewer.refresh();
                 preserveFieldViewerCheckedItems();
+                fieldViewer.refresh();
             }
         });
         
         search.addListener(SWT.KeyUp, new Listener() {
             public void handleEvent(Event e) {
-                fieldViewer.refresh();
                 preserveFieldViewerCheckedItems();
+                fieldViewer.refresh();
             }
         });
 

--- a/src/main/java/com/salesforce/dataloader/ui/mapping/MappingDragListener.java
+++ b/src/main/java/com/salesforce/dataloader/ui/mapping/MappingDragListener.java
@@ -69,7 +69,7 @@ public class MappingDragListener extends DragSourceAdapter {
                 }
 
                 Field[] newFields = fieldList.toArray(new Field[fieldList.size()]);
-                dlg.setFields(newFields);
+                dlg.setSforceFields(newFields);
 
                 viewer.setInput(newFields);
                 viewer.refresh();

--- a/src/main/java/com/salesforce/dataloader/ui/mapping/MappingDropAdapter.java
+++ b/src/main/java/com/salesforce/dataloader/ui/mapping/MappingDropAdapter.java
@@ -53,25 +53,18 @@ public class MappingDropAdapter extends ViewerDropAdapter {
 
     @Override
     public boolean performDrop(Object arg0) {
-
-        TableViewer viewer = (TableViewer)getViewer();
-
         @SuppressWarnings("unchecked")
         Map.Entry<String, String> entry = (Entry<String, String>)getCurrentTarget();
 
         //replenish the old
         String oldSforce = entry.getValue();
         if (oldSforce != null && oldSforce.length() > 0) {
-            dlg.replenishField(oldSforce);
+            dlg.replenishSforceField(oldSforce);
         }
 
         entry.setValue((String)arg0);
         dlg.getMapper().putMapping(entry.getKey(), entry.getValue());
-
-        viewer.refresh();
         dlg.packMappingColumns();
-
-
         return true;
     }
 

--- a/src/main/java/com/salesforce/dataloader/ui/mapping/SforceDragListener.java
+++ b/src/main/java/com/salesforce/dataloader/ui/mapping/SforceDragListener.java
@@ -68,8 +68,8 @@ public class SforceDragListener extends DragSourceAdapter {
                     dlg.getMapper().removeMapping(eventElem.getKey());
                 }
 
-                viewer.refresh();
                 dlg.packMappingColumns();
+                viewer.refresh();
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/salesforce/dataloader/ui/mapping/SforceDropAdapter.java
+++ b/src/main/java/com/salesforce/dataloader/ui/mapping/SforceDropAdapter.java
@@ -50,15 +50,8 @@ public class SforceDropAdapter extends ViewerDropAdapter {
 
     @Override
     public boolean performDrop(Object arg0) {
-
-        TableViewer viewer = (TableViewer)getViewer();
-
-        dlg.replenishField((String) arg0);
-
-
-        viewer.refresh();
+        dlg.replenishSforceField((String) arg0);
         dlg.packMappingColumns();
-
         return true;
     }
 


### PR DESCRIPTION
Issue: Auto-match fields to columns action on Windows does not refresh display to show matched field names in the Field Mappings dialog

Root-cause: SWT versions used in Data Loader v55 and later do not correctly refresh the display on Windows.

Fix approach:
- Pack (resize) table columns before refreshing TableViewer.
- Redraw the Table widget in a TableViewer by invoking Table.redraw() method.