### PR TITLE
fix to preserve input fields ordering while mapping them

### DIFF
--- a/src/main/java/com/salesforce/dataloader/mapping/LoadMapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/LoadMapper.java
@@ -65,11 +65,12 @@ public class LoadMapper extends Mapper {
     }
 
     public Map<String, String> getMappingWithUnmappedColumns(boolean includeUnmapped) {
-        final Map<String, String> result = new HashMap<String, String>(getMap());
-        if (includeUnmapped) {
-            for (String daoColumn : getDaoColumns()) {
-                if (getMapping(daoColumn, true) == null) result.put(daoColumn, null);
-            }
+        final Map<String, String> result = new HashMap<String, String>();
+        for (String daoColumn : getDaoColumns()) {
+            String mapping = getMapping(daoColumn);
+            if (includeUnmapped || mapping != null) {
+                result.put(daoColumn, mapping);
+            }            
         }
         return result;
     }

--- a/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
@@ -344,7 +344,6 @@ public class MappingDialog extends Dialog {
         mappingTblViewer = new TableViewer(shell, SWT.FULL_SELECTION);
         mappingTblViewer.setContentProvider(new MappingContentProvider());
         mappingTblViewer.setLabelProvider(new MappingLabelProvider());
-        mappingTblViewer.setSorter(new MappingViewerSorter());
 
         //add drop support
         int ops = DND.DROP_MOVE;


### PR DESCRIPTION
The fix is to preserve ordering of input fields while mapping them to selected Salesforce entity's fields during a load (insert, update, upsert, delete) operation.