### PR TITLE
Fix for issue #603

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
 	<plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-jar-plugin</artifactId>
-   <version>3.2.2</version>
+      <version>3.2.2</version>
 	</plugin>
 <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-site-plugin -->
 	<plugin>
@@ -430,6 +430,9 @@
                 <manifest>
                   <mainClass>com.salesforce.dataloader.process.DataLoaderRunner</mainClass>
                 </manifest>
+                <manifestEntries>
+                    <Multi-Release>true</Multi-Release>
+                </manifestEntries>
               </archive>
               <descriptors>
                 <descriptor>src/main/assembly/uber.xml</descriptor>


### PR DESCRIPTION
Specify Multi-release attribute to true in assembly plugin to avoid the warning:

WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.

The solution is based on answer at https://stackoverflow.com/questions/60741008/maven-assembly-plugin-multi-releasetrue