### PR TITLE
Fix W-12572271 - "Finish" button of Data Loader upsert is grayed out …

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/FinishPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/FinishPage.java
@@ -150,7 +150,7 @@ public class FinishPage extends LoadPage {
 
     public void setPageComplete() {
         String outputDir = getOutputDir();
-        if (outputDir == null || outputDir.isBlank()) {
+        if (outputDir == null || outputDir.isBlank() || !this.isCurrentPage()) {
             setPageComplete(false);
         } else {
             setPageComplete(true);

--- a/src/main/java/com/salesforce/dataloader/ui/ForeignKeyExternalIdPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/ForeignKeyExternalIdPage.java
@@ -54,6 +54,8 @@ public class ForeignKeyExternalIdPage extends LoadPage {
 
     public ForeignKeyExternalIdPage(Controller controller) {
         super("ForeignKeyExternalIdPage", controller); //$NON-NLS-1$
+        // Mark this page as completed as the selected sObject may not have any foreign key
+        setPageComplete();
     }
 
     @Override
@@ -98,7 +100,6 @@ public class ForeignKeyExternalIdPage extends LoadPage {
         }
         scrollComp.setMinSize(comp.computeSize(SWT.DEFAULT, SWT.DEFAULT));
         containerComp.layout();
-        setPageComplete();
     }
 
     /**


### PR DESCRIPTION
…at first time after login

Finish button is enabled when all of Wizard steps are marked as "Completed". If an sObject does not have a modifiable lookup relationship to another sObject, Upsert Wizards skip "Step 2b", which means that the page rendering Step 2b is not marked as "Completed" and consequently Finish button remains grayed out in the final step. The fix is to mark the "Step 2b" page as "Completed" in its constructor instead of when it is rendered.