### PR TITLE
include linux SWT jars in mac zip

### DIFF
--- a/dlbuilder.sh
+++ b/dlbuilder.sh
@@ -62,9 +62,6 @@ run_mvn() {
     echo "packaging dataloader_win_<version>.zip"
     mvn package -DskipTests -Duberjar.skip -Pzip,!mac_x86_64,win32_x86_64,!linux_x86_64
     cp target/win/dataloader_win_v*.zip .
-    echo "packaging dataloader_linux_<version>.zip"
-    mvn package -DskipTests -Duberjar.skip -Pzip,!mac_x86_64,!win32_x86_64,linux_x86_64
-    cp target/linux/dataloader_linux_v*.zip .
   fi
 
   if [ $1 = true ]; then

--- a/extractSWTJar.xml
+++ b/extractSWTJar.xml
@@ -5,7 +5,7 @@
 		<fileset dir="${basedir}/local-proj-repo/local/swt/" includes="swt*/*/*.jar"/>
 	  </copy>
 	  <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
-	  <foreach param="fileName" target="unzip">
+	  <foreach param="fileName" target="flatten">
 	    <path>
 	    <dirset dir="${basedir}/target/">
 	      <include name="swt*" />
@@ -13,7 +13,7 @@
 	    </path>
 	  </foreach>
 	</target>
-	<target name="unzip">
+	<target name="flatten">
 	  <move todir="${fileName}" flatten="true">
 		<fileset dir="${fileName}/">
 		  <include name="**/*.jar"/>

--- a/pom.xml
+++ b/pom.xml
@@ -543,10 +543,6 @@
                             <copy file="${basedir}/release/install/install.command"
                                   todir="${basedir}/target/${OSType}/" />
                             <echo>copying dataloader_console to OS-specific folder for the target OS: ${OSType}</echo>
-<!--
-                            <copy file="${basedir}/release/mac/dataloader_console"
-                                  todir="${basedir}/target/${OSType}/" />
--->
                             <fixcrlf srcdir="${basedir}/target/${OSType}/"
                                         includes="**/*.command" eol="lf" eof="remove"/>
                             <fixcrlf srcdir="${basedir}/target/${OSType}/"
@@ -559,10 +555,18 @@
                     <echo>copying uber jar to OS-specific folder for the target OS: ${OSType}</echo>
                     <copy file="${basedir}/target/dataloader-${project.version}-uber.jar" 
                        todir="${basedir}/target/${OSType}"/>
-                       
+
                     <copy todir="${basedir}/target/${OSType}" >
                       <fileset dir="${basedir}/target/" includes="swt${OSType}*/*"/>
                     </copy> 
+                    <if>
+                        <equals arg1="${OSType}" arg2="mac"/>
+                        <then>
+                            <copy todir="${basedir}/target/${OSType}" >
+                              <fileset dir="${basedir}/target/" includes="swtlinux*/*"/>
+                            </copy> 
+                        </then>
+                    </if>
                     <echo>zip OS-specific folder</echo>
                     <zip update="true" destfile="${basedir}/target/${OSType}/dataloader_${OSType}_v${version}.zip" >
                       <zipfileset dirmode="755" filemode="755" 

--- a/release/util/util.bat
+++ b/release/util/util.bat
@@ -61,17 +61,17 @@ EXIT /b %ERRORLEVEL%
 
 :NoJavaErrorExit
     echo Did not find java command.
-    echo Java JRE %MIN_JAVA_VERSION% or later is not installed or DATALOADER_JAVA_HOME environment variable is not set.
     echo.
-    GOTO :CommonJavaErrorExit
+    GOTO :exitWithJavaDownloadMessage
 
 :JavaVersionErrorExit
     echo Found Java JRE version %JAVA_FULL_VERSION% whereas Data Loader requires Java JRE %MIN_JAVA_VERSION% or later.
-    GOTO :CommonJavaErrorExit
+    GOTO :exitWithJavaDownloadMessage
 
-:CommonJavaErrorExit
-    echo For example, download and install Zulu OpenJDK %MIN_JAVA_VERSION% or later JRE for Windows from here:
-    echo    https://www.azul.com/downloads/zulu/zulu-windows/
+:exitWithJavaDownloadMessage
+    echo Java JRE %MIN_JAVA_VERSION% or later is not installed or DATALOADER_JAVA_HOME environment variable is not set.
+    echo For example, download and install Zulu JRE %MIN_JAVA_VERSION% or later from here:
+    echo     https://www.azul.com/downloads/
     echo.
     echo After the installation, set DATALOADER_JAVA_HOME environment variable to the value
     echo ^<full path to the JRE installation folder^>

--- a/release/util/util.sh
+++ b/release/util/util.sh
@@ -39,6 +39,8 @@ checkJavaVersion() {
     JAVA_VERSION=$(java -version 2>&1 | grep -i version | cut -d'"' -f 2 | cut -d'.' -f 1)
     if [ -z "${JAVA_VERSION}" ]
     then
+        echo "Did not find java command."
+        echo ""
         exitWithJavaDownloadMessage
     fi
     if [ ${JAVA_VERSION} \< ${MIN_JAVA_VERSION} ]
@@ -49,6 +51,8 @@ checkJavaVersion() {
 }
 
 exitWithJavaDownloadMessage() {
-        echo "Java JRE ${MIN_JAVA_VERSION} or later is not installed. For example, download and install Zulu OpenJDK ${MIN_JAVA_VERSION} or later JRE for macOS from https://www.azul.com/downloads/zulu/zulu-mac/"
+        echo "Java JRE ${MIN_JAVA_VERSION} or later is not installed or DATALOADER_JAVA_HOME environment variable is not set."
+        echo "For example, download and install Zulu JRE ${MIN_JAVA_VERSION} or later from here:"
+        echo "    https://www.azul.com/downloads/"
         exit -1
 }

--- a/src/main/assembly/uber.xml
+++ b/src/main/assembly/uber.xml
@@ -16,9 +16,4 @@
       </excludes>
     </dependencySet>
   </dependencySets>
-  <fileSets>
-    <fileSet>
-      <directory>${project.build.outputDirectory}</directory>
-    </fileSet>
-  </fileSets>
 </assembly>


### PR DESCRIPTION
Include linux SWT jars in Mac zip so that linux users don't have to build the repo to install dataloader.

Make sure that java incorrect version and no java found error messages are identical on linux, mac, and windows.

Avoid including target/classes folder in uber jar.

Skip building linux zip as Mac zip can be used to install on linux.