### PR TITLE
minor cleanup and version updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,8 @@
     <force.wsc.version>57.0.0</force.wsc.version>
     <force.partner.api.version>${force.wsc.version}</force.partner.api.version>
     <build.year>2022</build.year>
-    <java.compile.version>11</java.compile.version>
+    <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <config.additional.properties></config.additional.properties>
     <swt.version>4.27</swt.version>
 
     <!-- test properties -->
@@ -115,7 +114,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>5.3.23</version>
+      <version>5.3.26</version>
     </dependency>
 <!-- https://mvnrepository.com/artifact/org.eclipse.platform/org.eclipse.jface --> 
     <dependency>
@@ -149,7 +148,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
-      <version>5.3.23</version>
+      <version>5.3.26</version>
       <scope>test</scope>
     </dependency>
 <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
@@ -286,8 +285,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.10.1</version>
         <configuration>
-          <source>${java.compile.version}</source>
-          <target>${java.compile.version}</target>
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
           <compilerArgs>
             <!-- <arg>-verbose</arg> -->
@@ -299,13 +296,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M9</version>
+        <version>3.0.0</version>
           <dependencies>
 <!-- https://mvnrepository.com/artifact/org.apache.maven.surefire/surefire-junit4 -->
               <dependency>
                   <groupId>org.apache.maven.surefire</groupId>
                   <artifactId>surefire-junit4</artifactId>
-                  <version>3.0.0-M9</version>
+                  <version>3.0.0</version>
               </dependency>
           </dependencies>
         <configuration>
@@ -430,9 +427,9 @@
               </artifactSet>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>com.salesforce.dataloader.install.Installer</mainClass>
+                  <mainClass>com.salesforce.dataloader.process.DataLoaderRunner</mainClass>
                   <manifestEntries>
-                    <Main-Class>com.salesforce.dataloader.install.Installer</Main-Class>
+                    <Main-Class>com.salesforce.dataloader.process.DataLoaderRunner</Main-Class>
                     <Multi-Release>true</Multi-Release>
                     <Permissions>all-permissions</Permissions>
                     <Application-Name>${project.name}</Application-Name>
@@ -493,7 +490,7 @@
                 <phase>compile</phase>
                 <configuration>
                   <target>
-                    <ant antfile="${basedir}/extractSWTJar.xml" inheritAll="true" />
+                    <ant antfile="${basedir}/extractSWTJar.xml" inheritAll="true"/>
                     <delete includeEmptyDirs="true">
                       <dirset dir="${basedir}/target/">
                         <patternset>
@@ -503,7 +500,7 @@
                     </delete>
 
                     <replace dir="${basedir}/target/classes/" token="@@FULL_VERSION@@" value="${project.version}"/>
-                    <replace dir="${basedir}/target/classes/" token="@@MIN_JAVA_VERSION@@" value="${java.compile.version}"/>
+                    <replace dir="${basedir}/target/classes/" token="@@MIN_JAVA_VERSION@@" value="${maven.compiler.release}"/>
                   </target>
                 </configuration>
                 <goals>
@@ -623,13 +620,13 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>3.0.0-M9</version>
+            <version>3.0.0</version>
             <dependencies>
 <!-- https://mvnrepository.com/artifact/org.apache.maven.surefire/surefire-junit4 -->
               <dependency>
                 <groupId>org.apache.maven.surefire</groupId>
                 <artifactId>surefire-junit4</artifactId>
-                <version>3.0.0-M9</version>
+                <version>3.0.0</version>
               </dependency>
             </dependencies>
             <configuration>

--- a/release/install/install.command
+++ b/release/install/install.command
@@ -2,12 +2,12 @@
 :; #
 :; source "`dirname $0`/util/util.sh" #
 :; checkJavaVersion #
-:; java -cp "`dirname $0`/*" com.salesforce.dataloader.install.Installer #
+:; java -cp "`dirname $0`/*" com.salesforce.dataloader.process.DataLoaderRunner %* run.mode=install #
 :; exit 0 #
 
 @echo off
 setlocal
 CALL "%~dp0util\util.bat" :checkJavaVersion
-java -cp "%~dp0*" com.salesforce.dataloader.install.Installer %*
+java -cp "%~dp0*" com.salesforce.dataloader.process.DataLoaderRunner %* run.mode=install
 endlocal
 PAUSE

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -392,6 +392,8 @@ public class Config {
     public static final String CLI_OPTION_RUN_MODE = "run.mode";
     public static final String RUN_MODE_UI_VAL = "ui";
     public static final String RUN_MODE_BATCH_VAL = "batch";
+    public static final String RUN_MODE_INSTALL_VAL = "install";
+    public static final String RUN_MODE_ENCRYPT_VAL = "encrypt";
     public static final String CLI_OPTION_GMT_FOR_DATE_FIELD_VALUE = "datefield.usegmt";
     public static final String CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH = "swt.nativelib.inpath";
     public static final String CLI_OPTION_CONFIG_DIR_PROP = "salesforce.config.dir";

--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -300,10 +300,6 @@ public class Controller {
         this.loaderWindow.updateTitle(null);
     }
 
-    public static synchronized Controller getInstance(String lastRunFilePrefix, String[] args) throws ControllerInitializationException {
-        return getInstance(lastRunFilePrefix, AppUtil.getArgMapFromArgArray(args));
-    }
-
     public static synchronized Controller getInstance(String lastRunFilePrefix, Map<String, String> argMap) throws ControllerInitializationException {
         return new Controller(lastRunFilePrefix, argMap);
     }

--- a/src/main/java/com/salesforce/dataloader/install/Installer.java
+++ b/src/main/java/com/salesforce/dataloader/install/Installer.java
@@ -57,12 +57,12 @@ public class Installer extends Thread {
         System.out.println(Messages.getMessage(Installer.class, "exitMessage"));
     }
 
-    public static void main(String[] args) {
+    public static void install(String[] args) {
         String installationDir = ".";
         try {
             Runtime.getRuntime().addShutdownHook(new Installer());
             try {
-                AppUtil.initializeLog(AppUtil.getArgMapFromArgArray(args));
+                AppUtil.initializeLog(AppUtil.convertCommandArgsArrayToArgMap(args));
             } catch (FactoryConfigurationError | IOException ex) {
                 handleException(ex, Level.ERROR);
             }
@@ -356,7 +356,7 @@ public class Installer extends Thread {
         logger.debug("going to create " + MACOS_PACKAGE_BASE + "/MacOS");
         createDir(MACOS_PACKAGE_BASE + "/MacOS");
         createSymLink(PATH_TO_DL_EXECUTABLE_ON_MAC,
-                installationDir + "/dataloader_console", false);
+                installationDir + "/dataloader_console", true);
     }
     
     private static void configureWindowsArtifactsPostCopy(String installationDir) throws IOException {

--- a/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
@@ -246,7 +246,7 @@ public class ProcessRunner implements InitializingBean {
     }
     
     public static ProcessRunner runBatchMode(String[] args, ILoaderProgress progressMonitor) throws UnsupportedOperationException {
-        Map<String,String> argMap = AppUtil.getArgMapFromArgArray(args);
+        Map<String,String> argMap = AppUtil.convertCommandArgsArrayToArgMap(args);
         if (!argMap.containsKey(Config.CLI_OPTION_CONFIG_DIR_PROP) && args.length < 2) {
             // config directory must be specified in the first argument
             System.err.println(

--- a/src/main/resources/com/salesforce/dataloader/version.properties
+++ b/src/main/resources/com/salesforce/dataloader/version.properties
@@ -1,4 +1,4 @@
 dataloader.name = ${project.name}
 dataloader.version = ${project.version}
 dataloader.vendor = ${organization.name}
-java.min.version = ${java.compile.version}
+java.min.version = ${maven.compiler.release}

--- a/src/main/resources/win/bin/encrypt.bat
+++ b/src/main/resources/win/bin/encrypt.bat
@@ -6,7 +6,7 @@ IF "%ERRORLEVEL%" NEQ "0" (
     PAUSE
     GOTO :exit
 )
-java -cp "%~dp0../*" com.salesforce.dataloader.security.EncryptionUtil %*
+java -cp "%~dp0../*" com.salesforce.dataloader.process.DataLoaderRunner %* run.mode=encrypt
 
 :exit
 ENDLOCAL


### PR DESCRIPTION
- pom.xml changes
  - Update spring-context from 5.3.23 to 5.3.26
  - Use the maven.compiler.release property recognized by maven-compiler-plugin 3.8 and later to specify java version for the bytecode instead of java.compile.version property
   - Update maven-surefire-plugin and surefire-junit4 plugin from 3.0.0-M9 to 3.0.0.
   - specify DataLoaderRunner as the Main-Class in Manifest file of the jar.

- Changes to support DataLoaderRunner as the only entry point for install, batch mode, UI mode, and encrypt mode.