### PR TITLE
fix minor bug in install.command

### DIFF
--- a/release/install/install.command
+++ b/release/install/install.command
@@ -2,7 +2,7 @@
 :; #
 :; source "`dirname $0`/util/util.sh" #
 :; checkJavaVersion #
-:; java -cp "`dirname $0`/*" com.salesforce.dataloader.process.DataLoaderRunner %* run.mode=install #
+:; java -cp "`dirname $0`/*" com.salesforce.dataloader.process.DataLoaderRunner $@ run.mode=install #
 :; exit 0 #
 
 @echo off


### PR DESCRIPTION
Use $@ instead of %* to specify command line options in the shell script portion.