### PR TITLE
support logging level as a command line option

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -403,6 +403,8 @@ public class Config {
     public static final String SAVE_BULK_SERVER_LOAD_AND_RAW_RESULTS_IN_CSV = "process.bulk.saveServerLoadAndRawResultsInCSV";
     public static final String PROCESS_BULK_CACHE_DATA_FROM_DAO = "process.bulk.cacheDataFromDao";
     private static final String LAST_RUN_FILE_SUFFIX = "_lastRun.properties"; //$NON-NLS-1$
+    public static final String LOGGING_LEVEL = "logging.level"; // valid values are as specified by org.apache.logging.lo4j.Level class
+                                                                // viz. ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN
 
     // Following properties are read-only, i.e. they are not overridden during save() to config.properties
     // - These properties are not set in Advanced Settings dialog.
@@ -427,7 +429,8 @@ public class Config {
             PROCESS_BULK_CACHE_DATA_FROM_DAO,
             SAVE_BULK_SERVER_LOAD_AND_RAW_RESULTS_IN_CSV,
             API_VERSION_PROP,
-            READ_CHARSET
+            READ_CHARSET,
+            LOGGING_LEVEL
     };
     
     private static boolean useGMTForDateFieldValue;

--- a/src/main/java/com/salesforce/dataloader/util/AppUtil.java
+++ b/src/main/java/com/salesforce/dataloader/util/AppUtil.java
@@ -46,8 +46,12 @@ import java.util.Properties;
 
 import javax.xml.parsers.FactoryConfigurationError;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
 
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.config.Messages;
@@ -283,8 +287,23 @@ public class AppUtil {
             logger.info("Using log4j2 configuration file at location: " + logConfigLocation);
         }
         */
+        if (argsMap.containsKey(Config.LOGGING_LEVEL)) {
+            setLoggingLevel(argsMap.get(Config.LOGGING_LEVEL));
+        }
         logger = LogManager.getLogger(AppUtil.class);
         logger.info(Messages.getString("AppUtil.logInit")); //$NON-NLS-1$
+    }
+    
+    public static void setLoggingLevel(String newLevelStr) {
+        if (newLevelStr == null) {
+            return;
+        }
+        Level newLevel = Level.toLevel(newLevelStr);
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration config = ctx.getConfiguration();
+        LoggerConfig loggerConfig = config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME); 
+        loggerConfig.setLevel(newLevel);
+        ctx.updateLoggers();  // This causes all Loggers to refetch information from their LoggerConfig.
     }
     
     private static String getDefaultConfigDir() {


### PR DESCRIPTION
Having logging level as a command line option simplifies customer troubleshooting as they don't have to change log-conf.xml. This change adds a command line option, logging.level, that allows user to specify one of the logging levels defined in org.apache.log4j.Level class. It defaults to DEBUG level if logging.level option is specified with a value other than the ones listed in org.apache.log4j.Level class.