### PR TITLE
internal cleanup

### DIFF
--- a/src/main/java/com/salesforce/dataloader/process/IProcess.java
+++ b/src/main/java/com/salesforce/dataloader/process/IProcess.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.dataloader.process;
+
+import com.salesforce.dataloader.action.progress.ILoaderProgress;
+import com.salesforce.dataloader.controller.Controller;
+
+public interface IProcess {
+    public Controller getController();
+    public ILoaderProgress getMonitor();
+}

--- a/src/main/java/com/salesforce/dataloader/util/DateOnlyCalendar.java
+++ b/src/main/java/com/salesforce/dataloader/util/DateOnlyCalendar.java
@@ -33,10 +33,6 @@ import java.util.TimeZone;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.salesforce.dataloader.config.Config;
-
-
-
 public class DateOnlyCalendar extends GregorianCalendar {
     /**
      * 
@@ -69,7 +65,7 @@ public class DateOnlyCalendar extends GregorianCalendar {
         Calendar cal = Calendar.getInstance(myTimeZone);
         cal.setTimeInMillis(specifiedTimeInMilliSeconds);
 
-        if (!Config.isUseGMTForDateFieldValue() && myTimeZone != null) {
+        if (!AppUtil.isUseGMTForDateFieldValue() && myTimeZone != null) {
             // Set hour, minute, second, and millisec to 0 (12:00AM) as it is date-only value
             cal.set(Calendar.HOUR, 0);
             cal.set(Calendar.MINUTE, 0);
@@ -88,7 +84,7 @@ public class DateOnlyCalendar extends GregorianCalendar {
     }
 
     public static DateOnlyCalendar getInstance(TimeZone timeZone) {
-        if (Config.isUseGMTForDateFieldValue()) {
+        if (AppUtil.isUseGMTForDateFieldValue()) {
             timeZone = GMT_TZ;
         } 
         return new DateOnlyCalendar(timeZone);

--- a/src/main/java/com/salesforce/dataloader/util/LoggingUtil.java
+++ b/src/main/java/com/salesforce/dataloader/util/LoggingUtil.java
@@ -106,6 +106,13 @@ public class LoggingUtil {
             logger.info("Using log4j2 configuration file at location: " + logConfigLocation);
         }
         */
+        
+        // From https://people.apache.org/~rgoers/log4j2/faq.html#reconfig_from_code
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+        File file = new File(log4jConfigFileAbsolutePath);
+         
+        // this will force a reconfiguration
+        context.setConfigLocation(file.toURI());
         logger = LogManager.getLogger(AppUtil.class);
         logger.debug(Messages.getMessage(AppUtil.class, "logInit")); //$NON-NLS-1$
     }

--- a/src/test/java/com/salesforce/dataloader/ConfigTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/ConfigTestBase.java
@@ -28,6 +28,8 @@ package com.salesforce.dataloader;
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.exception.ConfigInitializationException;
 import com.salesforce.dataloader.exception.ParameterLoadException;
+import com.salesforce.dataloader.util.AppUtil;
+
 import org.junit.Before;
 
 import java.util.Collections;
@@ -73,6 +75,7 @@ public abstract class ConfigTestBase extends TestBase {
         for (TestProperties prop : getDefaultTestPropertiesSet()) {
             prop.putConfigSetting(configBase);
         }
+        configBase.put(AppUtil.CLI_OPTION_CONFIG_DIR_PROP, TEST_CONF_DIR);
         return configBase;
     }
 

--- a/src/test/java/com/salesforce/dataloader/TestBase.java
+++ b/src/test/java/com/salesforce/dataloader/TestBase.java
@@ -30,7 +30,6 @@ import com.salesforce.dataloader.client.PartnerClient;
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.config.Messages;
 import com.salesforce.dataloader.controller.Controller;
-import com.salesforce.dataloader.exception.ControllerInitializationException;
 import com.salesforce.dataloader.exception.PasswordExpiredException;
 import com.salesforce.dataloader.util.AppUtil;
 import com.sforce.soap.partner.Connector;
@@ -85,7 +84,7 @@ abstract class TestBase {
      */
     private static final Properties TEST_PROPS;
     private static final String TEST_FILES_DIR;
-    private static final String TEST_CONF_DIR;
+    protected static final String TEST_CONF_DIR;
     private static final String TEST_DATA_DIR;
     private static final String TEST_STATUS_DIR;
 
@@ -104,18 +103,19 @@ abstract class TestBase {
         TEST_PROPS = loadTestProperties();
         TEST_FILES_DIR = getProperty("testfiles.dir");
         TEST_CONF_DIR = TEST_FILES_DIR + File.separator + "conf";
+        TEST_PROPS.put(AppUtil.CLI_OPTION_CONFIG_DIR_PROP, TEST_CONF_DIR);
         TEST_DATA_DIR = TEST_FILES_DIR + File.separator + "data";
         TEST_STATUS_DIR = TEST_FILES_DIR + File.separator + "status";
         DEFAULT_ACCOUNT_EXT_ID_FIELD = getProperty("test.account.extid");
         
         Map<String, String> argsMap = new HashMap<String, String>();
-        argsMap.put(Config.CLI_OPTION_CONFIG_DIR_PROP, getTestConfDir());
+        argsMap.put(AppUtil.CLI_OPTION_CONFIG_DIR_PROP, getTestConfDir());
         try {
-            AppUtil.initializeAppConfig(argsMap);
+            AppUtil.initializeAppConfig(AppUtil.convertCommandArgsMapToArgsArray(argsMap));
         } catch (FactoryConfigurationError e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (IOException e) {
+        } catch (Exception e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
@@ -183,13 +183,13 @@ abstract class TestBase {
 
     protected void setupController(Map<String, String> configOverrideMap) {
         // configure the Controller to point to our testing config
-        configOverrideMap.put(Config.CLI_OPTION_READ_ONLY_CONFIG_PROPERTIES, Boolean.TRUE.toString());
-        if (!System.getProperties().contains(Config.CLI_OPTION_CONFIG_DIR_PROP))
-            System.setProperty(Config.CLI_OPTION_CONFIG_DIR_PROP, getTestConfDir());
+        configOverrideMap.put(Config.READ_ONLY_CONFIG_PROPERTIES, Boolean.TRUE.toString());
+        if (!System.getProperties().contains(AppUtil.CLI_OPTION_CONFIG_DIR_PROP))
+            System.setProperty(AppUtil.CLI_OPTION_CONFIG_DIR_PROP, getTestConfDir());
 
         try {
-            controller = Controller.getInstance(testName.getMethodName(), configOverrideMap);
-        } catch (ControllerInitializationException e) {
+            controller = Controller.getInstance(configOverrideMap);
+        } catch (Exception e) {
             fail("While initializing controller instance", e);
         }
     }

--- a/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
+++ b/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
@@ -30,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.salesforce.dataloader.config.Config;
+import com.salesforce.dataloader.util.AppUtil;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -657,7 +658,7 @@ public class DateConverterTest {
         assertEquals(6, result.get(Calendar.MONTH) + 1);
         assertEquals(22, result.get(Calendar.DAY_OF_MONTH));
 
-        Config.setUseGMTForDateFieldValue(true);
+        AppUtil.setUseGMTForDateFieldValue(true);
         AsianTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("Asia/Tokyo"), false);
         USTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("America/Los_Angeles"), false);
         result = (Calendar) USTZDateOnlyConverter.convert(null, "6/22/2012");
@@ -695,7 +696,7 @@ public class DateConverterTest {
         assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
         assertEquals(TimeZone.getTimeZone("GMT"), result.getTimeZone());
         
-        Config.setUseGMTForDateFieldValue(false);
+        AppUtil.setUseGMTForDateFieldValue(false);
         AsianTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("Asia/Tokyo"), false);
         USTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("America/Los_Angeles"), false);
 

--- a/src/test/java/com/salesforce/dataloader/process/BulkCsvProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/BulkCsvProcessTest.java
@@ -97,7 +97,7 @@ public class BulkCsvProcessTest extends ProcessTestBase {
 
     private ILoaderProgress runProcess(Map<String, String> argMap, int numInserts, int numUpdates, int numFailures, boolean emptyId) throws Exception {
 
-        final ProcessRunner runner = this.runBatchProcess(argMap);
+        final IProcess runner = this.runBatchProcess(argMap);
         ILoaderProgress monitor = runner.getMonitor();
         Controller controller = runner.getController();
 

--- a/src/test/java/com/salesforce/dataloader/process/CsvExtractProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvExtractProcessTest.java
@@ -169,7 +169,7 @@ public class CsvExtractProcessTest extends ProcessExtractTestBase {
         String lastRunFilePath = config.getLastRunFilename();
         File lastRunFile = new File(lastRunFilePath);
         try {
-            String defaultFileName = baseProcessName + "_lastRun.properties";
+            String defaultFileName = argMap.get(Config.OPERATION) + "_lastRun.properties";
             File expectedFile = useDefault ? new File(config.constructConfigFilePath(defaultFileName)) : new File(
                     outputDir, defaultFileName);
             if (enableOutput) {

--- a/src/test/java/com/salesforce/dataloader/process/CsvProcessAttachmentTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvProcessAttachmentTest.java
@@ -148,7 +148,7 @@ public class CsvProcessAttachmentTest extends ProcessTestBase {
                                                         AttachmentTemplateListener myAttachmentTemplateListener, String... files)
             throws ProcessInitializationException, DataAccessObjectException, ConnectionException, IOException {
 
-        final ProcessRunner runner = this.runBatchProcess(argMap);
+        final IProcess runner = this.runBatchProcess(argMap);
         ILoaderProgress monitor = runner.getMonitor();
         Controller controller = runner.getController();
 

--- a/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
@@ -48,6 +48,7 @@ import com.salesforce.dataloader.dao.csv.CSVFileWriter;
 import com.salesforce.dataloader.exception.*;
 import com.salesforce.dataloader.exception.UnsupportedOperationException;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.util.AppUtil;
 import com.salesforce.dataloader.util.Base64;
 import com.sforce.soap.partner.*;
 import com.sforce.soap.partner.fault.ApiFault;
@@ -735,10 +736,10 @@ public abstract class ProcessTestBase extends ConfigTestBase {
         return controller;
     }
     
-    protected ProcessRunner runBatchProcess(Map<String, String> argMap) {
+    protected IProcess runBatchProcess(Map<String, String> argMap) {
         if (argMap == null) argMap = getTestConfig();
         argMap.put(Config.PROCESS_THREAD_NAME, this.baseName);
-        argMap.put(Config.CLI_OPTION_READ_ONLY_CONFIG_PROPERTIES, Boolean.TRUE.toString());
+        argMap.put(Config.READ_ONLY_CONFIG_PROPERTIES, Boolean.TRUE.toString());
 
         // emulate invocation through process.bat script
         String[] args = new String[argMap.size()+1];
@@ -753,13 +754,13 @@ public abstract class ProcessTestBase extends ConfigTestBase {
             args[i++] = entry.getKey() + "=" + entry.getValue();
         }
         final TestProgressMontitor monitor = new TestProgressMontitor();        
-        return ProcessRunner.runBatchMode(args, monitor);
+        return DataLoaderRunner.runApp(args, monitor);
     }
 
     protected Controller runProcess(Map<String, String> argMap, boolean expectProcessSuccess, String failMessage,
             int numInserts, int numUpdates, int numFailures, boolean emptyId) throws ProcessInitializationException,
             DataAccessObjectException {
-        ProcessRunner runner = runBatchProcess(argMap);
+        IProcess runner = runBatchProcess(argMap);
         ILoaderProgress monitor = runner.getMonitor();
         Controller controller = runner.getController();
 
@@ -963,4 +964,10 @@ public abstract class ProcessTestBase extends ConfigTestBase {
         return argMap;
     }
 
+    protected Map<String, String> getTestConfig() {
+        Map<String, String> configArgsMap = super.getTestConfig();
+        // run process tests in batch mode
+        configArgsMap.put(Config.CLI_OPTION_RUN_MODE, Config.RUN_MODE_BATCH_VAL);
+        return configArgsMap;
+    }
 }


### PR DESCRIPTION
- Move CLI_OPTION_* to AppUtil because config properties primarily drive Controller behavior whereas CLI options are application-level.
- Centralize the use of Config.OPERATION value as the prefix of lastrun.properties file in batch mode.
- Tests invoke main method of DataLoaderRunner to make sure that tests cover application initialization code.