### PR TITLE
remove dependency on ant-contrib

### DIFF
--- a/extractSWTJar.xml
+++ b/extractSWTJar.xml
@@ -1,29 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="maven-antrun-" default="main"  >
 	<target name="main">
-	  <copy todir="${basedir}/target/classes/mac/" >
+	  <copy todir="${basedir}/target/classes/mac/" flatten="true">
 		<fileset dir="${basedir}/local-proj-repo/local/swt/" includes="swtmac*/*/*.jar"/>
 	  </copy>
-      <copy todir="${basedir}/target/classes/win/" >
+      <copy todir="${basedir}/target/classes/win/"  flatten="true">
         <fileset dir="${basedir}/local-proj-repo/local/swt/" includes="swtwin*/*/*.jar"/>
       </copy>
-      <copy todir="${basedir}/target/classes/linux/" >
+      <copy todir="${basedir}/target/classes/linux/"  flatten="true">
         <fileset dir="${basedir}/local-proj-repo/local/swt/" includes="swtlinux*/*/*.jar"/>
       </copy>
-	  <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
-	  <foreach param="fileName" target="flatten">
-	    <path>
-    	    <dirset dir="${basedir}/target/classes/">
-    	      <include name="**/swt*" />
-    	    </dirset>
-        </path>
-	  </foreach>
-	</target>
-	<target name="flatten">
-	  <move todir="${fileName}" flatten="true">
-		<fileset dir="${fileName}/">
-		  <include name="**/*.jar"/>
-		</fileset>
-	  </move>
 	</target>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -507,20 +507,6 @@
                 </goals>
               </execution>
             </executions>
-	        <dependencies>
-<!-- https://mvnrepository.com/artifact/ant-contrib/ant-contrib -->
-              <dependency>
-              <groupId>ant-contrib</groupId>
-              <artifactId>ant-contrib</artifactId>
-              <version>1.0b3</version>
-              <exclusions>
-                <exclusion>
-                  <groupId>ant</groupId>
-                  <artifactId>ant</artifactId>
-                </exclusion>
-              </exclusions>
-            </dependency>
-          </dependencies>
 	      </plugin>
         </plugins>
       </build>

--- a/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
@@ -297,11 +297,13 @@ public class DataLoaderRunner extends Thread {
                 continue;
             }
             for (Boolean skipOSAndArchVal : skipOSAndArchInFileNameConstructionArray) {
-                String swtDirPathStr = parentDirOfSwtDir + "/*";
-                String swtJarPathWithParentDirWildcard = constructSwtJarNameFromOSAndArch(skipOSAndArchVal);
-                File swtJarFileHandle = getSWTJarFileHandleFromWildcard(swtDirPathStr, swtJarPathWithParentDirWildcard);
+                File swtJarFileHandle = getSWTJarFileHandleFromDir(parentDirOfSwtDir, skipOSAndArchVal);
                 if (swtJarFileHandle != null) {
-                    logger.debug("Found SWT jar at " + swtJarFileHandle.getAbsolutePath());
+                    return swtJarFileHandle;
+                }
+                // look into sub-directories
+                swtJarFileHandle = getSWTJarFileHandleFromDir(parentDirOfSwtDir + "/*", skipOSAndArchVal);
+                if (swtJarFileHandle != null) {
                     return swtJarFileHandle;
                 }
             }
@@ -316,6 +318,15 @@ public class DataLoaderRunner extends Thread {
         }
         classPathStr = System.getProperty("java.class.path");
         return getSWTJarFileFromClassPath(classPathStr);
+    }
+    
+    private static File getSWTJarFileHandleFromDir(String dir, boolean skipOSAndArchVal) {
+        String swtJarPathWithParentDirWildcard = constructSwtJarNameFromOSAndArch(skipOSAndArchVal);
+        File swtJarFileHandle = getSWTJarFileHandleFromWildcard(dir, swtJarPathWithParentDirWildcard);
+        if (swtJarFileHandle != null) {
+            logger.debug("Found SWT jar at " + swtJarFileHandle.getAbsolutePath());
+        }
+        return swtJarFileHandle;
     }
     
     private static File getSWTJarFileFromClassPath(String classPathStr) {


### PR DESCRIPTION
Remove dependency on ant-contrib by replacing foreach ant-contrib task with flatten="true" when copying SWT jar files.