### PR TITLE
remove unneeded dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,18 +57,6 @@
       <artifactId>gson</artifactId>
       <version>2.10.1</version>
     </dependency>
-<!-- https://mvnrepository.com/artifact/com.force.api/force-wsc -->
-    <dependency>
-      <groupId>com.force.api</groupId>
-      <artifactId>force-wsc</artifactId>
-      <version>${force.wsc.version}</version>
-      <exclusions>
-        <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 <!-- https://mvnrepository.com/artifact/com.force.api/force-partner-api -->
     <dependency>
       <groupId>com.force.api</groupId>


### PR DESCRIPTION
data loader does not use WSC. Remove its dependency from POM.