### PR TITLE
minor cleanup of runtests script

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -2,18 +2,17 @@
 
 usage() {
   echo "Usage: "
-  echo "$0 [-v <version number such as 52.0.0>] [-d] [-t <test class name without the package prefix com.salesforce.dataloader e.g. dyna.DateConverterTest>] <test org URL> <test admin username> <test regular user username> <encrypted test password>"
+  echo "$0 [-d] [-t <test class name without the package prefix com.salesforce.dataloader e.g. dyna.DateConverterTest>] <test org URL> <test admin username> <test regular user username> <encrypted test password>"
   echo "listening on port 5005 for IDE to start the debugging session if -d is specified."
   exit 1
 }
 
 # To generate encrypted password
-# build uber jar with the following command:
-# mvn -DtargetOS=macos_x86_64 clean package -DskipTests
+# build jar with the following command:
+# mvn clean package -DskipTests
 # run the following command to get encrypted password for the test admin account:
 #java -cp target/dataloader-*-uber.jar com.salesforce.dataloader.security.EncryptionUtil -e <password>
 
-version=""
 test=""
 debug=""
 
@@ -25,9 +24,6 @@ do
       ;;
     t)
       test="-Dtest=com.salesforce.dataloader.${OPTARG}"
-      ;;
-    v)
-      version="${OPTARG}"
       ;;
     *)
       usage
@@ -50,12 +46,6 @@ fi
 echo $@
 
 cp pom.xml pomtest.xml
-
-if [ ! ${version} = "" ]
-then
-  sed -i '' "s/<version>[0-9][0-9]\.[0-9]\.[0-9]<\/version>/<version>${version}<\/version>/g" pomtest.xml
-  sed -i '' "s/<force.wsc.version>[0-9][0-9]\.[0-9]\.[0-9]<\/force.wsc.version>/<force.wsc.version>${version}<\/force.wsc.version>/g" pomtest.xml
-fi
 
 sed -i '' "s/http:\/\/testendpoint/${1}/g" pomtest.xml
 sed -i '' "s/admin@org.com/${2}/g" pomtest.xml


### PR DESCRIPTION
- no need to specify the API version number as a command line option