### PR TITLE
part of the fix for W-12948382 - Consistently carry over mapping file info from previous operation

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -422,7 +422,6 @@ public class Config {
             DAO_TYPE,
             ENTITY,
             OPERATION,
-            MAPPING_FILE,
             DEBUG_MESSAGES,
             DEBUG_MESSAGES_FILE,
             WIRE_OUTPUT,

--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -64,6 +64,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -258,13 +260,21 @@ public class Controller {
                 new SOQLMapper(getPartnerClient(), dao.getColumnNames(), getFieldTypes().getFields(), "") 
               : new LoadMapper(getPartnerClient(), dao.getColumnNames(), getFieldTypes().getFields(), "");
     }
-
-    public void createMapper(String daoTypeStr, String daoNameStr, String sObjectName) throws MappingInitializationException {
-        initializeOperation(daoTypeStr, daoNameStr, sObjectName);
+    
+    public void createMapperPostInitialize() throws MappingInitializationException {
         String mappingFile = config.getString(Config.MAPPING_FILE);
+        if (mappingFile != null 
+                && !mappingFile.isBlank() && !Files.exists(Path.of(mappingFile))) {
+            throw new MappingInitializationException("Mapping file " + mappingFile + " does not exist");
+        }
         this.mapper = getConfig().getOperationInfo().isExtraction() ? new SOQLMapper(getPartnerClient(),
                 dao.getColumnNames(), getFieldTypes().getFields(), mappingFile) : new LoadMapper(getPartnerClient(), dao.getColumnNames(),
                 getFieldTypes().getFields(), mappingFile);
+    }
+
+    public void initializeOperationAndCreateMapper(String daoTypeStr, String daoNameStr, String sObjectName) throws MappingInitializationException {
+        initializeOperation(daoTypeStr, daoNameStr, sObjectName);
+        createMapperPostInitialize();
     }
 
     public void createAndShowGUI() throws ControllerInitializationException {

--- a/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
@@ -164,7 +164,7 @@ public class ProcessRunner implements InitializingBean, IProcess {
 
                 // instantiate the map
                 logger.info(Messages.getString("Process.creatingMap")); //$NON-NLS-1$
-                controller.createMapper(config.getString(Config.DAO_TYPE), 
+                controller.initializeOperationAndCreateMapper(config.getString(Config.DAO_TYPE), 
                         config.getString(Config.DAO_NAME), config.getString(Config.ENTITY));
 
                 // execute the requested operation

--- a/src/main/java/com/salesforce/dataloader/ui/DataSelectionDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/DataSelectionDialog.java
@@ -128,6 +128,12 @@ public class DataSelectionDialog extends Dialog {
                     shell.setText(Labels.getString("DataSelectionDialog.titleError"));
                     return;
                 }
+                try {
+                    controller.createMapperPostInitialize();
+                } catch (MappingInitializationException e) {
+                    // skip mapping
+                    controller.getConfig().setValue(Config.MAPPING_FILE, "");
+                }
 
                 String daoPath = controller.getConfig().getString(Config.DAO_NAME);
                 File file = new File(daoPath);

--- a/src/main/java/com/salesforce/dataloader/ui/MappingPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/MappingPage.java
@@ -256,9 +256,6 @@ public class MappingPage extends LoadPage {
             return true; // further processing is not possible
         }
 
-        Config config = controller.getConfig();
-        // clear mapping file
-        config.setValue(Config.MAPPING_FILE, "");
         updateMapping();
         packMappingColumns();
         return true;


### PR DESCRIPTION
Use previous operation's mapping file to pre-map fields in this operation. Also, do not try to do mapping if mapping file is missing.