### PR TITLE
avoid drift in wizard windows

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/LoaderWindow.java
+++ b/src/main/java/com/salesforce/dataloader/ui/LoaderWindow.java
@@ -168,6 +168,11 @@ public class LoaderWindow extends ApplicationWindow {
         // Set the title bar text
         updateTitle(null);
         shell.setSize(600, 400);
+        Point shellLocation = shell.getLocation();
+        if (shellLocation.x < 50) {
+            shellLocation.x = 50;
+            shell.setLocation(shellLocation);
+        }
 
         shell.setImage(UIUtils.getImageRegistry().get("sfdc_icon"));
     }

--- a/src/main/java/com/salesforce/dataloader/ui/OperationPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/OperationPage.java
@@ -51,6 +51,8 @@ public abstract class OperationPage extends WizardPage {
     */
    protected final Controller controller;
    protected final Logger logger;
+   private static final int SHELL_X_OFFSET = 100;
+   private static final int SHELL_Y_OFFSET = 50;
 
    public OperationPage(String name, Controller controller) {
        super(name);
@@ -65,6 +67,14 @@ public abstract class OperationPage extends WizardPage {
        // Set the description
        String description = Labels.getString(this.getClass().getSimpleName() + ".description");
        this.setDescription(description);
+       Composite shellParent = this.getShell().getParent();
+       if (shellParent != null) {
+           Point shellLocation = shellParent.getLocation();
+           shellLocation.x += SHELL_X_OFFSET;
+           shellLocation.y += SHELL_Y_OFFSET;
+           this.getShell().setLocation(shellLocation);
+       }
+       
        boolean success = true;
        if (this.controller.isLoggedIn()) {
            success = setupPagePostLogin();


### PR DESCRIPTION
- place wizard windows at a fixed offset from the parent window.
- keep a horizontal gap of at least 50 pixels when the main window is displayed.