### PR TITLE
run unit and integration tests on shaded jar instead of compiled classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,18 +282,6 @@
         </configuration>
       </plugin>
 
-<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.1.0</version>
-        <configuration>
-          <excludes>
-            <exclude>${exclude.integration.tests}</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-
 <!-- https://mvnrepository.com/artifact/com.mycila/license-maven-plugin -->
       <plugin>
           <groupId>com.mycila</groupId>
@@ -462,6 +450,49 @@
               <goal>run</goal>
             </goals>
            </execution>
+          <execution>
+            <id>test-cleanup</id>
+            <phase>package</phase>
+            <configuration>
+              <target>
+                <delete dir="${basedir}/target/classes"/>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <excludes>
+            <exclude>${exclude.integration.tests}</exclude>
+          </excludes>
+          <!-- skip unit and integration tests during maven's test phase -->
+          <skipTests>true</skipTests>
+        </configuration>
+        <executions>
+          <!-- To run unit tests: mvn clean package -->
+          <!-- To run integration tests: mvn clean package -Pintegration-test to run integration tests -->
+          <execution>
+            <id>integration-test</id>
+            <phase>package</phase>
+            <configuration>
+              <skipTests>false</skipTests>
+              <additionalClasspathElements>
+                <additionalClasspathElement>${basedir}/target/dataloader-${project.version}.jar</additionalClasspathElement>
+              </additionalClasspathElements>
+            </configuration>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/runtests.sh
+++ b/runtests.sh
@@ -52,5 +52,5 @@ sed -i '' "s/admin@org.com/${2}/g" pomtest.xml
 sed -i '' "s/standard@org.com/${3}/g" pomtest.xml
 sed -i '' "s/<test\.password>/<test\.password>${4}/g" pomtest.xml
 
-mvn -f pomtest.xml clean test -Pintegration-test ${debug} ${test}
+mvn -f pomtest.xml clean package -Pintegration-test ${debug} ${test}
 rm pomtest.xml


### PR DESCRIPTION
Run unit and integration tests in package phase, after shaded jar is created to reduce chances of a bug such as W-13523757.