### PR TITLE
Use apache.commons.text.StringEscapeUtils.escapeHtml4() to escape HTM…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-text -->
+    <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>1.10.0</version>
+    </dependency>
 
 <!-- Testing dependencies -->
 <!-- https://mvnrepository.com/artifact/com.h2database/h2 -->

--- a/src/test/java/com/salesforce/dataloader/mapping/LoadMapperTest.java
+++ b/src/test/java/com/salesforce/dataloader/mapping/LoadMapperTest.java
@@ -26,10 +26,12 @@
 package com.salesforce.dataloader.mapping;
 
 import com.salesforce.dataloader.ConfigTestBase;
+import com.salesforce.dataloader.action.visitor.DAOLoadVisitor;
 import com.salesforce.dataloader.exception.MappingInitializationException;
 import com.salesforce.dataloader.model.Row;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -37,6 +39,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -262,6 +266,98 @@ public class LoadMapperTest extends ConfigTestBase {
         } catch (MappingInitializationException ignored) {
             // expected
         }
+    }
+    
+    @Test
+    public void testRichTextConversionNoHTMLTags() throws Exception {
+        String origText = "    a  ";
+        String convertedText = DAOLoadVisitor.convertToHTMLFormatting(origText);
+        assertEquals("Incorrect encoding of whitespace characters in string" + origText,
+                4, getSpaceChars(convertedText.substring(0, 24)));
+        assertEquals("Incorrect encoding of whitespace characters in string" + origText,
+                2, getSpaceChars(convertedText.substring(25)));
+
+    }
+    
+    @Test
+    public void testRichTextConversionHTMLTagAttrsWithDoubleQuotes() throws Exception {    
+        String tag = "<span style=\"font-size: 172px;\">";
+        String origText = tag + "    a</span>  ";
+        String convertedText = DAOLoadVisitor.convertToHTMLFormatting(origText);
+        assertEquals("Incorrect encoding of whitespace characters in string" + origText,
+                4, getSpaceChars(convertedText.substring(
+                        tag.length(), 
+                        tag.length()+24)));
+        assertEquals("Incorrect encoding of whitespace characters in string" + origText,
+                2, getSpaceChars(convertedText.substring(tag.length()+30)));  
+    }
+    
+    @Test
+    public void testRichTextConversionHTMLTagWithoutClosingQuote() throws Exception {    
+        String tag = "<span style=\"font-size: 172px;>"; // skip closing doublequotes in style attribute
+        String origText = tag + "    a  </p>";
+        String convertedText = DAOLoadVisitor.convertToHTMLFormatting(origText);
+        assertEquals("Incorrect conversion of " + origText, "&lt;", convertedText.substring(0, 4));
+    }
+    
+    @Test
+    public void testRichTextConversionHTMLTagAttrsWithSingleQuotes() throws Exception {    
+        String tag = "<span style=\'font-size: 172px;\'>";
+        String origText = tag + "    a</span    >  ";
+        String convertedText = DAOLoadVisitor.convertToHTMLFormatting(origText);
+        assertEquals("Incorrect encoding of whitespace characters in string" + origText,
+                4, getSpaceChars(convertedText.substring(
+                        tag.length(), 
+                        tag.length()+24)));
+        assertEquals("Incorrect encoding of whitespace characters in string" + origText,
+                2, getSpaceChars(convertedText.substring(tag.length()+34)));
+    }
+    
+    @Test
+    public void testRichTextConversionLTAndGTCharsInString() throws Exception {    
+        String origText = "    <    or > ";
+        String convertedText = DAOLoadVisitor.convertToHTMLFormatting(origText);
+        assertEquals("Incorrect encoding of whitespace characters in string" + origText,
+                true, convertedText.contains("<")); // text interpret as containing a HTML tag
+    }
+    
+    @Test
+    public void testRichTextConversionCascadingHTMLTags() throws Exception {    
+        String tag = 
+                  "<p>    "
+                +   "<strong>leading</strong>"
+                +   "     space "
+                +   "<em>and</em>"
+                +   " <u>ending</u>"
+                +   " <strike>tab</strike>"
+                + "</p>"
+                + "<ol>"
+                +   "<li><strike>line 1</strike>"
+                +       "<ol>"
+                +           "<li><strike>line 1a</strike></li>"
+                +           "<li><strike>line 1b</strike></li>"
+                +       "</ol>"
+                +   "</li>"
+                +   "<li>"
+                +       "<strike>line 2</strike>"
+                +   "</li>"
+                + "</ol>\n"
+                + "";
+        String origText = tag + "    a  </p>";
+        String convertedText = DAOLoadVisitor.convertToHTMLFormatting(origText);
+        assertEquals("Incorrect conversion of " + origText, "<", convertedText.substring(0, 1));
+    }
+
+    private static final String HTML_WHITESPACE_ENCODING = "&nbsp;";
+    private static final Pattern HTML_WHITESPACE_PATTERN = Pattern.compile(HTML_WHITESPACE_ENCODING);
+
+    private int getSpaceChars(String text) {
+        Matcher matcher = HTML_WHITESPACE_PATTERN.matcher(text);
+        int count = 0;
+        while (matcher.find()) {
+            count++;
+        }
+        return count;
     }
 
     /**

--- a/src/test/java/com/salesforce/dataloader/process/CsvProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvProcessTest.java
@@ -404,6 +404,19 @@ public class CsvProcessTest extends ProcessTestBase {
                     assertEquals("spaces not preserved for company " + companyName, true, isSpaceChar);
                 }
                 continue;
+            } else if (companyName.equalsIgnoreCase("Company C")) {
+                int idx = textWithSpaceChars.indexOf('<');
+                if (idx == -1) {
+                    idx = textWithSpaceChars.indexOf("&lt;");
+                }
+                if (idx != -1) {
+                    idx += 4;
+                    if (textWithSpaceChars.charAt(idx+1) != ' '
+                        || textWithSpaceChars.charAt(idx+2) != ' '
+                        || textWithSpaceChars.charAt(idx+1) != ' ') {
+                        assertEquals("spaces after < character not preserved for company " + companyName, true, false);
+                    }
+                }
             }
             String textWithoutLeadingSpaceChars = textWithSpaceChars.stripLeading();
             String textWithoutTrailingSpaceChars = textWithSpaceChars.stripTrailing();

--- a/src/test/resources/testfiles/data/accountsForInsert.csv
+++ b/src/test/resources/testfiles/data/accountsForInsert.csv
@@ -1,5 +1,5 @@
 "Name","NumEmp","Industry","RichText"
 "Company A","25","Heavy Industry","    4 <span style="" font-size: 172px;"">leading spaces and</span> 2 trailing <h1>spaces</h1>  "
 "Company B","36","Mining","<p>    4 leading spaces and 2 trailing spaces  </p>"
-"Company C","47","Aerospace","    4 leading spaces and 2 trailing spaces  "
+"Company C","47","Aerospace","    4 leading spaces and 2 trailing spaces with 3 spaces after <   char  "
 "Company D","58","Fiber Optics","    4 leading spaces and 2 trailing spaces  "


### PR DESCRIPTION
…L chars in RichText

- Handle HTML escaping of special chars using apache.commons.text.StringEscapeUtils.escapeHtml4().
- Add unit and integration tests to test handling of Strings containing HTML tags.