### PR TITLE
Fix for W-13609474 - support lookup mapping for any lookup field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.force</groupId>
   <artifactId>dataloader</artifactId>
   <packaging>jar</packaging>
-  <version>58.0.2</version>
+  <version>58.0.3</version>
   <name>Salesforce Data Loader</name>
   <url>https://github.com/forcedotcom/dataloader</url>
   <organization>
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.12.0</version>
+      <version>2.13.0</version>
     </dependency>
 <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
     <dependency>

--- a/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
+++ b/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
@@ -46,12 +46,9 @@ import com.sforce.soap.partner.DescribeGlobalSObjectResult;
 import com.sforce.soap.partner.DescribeSObjectResult;
 import com.sforce.soap.partner.Error;
 import com.sforce.soap.partner.Field;
-import com.sforce.soap.partner.FieldType;
 import com.sforce.soap.partner.LimitInfo;
 import com.sforce.soap.partner.LimitInfoHeader_element;
 import com.sforce.soap.partner.LoginResult;
-import com.sforce.soap.partner.OwnerChangeOption;
-import com.sforce.soap.partner.OwnerChangeOptionType;
 import com.sforce.soap.partner.PartnerConnection;
 import com.sforce.soap.partner.QueryResult;
 import com.sforce.soap.partner.SaveResult;
@@ -747,11 +744,16 @@ public class PartnerClient extends ClientBase<PartnerConnection> {
                         for (Field refField : refObjectFields) {
                             if (refField.isExternalId()
                                 || "id".equalsIgnoreCase(refField.getName())
-                                || ((refField.isNameField() ||  refField.getType().equals(FieldType.email)) 
-                                    && refField.isIdLookup())) {
-                                // change createable and updateable attributes of a reference field
-                                // only if it is not a self-reference.
+                                || refField.isIdLookup()) {
                                 if (!entityName.equalsIgnoreCase(refEntityName)) {
+                                    // Change createable and updateable attributes of a reference field
+                                    // only if it is not a self-reference.
+                                    // 
+                                    // The conditional check is to address the issue [W-10811419]:
+                                    // Name (Auto-Number - a read-only field) field shows up in mapping dialog
+                                    // when parent entity is the same as child entity (self-ref) because
+                                    // the field's "isUpdateable" attribute may get changed from "false"
+                                    // to "true" in the following code.
                                     refField.setCreateable(entityField.isCreateable());
                                     refField.setUpdateable(entityField.isUpdateable());
                                 }


### PR DESCRIPTION
Data Loader currently supports email and name as lookup fields if "isLookup == true" for these fields.

v53 introduced a change that supported any field for lookup if "isLookup == true" for that field - https://github.com/forcedotcom/dataloader/commit/f1be6679636d0b8acaad7052d4b7b450c6b83de7

It was restricted shortly afterwords to restrict the lookup mapping to name and email address fields of the lookup entity if "isLookup == true" for these fields: https://github.com/forcedotcom/dataloader/commit/901dbf402f74f1895b62ce850d29ea91200a68a1

The fix is to let any field whose "isLookup" attribute is true be used for lookup relationship mapping.