### PR TITLE
Single Whitespaces are not replaced by None-breaking Whitespace

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
@@ -324,7 +324,23 @@ public abstract class DAOLoadVisitor extends AbstractVisitor implements DAORowVi
         for (int i = 0, len = input.length(); i < len; i++) {
             char c = input.charAt(i);
             int cval = c;
-            if (Character.isWhitespace(c) || cval == NONBREAKING_SPACE_ASCII_VAL) {
+
+            char nextChar = 0;
+            if(i+1 < input.length()){
+                nextChar = input.charAt(i+1);
+            }
+            char prevChar = 0;
+            if(i>0){
+                prevChar = input.charAt(i-1);
+            }
+
+            boolean isCharWhitespace = Character.isWhitespace(c) || cval == NONBREAKING_SPACE_ASCII_VAL;
+            //If last char, also evaluates to as whitespace
+            boolean isNextCharWhitespace = nextChar == 0 || Character.isWhitespace(nextChar) || nextChar == NONBREAKING_SPACE_ASCII_VAL;
+            //If first char, also evaluates to as whitespace
+            boolean isPrevCharWhitespace = prevChar == 0 || Character.isWhitespace(prevChar) || prevChar == NONBREAKING_SPACE_ASCII_VAL;
+            //only occurrences of multiple w
+            if (isCharWhitespace && (isNextCharWhitespace || isPrevCharWhitespace)){
                 htmlFormattedStr.append("&nbsp;");
             } else {
                 htmlFormattedStr.append(c);


### PR DESCRIPTION
Added nullsafe ahead and back look when escapeHTMLChars so only multiple whitespace occurences are replaced by non-breaking whitespace.

U+0020 = Normal Whitespace = ` `
U+00A0 = No-Break Space = `&nbsp;`

Recent behavior:
> This is     a scentence! <Github doesn't render the additional spaces here
> ThisU+0020isU+0020U+0020U+0020U+0020aU+0020scentence!

turns into
> ThisU+00A0isU+00A0U+00A0U+00A0U+00A0aU+00A0scentence!
Which break line breaks in Rich Text fields, as any words will be evaluated as one long word (Firefox & Chrome).

Expected behavior:
> This is     a scentence!
> ThisU+0020isU+0020U+0020U+0020U+0020aU+0020scentence!

turns into
> ThisU+0020isU+0020U+0020U+0020U+0020aU+0020scentence!
preserving single whitespaces so rich text fields break correctly.

I don't know if you accept PRs. The unit tests are still working and the code includes relevant comments, if there are any questions feel free to comment. :)