### PR TITLE
skip logging of debug message for for each CSV file row

### DIFF
--- a/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileReader.java
@@ -196,12 +196,6 @@ public class CSVFileReader implements DataReader {
             String errMsg = Messages.getFormattedString("CSVFileDAO.errorRowTooSmall", new String[]{
                     String.valueOf(currentRowNumber), String.valueOf(record.size()), String.valueOf(headerRow.size())});
             throw new DataAccessRowException(errMsg);
-        } else {
-            LOGGER.debug(Messages.getFormattedString("CSVFileDAO.debugMessageRowSize", 
-                    new String[] {
-                            String.valueOf(currentRowNumber), String.valueOf(record.size())
-                            }
-            ));
         }
 
         Row row = new Row(record.size());


### PR DESCRIPTION
logging the number of columns for each row in a large CSV file if it is the same number as the number of header columns for debugging purposes is not useful and can bloat the debug log, making it harder to troubleshoot issues.