### PR TITLE
cache GetUserInfoResult for the session

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
@@ -30,7 +30,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
 import com.salesforce.dataloader.model.Row;
-import com.salesforce.dataloader.util.AppUtil;
 import com.salesforce.dataloader.util.DAORowUtil;
 
 import org.apache.commons.beanutils.*;
@@ -54,7 +53,6 @@ import com.sforce.async.AsyncApiException;
 import com.sforce.soap.partner.DescribeSObjectResult;
 import com.sforce.soap.partner.Field;
 import com.sforce.soap.partner.FieldType;
-import com.sforce.soap.partner.GetUserInfoResult;
 import com.sforce.soap.partner.fault.ApiFault;
 import com.sforce.ws.ConnectionException;
 
@@ -354,11 +352,8 @@ public abstract class DAOLoadVisitor extends AbstractVisitor implements DAORowVi
             return fieldValue;
         }
         String localeStr = Locale.getDefault().toString(); 
-        try {
-            GetUserInfoResult userInfo = this.controller.getPartnerClient().getClient().getUserInfo();
-            localeStr = userInfo.getUserLocale();
-        } catch (ConnectionException e) {
-            logger.debug("Unable to access user locale from server");
+        if (this.controller.getCachedUserInfoForTheSession() != null) {
+            localeStr = this.controller.getCachedUserInfoForTheSession().getUserLocale();
         }
         return DAORowUtil.getPhoneFieldValue((String)fieldValue, localeStr);
     }

--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -837,7 +837,7 @@ public class AdvancedSettingsDialog extends Dialog {
                 }
                 controller.saveConfig();
                 controller.logout();
-                controller.updateLoaderWindowTitle();
+                controller.updateLoaderWindowTitleAndCacheUserInfoForTheSession();
 
                 input = Labels.getString("UI.ok"); //$NON-NLS-1$
                 shell.close();

--- a/src/main/java/com/salesforce/dataloader/ui/AuthenticationRunner.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AuthenticationRunner.java
@@ -133,7 +133,7 @@ public class AuthenticationRunner {
             if (controller.login() && controller.setEntityDescribes()) {
                 messenger.accept(Labels.getString("SettingsPage.loginSuccessful"));
                 controller.saveConfig();
-                controller.updateLoaderWindowTitle();
+                controller.updateLoaderWindowTitleAndCacheUserInfoForTheSession();
                 PartnerConnection conn = controller.getPartnerClient().getClient();
                 logger.debug("org_id = " + conn.getUserInfo().getOrganizationId());
                 logger.debug("user_id = " + conn.getUserInfo().getUserId());

--- a/src/main/java/com/salesforce/dataloader/ui/uiActions/LogoutUIAction.java
+++ b/src/main/java/com/salesforce/dataloader/ui/uiActions/LogoutUIAction.java
@@ -48,7 +48,7 @@ public class LogoutUIAction extends Action {
     @Override
     public void run() {
         controller.logout();
-        controller.updateLoaderWindowTitle();
+        controller.updateLoaderWindowTitleAndCacheUserInfoForTheSession();
     }
 
 }


### PR DESCRIPTION
Issue W-13771132 (Redundant/expensive checks for phone data types introduced in v58) is caused by invoking server API to get user locale from GetUserInfoResult. This fix fetches and caches GetUserInfoResult when the user logs in to address the issue.