### PR TITLE
Fix for issue #723

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/AbstractAction.java
+++ b/src/main/java/com/salesforce/dataloader/action/AbstractAction.java
@@ -233,7 +233,7 @@ abstract class AbstractAction implements IAction {
         if (filename == null || filename.length() == 0)
             throw new DataAccessObjectInitializationException(getMessage("errorMissingErrorFile"));
         // TODO: Make sure that specific DAO is not mentioned: use DataReader, DataWriter, or DataAccessObject
-        return new CSVFileWriter(filename, getConfig());
+        return new CSVFileWriter(filename, getConfig(), ",");
     }
 
     /**
@@ -245,7 +245,7 @@ abstract class AbstractAction implements IAction {
         if (filename == null || filename.length() == 0)
             throw new DataAccessObjectInitializationException(getMessage("errorMissingSuccessFile"));
         // TODO: Make sure that specific DAO is not mentioned: use DataReader, DataWriter, or DataAccessObject
-        return new CSVFileWriter(filename, getConfig());
+        return new CSVFileWriter(filename, getConfig(), ",");
     }
 
     private void openErrorWriter(List<String> headers) throws OperationException {

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -204,6 +204,7 @@ public class Config {
     public static final String CSV_DELIMETER_TAB = "loader.csvTab";
     public static final String CSV_DELIMETER_OTHER = "loader.csvOther";
     public static final String CSV_DELIMETER_OTHER_VALUE = "loader.csvOtherValue";
+    public static final String CSV_DELIMITER_FOR_QUERY_RESULTS = "loader.query.delimiter";
     public static final String BUFFER_UNPROCESSED_BULK_QUERY_RESULTS = "loader.bufferUnprocessedBulkQueryResults";
 
     //Special Internal Configs
@@ -515,6 +516,7 @@ public class Config {
         setDefaultValue(CSV_DELIMETER_TAB, true);
         setDefaultValue(CSV_DELIMETER_OTHER, false);
         setDefaultValue(CSV_DELIMETER_OTHER_VALUE, "-");
+        setDefaultValue(CSV_DELIMITER_FOR_QUERY_RESULTS, ",");
 
         setDefaultValue(ENDPOINT, DEFAULT_ENDPOINT_URL);
         setDefaultValue(LOAD_BATCH_SIZE, useBulkApiByDefault() ? DEFAULT_BULK_API_BATCH_SIZE : DEFAULT_LOAD_BATCH_SIZE);

--- a/src/main/java/com/salesforce/dataloader/dao/DataAccessObjectFactory.java
+++ b/src/main/java/com/salesforce/dataloader/dao/DataAccessObjectFactory.java
@@ -52,9 +52,9 @@ public class DataAccessObjectFactory {
         logger.info(Messages.getFormattedString("DataAccessObjectFactory.creatingDao", new String[] {config.getString(Config.DAO_NAME), daoType}));
 
         if (CSV_READ_TYPE.equalsIgnoreCase(daoType)) {
-            dao = new CSVFileReader(config);
+            dao = new CSVFileReader(config, false);
         } else if (CSV_WRITE_TYPE.equalsIgnoreCase(daoType)) {
-            dao = new CSVFileWriter(config.getString(Config.DAO_NAME), config);
+            dao = new CSVFileWriter(config.getString(Config.DAO_NAME), config, config.getString(Config.CSV_DELIMITER_FOR_QUERY_RESULTS));
         } else if (DATABASE_READ_TYPE.equalsIgnoreCase(daoType)) {
             dao = new DatabaseReader(config);
         } else if (DATABASE_WRITE_TYPE.equalsIgnoreCase(daoType)) {

--- a/src/main/java/com/salesforce/dataloader/dao/csv/CSVColumnVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/dao/csv/CSVColumnVisitor.java
@@ -48,13 +48,15 @@ public class CSVColumnVisitor {
     private static final char EQUAL = '=';
 
     private Writer writer;
+    private char columnDelimiter = COMMA;
 
     //logger
     private static Logger logger = LogManager.getLogger(CSVColumnVisitor.class);
 
-    public CSVColumnVisitor(Writer writer, boolean escapeFormulaValue) {
+    public CSVColumnVisitor(Writer writer, boolean escapeFormulaValue, char columnDelimiter) {
         this.writer = writer;
         this.escapeFormulaValue = escapeFormulaValue;
+        this.columnDelimiter = columnDelimiter;
     }
 
     public void newRow() {
@@ -68,7 +70,7 @@ public class CSVColumnVisitor {
         }
         try {
             if (!first)
-                writer.write(COMMA);
+                writer.write(this.columnDelimiter);
             else
                 first = false;
 

--- a/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileWriter.java
+++ b/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileWriter.java
@@ -74,12 +74,19 @@ public class CSVFileWriter implements DataWriter {
      * If <code>capitalizedHeadings</code> is true, output header row in caps
      */
     private final boolean capitalizedHeadings;
+    private final char columnDelimiter;
+        
+    public CSVFileWriter(String fileName, Config config, String columnDelimiterStr) {
 
-    public CSVFileWriter(String fileName, Config config) {
         this.fileName = fileName;
         this.capitalizedHeadings = true;
         encoding = config.getCsvEncoding(true);
         logger.debug(this.getClass().getName(), "encoding used to write to CSV file is " + encoding);
+        
+        if (columnDelimiterStr.length() == 0) {
+            columnDelimiterStr = ",";
+        }
+        this.columnDelimiter = columnDelimiterStr.charAt(0);
     }
 
     /**
@@ -137,7 +144,7 @@ public class CSVFileWriter implements DataWriter {
     }
 
     private void writeHeaderRow() throws DataAccessObjectInitializationException {
-        CSVColumnVisitor visitor = new CSVColumnVisitor(fileOut, false);
+        CSVColumnVisitor visitor = new CSVColumnVisitor(fileOut, false, this.columnDelimiter);
         try {
             visitHeaderColumns(this.columnNames, visitor);
             fileOut.newLine();
@@ -155,7 +162,7 @@ public class CSVFileWriter implements DataWriter {
      */
     @Override
     public boolean writeRow(Row row) throws DataAccessObjectException {
-        CSVColumnVisitor visitor = new CSVColumnVisitor(fileOut, false);
+        CSVColumnVisitor visitor = new CSVColumnVisitor(fileOut, false, this.columnDelimiter);
         try {
             visitColumns(columnNames, row, visitor);
             fileOut.newLine();

--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -76,6 +76,7 @@ public class AdvancedSettingsDialog extends Dialog {
     private Text textBatch;
     private Text textQueryBatch;
     private Text textSplitterValue;
+    private Text queryResultsDelimiterValue;
     private Button buttonNulls;
     private Text textRule;
     private Text textEndpoint;
@@ -495,6 +496,17 @@ public class AdvancedSettingsDialog extends Dialog {
         data = new GridData();
         data.widthHint = 15 * textSize.x;
         textSplitterValue.setLayoutData(data);
+
+        Label labelQueryResultsDelimiter = new Label(restComp, SWT.RIGHT | SWT.WRAP);
+        labelQueryResultsDelimiter.setText(Labels.getString("AdvancedSettingsDialog.queryResultsDelimiterValue"));
+        data = new GridData(GridData.HORIZONTAL_ALIGN_END);
+        labelQueryResultsDelimiter.setLayoutData(data);
+        queryResultsDelimiterValue = new Text(restComp, SWT.BORDER);
+        queryResultsDelimiterValue.setText(config.getString(Config.CSV_DELIMITER_FOR_QUERY_RESULTS));
+        queryResultsDelimiterValue.setTextLimit(1);
+        data = new GridData();
+        data.widthHint = 5 * textSize.x;
+        queryResultsDelimiterValue.setLayoutData(data);
         
         // Enable Bulk API Setting
         Label labelUseBulkApi = new Label(restComp, SWT.RIGHT | SWT.WRAP);
@@ -796,6 +808,11 @@ public class AdvancedSettingsDialog extends Dialog {
                     return;
                 }
                 config.setValue(Config.CSV_DELIMETER_OTHER_VALUE, textSplitterValue.getText());
+                String queryResultsDelimiterStr = queryResultsDelimiterValue.getText();
+                if (queryResultsDelimiterStr.length() == 0) {
+                    queryResultsDelimiterStr = ","; // set to default
+                }
+                config.setValue(Config.CSV_DELIMITER_FOR_QUERY_RESULTS, queryResultsDelimiterStr);
                 config.setValue(Config.CSV_DELIMETER_COMMA, buttonCsvComma.getSelection());
                 config.setValue(Config.CSV_DELIMETER_TAB, buttonCsvTab.getSelection());
                 config.setValue(Config.CSV_DELIMETER_OTHER, buttonCsvOther.getSelection());

--- a/src/main/java/com/salesforce/dataloader/ui/CSVChooserDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/CSVChooserDialog.java
@@ -239,9 +239,8 @@ public class CSVChooserDialog extends Dialog {
                 FileDialog dlg = new FileDialog(shell, SWT.OPEN);
                 String fn = dlg.open();
                 if (fn != null) {
-                    openViewer(fn, true);
+                    openViewer(fn, false, false);
                 }
-
             }
         });
 
@@ -257,7 +256,7 @@ public class CSVChooserDialog extends Dialog {
             public void widgetSelected(SelectionEvent event) {
                 String successFilePath = controller.getConfig().getString(Config.OUTPUT_SUCCESS);
                 if(StringUtils.hasText(successFilePath)) {
-                    openViewer(successFilePath, false);
+                    openViewer(successFilePath, true, false);
                 } else {
                     UIUtils.infoMessageBox(shell, Messages.getString("CSVChooser.noSucessOrErrorFile"));
                 }
@@ -276,7 +275,7 @@ public class CSVChooserDialog extends Dialog {
             public void widgetSelected(SelectionEvent event) {
                 String errorFilePath = controller.getConfig().getString(Config.OUTPUT_ERROR);
                 if(StringUtils.hasText(errorFilePath)) {
-                    openViewer(errorFilePath, false);
+                    openViewer(errorFilePath, true, false);
                 } else {
                     UIUtils.infoMessageBox(shell, Messages.getString("CSVChooser.noSucessOrErrorFile"));
                 }
@@ -321,11 +320,11 @@ public class CSVChooserDialog extends Dialog {
         shell.setDefaultButton(ok);
     }
 
-    private void openViewer(String filename, boolean useCustomSplitter) {
-        CSVViewerDialog dlg = new CSVViewerDialog(getParent(), controller);
+    private void openViewer(String filename, boolean ignoreDelimiterConfig, boolean isQueryOperationResult) {
+        // 
+        CSVViewerDialog dlg = new CSVViewerDialog(getParent(), controller, ignoreDelimiterConfig, isQueryOperationResult);
         dlg.setNumberOfRows(Integer.parseInt(textRows.getText()));
         dlg.setFileName(filename);
-        dlg.setUseCustomSplitter(useCustomSplitter);
         try {
             dlg.open();
         } catch (DataAccessObjectInitializationException e) {

--- a/src/main/java/com/salesforce/dataloader/ui/CSVViewerDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/CSVViewerDialog.java
@@ -26,6 +26,7 @@
 
 package com.salesforce.dataloader.ui;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -69,17 +70,13 @@ public class CSVViewerDialog extends Dialog {
 
     private Logger logger = LogManager.getLogger(CSVViewerDialog.class);
     private String filename;
-    private boolean useCustomSplitter = false;
+    private final boolean ignoreDelimiterConfig;
+    private final boolean isQueryOperationResult;
     private int numberOfRows;
 
     //the two tableViewers
     private TableViewer csvTblViewer;
     private final Controller controller;
-
-    public void setUseCustomSplitter(boolean useCustomSplitter)
-    {
-        this.useCustomSplitter = useCustomSplitter;
-    }
 
     public void setFileName(String filename) {
         this.filename = filename;
@@ -91,23 +88,16 @@ public class CSVViewerDialog extends Dialog {
 
     /**
      * @param parent
-     */
-    public CSVViewerDialog(Shell parent, Controller controller) {
-        // Pass the default styles here
-        this(parent, SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL | SWT.MAX | SWT.MIN, controller);
-    }
-
-    /**
-     * @param parent
      *            the parent
      * @param style
      *            the style
      */
-    public CSVViewerDialog(Shell parent, int style, Controller controller) {
-        // Let users override the default styles
-        super(parent, style);
+    public CSVViewerDialog(Shell parent, Controller controller, boolean ignoreDelimiterConfig, boolean isQueryOperationResult) {
+        super(parent, SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL | SWT.MAX | SWT.MIN);
         setText(Labels.getString("CSVViewer.title")); //$NON-NLS-1$
         this.controller = controller;
+        this.ignoreDelimiterConfig = ignoreDelimiterConfig;
+        this.isQueryOperationResult = isQueryOperationResult;
     }
 
     /**
@@ -250,9 +240,10 @@ public class CSVViewerDialog extends Dialog {
 
     private void initializeCSVViewer(Shell shell) throws DataAccessObjectInitializationException {
         GridData data;
-
-        CSVFileReader csvReader = new CSVFileReader(filename, controller, useCustomSplitter);
-
+        
+        // use delimiter settings for load operations by specifying 'false' for isQueryOperationResult param
+        CSVFileReader csvReader = new CSVFileReader(new File(filename),
+                                        controller.getConfig(), ignoreDelimiterConfig, isQueryOperationResult);
         try {
             csvReader.open();
 

--- a/src/main/java/com/salesforce/dataloader/ui/LoadFinishDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/LoadFinishDialog.java
@@ -193,10 +193,9 @@ public class LoadFinishDialog extends Dialog {
     }
 
     private void openViewer(String filename) {
-        CSVViewerDialog dlg = new CSVViewerDialog(getParent(), controller);
+        CSVViewerDialog dlg = new CSVViewerDialog(getParent(), controller, false, false);
         dlg.setNumberOfRows(200000);
         dlg.setFileName(filename);
-        dlg.setUseCustomSplitter(false);
         try {
             dlg.open();
         } catch (DataAccessObjectInitializationException e) {

--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionFinishDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionFinishDialog.java
@@ -206,8 +206,7 @@ public class ExtractionFinishDialog extends Dialog {
     }
 
     private void openViewer(String filename) {
-        CSVViewerDialog dlg = new CSVViewerDialog(getParent(), controller);
-        dlg.setUseCustomSplitter(false);
+        CSVViewerDialog dlg = new CSVViewerDialog(getParent(), controller, false, true);
         dlg.setNumberOfRows(200000);
         dlg.setFileName(filename);
         try {

--- a/src/main/resources/labels.properties
+++ b/src/main/resources/labels.properties
@@ -91,6 +91,7 @@ AdvancedSettingsDialog.useCommaAsCsvDelimiter=Allow comma as a CSV delimiter for
 AdvancedSettingsDialog.useTabAsCsvDelimiter=Allow Tab as a CSV delimiter for load operations:
 AdvancedSettingsDialog.useOtherAsCsvDelimiter=Allow other characters as CSV delimiters for load operations:
 AdvancedSettingsDialog.csvOtherDelimiterValue=Other Delimiters for load operations\n(enter multiple values with no separator; for example, !+?):
+AdvancedSettingsDialog.queryResultsDelimiterValue=Delimiter for query results:
 AdvancedSettingsDialog.escapeFormulaInFieldValue=Escape formula values in exported results with a single-quote character:
 AdvancedSettingsDialog.loginFromBrowser=Enable OAuth login from browser:
 AdvancedSettingsDialog.clientIdInProduction=Client ID in Production:

--- a/src/test/java/com/salesforce/dataloader/process/BulkCsvProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/BulkCsvProcessTest.java
@@ -121,7 +121,7 @@ public class BulkCsvProcessTest extends ProcessTestBase {
 
         CSVFileWriter writer = null;
         try {
-            writer = new CSVFileWriter(CSV_FILE_PATH, getController().getConfig());
+            writer = new CSVFileWriter(CSV_FILE_PATH, getController().getConfig(), ",");
             writer.open();
             writer.setColumnNames(new ArrayList<String>(rows[0].keySet()));
             writer.writeRowList(Arrays.asList(rows));

--- a/src/test/java/com/salesforce/dataloader/process/CsvProcessWithOffsetTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvProcessWithOffsetTest.java
@@ -221,7 +221,7 @@ public class CsvProcessWithOffsetTest extends ProcessTestBase {
 
     private CSVFileReader openConfiguredPath(Config cfg, String configSetting)
             throws DataAccessObjectInitializationException {
-        final CSVFileReader rdr = new CSVFileReader(new File(cfg.getString(configSetting)), cfg);
+        final CSVFileReader rdr = new CSVFileReader(new File(cfg.getString(configSetting)), cfg, false, false);
         rdr.open();
         return rdr;
     }

--- a/src/test/java/com/salesforce/dataloader/process/NAProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/NAProcessTest.java
@@ -210,7 +210,7 @@ public class NAProcessTest extends ProcessTestBase {
     }
 
     private String getCsvFieldValue(String csvFile, String fieldName) throws Exception {
-        CSVFileReader reader = new CSVFileReader(csvFile, getController(), false);
+        CSVFileReader reader = new CSVFileReader(csvFile, getController());
         reader.open();
         assertEquals(1, reader.getTotalRows());
         String fieldValue = (String)reader.readRow().get(fieldName);
@@ -256,7 +256,7 @@ public class NAProcessTest extends ProcessTestBase {
 
         CSVFileWriter writer = null;
         try {
-            writer = new CSVFileWriter(CSV_FILE_PATH, getController().getConfig());
+            writer = new CSVFileWriter(CSV_FILE_PATH, getController().getConfig(), ",");
             writer.open();
             writer.setColumnNames(new ArrayList<String>(row.keySet()));
             writer.writeRow(row);

--- a/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
@@ -643,7 +643,7 @@ public abstract class ProcessTestBase extends ConfigTestBase {
                 idx++;
             }
             final String inputPath = new File(getTestDataDir(), inputFileName).getAbsolutePath();
-            final CSVFileWriter inputWriter = new CSVFileWriter(inputPath, getController().getConfig());
+            final CSVFileWriter inputWriter = new CSVFileWriter(inputPath, getController().getConfig(), ",");
             try {
                 inputWriter.open();
                 inputWriter.setColumnNames(templateReader.getColumnNames());


### PR DESCRIPTION
Fix for issue #723
- add property "loader.query.delimiter"
- enable its setting in "Advanced Settings" dialog with a text field labeled "Delimiter for query results:" that's set by default to comma character.
- delimiter for success and failure results csv files continues to be hardcoded as comma character.