### PR TITLE
log the server API invocation count when exiting

### DIFF
--- a/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
@@ -70,7 +70,6 @@ public class DataLoaderRunner extends Thread {
     public void run() {
         // called just before the program closes
         HttpClientTransport.closeConnections();
-        logger.debug("Number of server API invocations = " + HttpClientTransport.getServerInvocationCount());
     }
     
     private static void extractInstallationArtifacts() {
@@ -82,7 +81,11 @@ public class DataLoaderRunner extends Thread {
     }
 
     public static void main(String[] args) {
-        runApp(args, null);
+        try {
+            runApp(args, null);
+        } finally {
+            logger.debug("Number of server API invocations = " + HttpClientTransport.getServerInvocationCount());
+        }
     }
     
     public static IProcess runApp(String[] args, ILoaderProgress monitor) {


### PR DESCRIPTION
log the server API invocation count when exiting in main() method instead of the shutdown hook because logger is null in the shutdown hook, resulting in a NPE.