### PR TITLE
minor code cleanup

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/AbstractAction.java
+++ b/src/main/java/com/salesforce/dataloader/action/AbstractAction.java
@@ -47,6 +47,7 @@ import com.salesforce.dataloader.exception.LoadException;
 import com.salesforce.dataloader.exception.MappingInitializationException;
 import com.salesforce.dataloader.exception.OperationException;
 import com.salesforce.dataloader.exception.ParameterLoadException;
+import com.salesforce.dataloader.util.AppUtil;
 import com.sforce.async.AsyncApiException;
 import com.sforce.soap.partner.fault.ApiFault;
 import com.sforce.ws.ConnectionException;
@@ -233,7 +234,7 @@ abstract class AbstractAction implements IAction {
         if (filename == null || filename.length() == 0)
             throw new DataAccessObjectInitializationException(getMessage("errorMissingErrorFile"));
         // TODO: Make sure that specific DAO is not mentioned: use DataReader, DataWriter, or DataAccessObject
-        return new CSVFileWriter(filename, getConfig(), ",");
+        return new CSVFileWriter(filename, getConfig(), AppUtil.COMMA);
     }
 
     /**
@@ -245,7 +246,7 @@ abstract class AbstractAction implements IAction {
         if (filename == null || filename.length() == 0)
             throw new DataAccessObjectInitializationException(getMessage("errorMissingSuccessFile"));
         // TODO: Make sure that specific DAO is not mentioned: use DataReader, DataWriter, or DataAccessObject
-        return new CSVFileWriter(filename, getConfig(), ",");
+        return new CSVFileWriter(filename, getConfig(), AppUtil.COMMA);
     }
 
     private void openErrorWriter(List<String> headers) throws OperationException {

--- a/src/main/java/com/salesforce/dataloader/action/AbstractExtractAction.java
+++ b/src/main/java/com/salesforce/dataloader/action/AbstractExtractAction.java
@@ -38,6 +38,7 @@ import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.dao.*;
 import com.salesforce.dataloader.exception.*;
 import com.salesforce.dataloader.mapping.SOQLMapper;
+import com.salesforce.dataloader.util.AppUtil;
 
 /**
  * Parent class for all extract dataloader actions.
@@ -99,7 +100,7 @@ abstract class AbstractExtractAction extends AbstractAction {
         }
 
         // normalize the SOQL string and find the field list
-        final String trimmedSoql = soql.trim().replaceAll("[\\s]*,[\\s]*", ",");
+        final String trimmedSoql = soql.trim().replaceAll("[\\s]*,[\\s]*", AppUtil.COMMA);
         final String upperSOQL = trimmedSoql.toUpperCase();
         final int selectPos = upperSOQL.indexOf("SELECT ");
         if (selectPos == -1) {
@@ -112,7 +113,7 @@ abstract class AbstractExtractAction extends AbstractAction {
 
         try {
             final String fieldString = trimmedSoql.substring(fieldListStart, fieldListEnd).trim();
-            final String[] fields = fieldString.split(","); //$NON-NLS-1$
+            final String[] fields = fieldString.split(AppUtil.COMMA); //$NON-NLS-1$
             return new ArrayList<String>(Arrays.asList(fields));
         } catch (final Exception e) {
             String errMsg;

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -200,10 +200,10 @@ public class Config {
     public static final String HIDE_WELCOME_SCREEN = "loader.hideWelcome";
 
     // Delimiter settings
-    public static final String CSV_DELIMETER_COMMA = "loader.csvComma";
-    public static final String CSV_DELIMETER_TAB = "loader.csvTab";
-    public static final String CSV_DELIMETER_OTHER = "loader.csvOther";
-    public static final String CSV_DELIMETER_OTHER_VALUE = "loader.csvOtherValue";
+    public static final String CSV_DELIMITER_COMMA = "loader.csvComma";
+    public static final String CSV_DELIMITER_TAB = "loader.csvTab";
+    public static final String CSV_DELIMITER_OTHER = "loader.csvOther";
+    public static final String CSV_DELIMITER_OTHER_VALUE = "loader.csvOtherValue";
     public static final String CSV_DELIMITER_FOR_QUERY_RESULTS = "loader.query.delimiter";
     public static final String BUFFER_UNPROCESSED_BULK_QUERY_RESULTS = "loader.bufferUnprocessedBulkQueryResults";
 
@@ -512,11 +512,11 @@ public class Config {
     private void setDefaults() {
         setDefaultValue(HIDE_WELCOME_SCREEN, true);
 
-        setDefaultValue(CSV_DELIMETER_COMMA, true);
-        setDefaultValue(CSV_DELIMETER_TAB, true);
-        setDefaultValue(CSV_DELIMETER_OTHER, false);
-        setDefaultValue(CSV_DELIMETER_OTHER_VALUE, "-");
-        setDefaultValue(CSV_DELIMITER_FOR_QUERY_RESULTS, ",");
+        setDefaultValue(CSV_DELIMITER_COMMA, true);
+        setDefaultValue(CSV_DELIMITER_TAB, true);
+        setDefaultValue(CSV_DELIMITER_OTHER, false);
+        setDefaultValue(CSV_DELIMITER_OTHER_VALUE, "-");
+        setDefaultValue(CSV_DELIMITER_FOR_QUERY_RESULTS, AppUtil.COMMA);
 
         setDefaultValue(ENDPOINT, DEFAULT_ENDPOINT_URL);
         setDefaultValue(LOAD_BATCH_SIZE, useBulkApiByDefault() ? DEFAULT_BULK_API_BATCH_SIZE : DEFAULT_LOAD_BATCH_SIZE);
@@ -553,7 +553,7 @@ public class Config {
         setDefaultValue(OAUTH_SERVER, DEFAULT_ENDPOINT_URL);
         setDefaultValue(OAUTH_REDIRECTURI, DEFAULT_ENDPOINT_URL);
         setDefaultValue(OAUTH_ENVIRONMENT, OAUTH_PROD_ENVIRONMENT_VAL);
-        setDefaultValue(OAUTH_ENVIRONMENTS, OAUTH_PROD_ENVIRONMENT_VAL + "," + OAUTH_SB_ENVIRONMENT_VAL);
+        setDefaultValue(OAUTH_ENVIRONMENTS, OAUTH_PROD_ENVIRONMENT_VAL + AppUtil.COMMA + OAUTH_SB_ENVIRONMENT_VAL);
 
         /* sfdc.oauth.<env>.<bulk | partner>.clientid = DataLoaderBulkUI | DataLoaderPartnerUI */
         setDefaultValue(OAUTH_PREFIX + OAUTH_PROD_ENVIRONMENT_VAL + "." + OAUTH_PARTIAL_BULK_CLIENTID, OAUTH_BULK_CLIENTID_VAL);
@@ -722,7 +722,7 @@ public class Config {
         String values = getString(name);
         ArrayList<String> list = new ArrayList<>();
         if (values != null && !values.trim().isEmpty()) {
-            Collections.addAll(list, values.trim().split(","));
+            Collections.addAll(list, values.trim().split(AppUtil.COMMA));
         }
         return list;
     }
@@ -795,7 +795,7 @@ public class Config {
         String value = getParamValue(name);
         if (value == null || value.length() == 0) return MAP_STRING_DEFAULT;
         Map<String, String> mval = new HashMap<String, String>();
-        String[] pairs = value.split(",");
+        String[] pairs = value.split(AppUtil.COMMA);
         for (String pair : pairs) {
             String[] nameValue = pair.split("=");
             if (nameValue.length != 2) {
@@ -1211,7 +1211,7 @@ public class Config {
         for (String key : valueMap.keySet()) {
             // add comma for subsequent entries
             if (sb.length() != 0) {
-                sb.append(",");
+                sb.append(AppUtil.COMMA);
             }
             sb.append(key + "=" + valueMap.get(key));
         }
@@ -1264,7 +1264,7 @@ public class Config {
     
     private void setValue(String name,  boolean skipIfAlreadySet, String... values) {
         if (values != null && values.length > 1) {
-            StringJoiner joiner = new StringJoiner(",");
+            StringJoiner joiner = new StringJoiner(AppUtil.COMMA);
             for (String value : values) {
                 joiner.add(value);
             }

--- a/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileReader.java
@@ -49,6 +49,7 @@ import com.salesforce.dataloader.exception.DataAccessObjectException;
 import com.salesforce.dataloader.exception.DataAccessObjectInitializationException;
 import com.salesforce.dataloader.exception.DataAccessRowException;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.util.AppUtil;
 import com.salesforce.dataloader.util.DAORowUtil;
 import com.sforce.async.CSVReader;
 
@@ -93,22 +94,22 @@ public class CSVFileReader implements DataReader {
         this.config = config;
         StringBuilder separator = new StringBuilder();
         if (ignoreDelimiterConfig) {
-            separator.append(",");
+            separator.append(AppUtil.COMMA);
             LOGGER.debug(Messages.getString("CSVFileDAO.debugMessageCommaSeparator"));            
         } else {
             if (isQueryOperationResult) {
                 separator.append(config.getString(Config.CSV_DELIMITER_FOR_QUERY_RESULTS));
             } else { // reading CSV for a load operation
-                if (config.getBoolean(Config.CSV_DELIMETER_COMMA)) {
-                    separator.append(",");
+                if (config.getBoolean(Config.CSV_DELIMITER_COMMA)) {
+                    separator.append(AppUtil.COMMA);
                     LOGGER.debug(Messages.getString("CSVFileDAO.debugMessageCommaSeparator"));
                 }
-                if (config.getBoolean(Config.CSV_DELIMETER_TAB)) {
-                    separator.append("\t");
+                if (config.getBoolean(Config.CSV_DELIMITER_TAB)) {
+                    separator.append(AppUtil.TAB);
                     LOGGER.debug(Messages.getString("CSVFileDAO.debugMessageTabSeparator"));
                 }
-                if (config.getBoolean(Config.CSV_DELIMETER_OTHER)) {
-                    separator.append(config.getString(Config.CSV_DELIMETER_OTHER_VALUE));
+                if (config.getBoolean(Config.CSV_DELIMITER_OTHER)) {
+                    separator.append(config.getString(Config.CSV_DELIMITER_OTHER_VALUE));
                     LOGGER.debug(Messages.getFormattedString("CSVFileDAO.debugMessageSeparatorChar", separator));
                 }
             }

--- a/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileWriter.java
+++ b/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileWriter.java
@@ -43,6 +43,7 @@ import com.salesforce.dataloader.dao.DataWriter;
 import com.salesforce.dataloader.exception.DataAccessObjectException;
 import com.salesforce.dataloader.exception.DataAccessObjectInitializationException;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.util.AppUtil;
 
 /**
  * Writes csv files.
@@ -84,7 +85,7 @@ public class CSVFileWriter implements DataWriter {
         logger.debug(this.getClass().getName(), "encoding used to write to CSV file is " + encoding);
         
         if (columnDelimiterStr.length() == 0) {
-            columnDelimiterStr = ",";
+            columnDelimiterStr = AppUtil.COMMA;
         }
         this.columnDelimiter = columnDelimiterStr.charAt(0);
     }

--- a/src/main/java/com/salesforce/dataloader/mapping/LoadMapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/LoadMapper.java
@@ -29,6 +29,7 @@ package com.salesforce.dataloader.mapping;
 import com.salesforce.dataloader.client.PartnerClient;
 import com.salesforce.dataloader.exception.MappingInitializationException;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.util.AppUtil;
 import com.sforce.soap.partner.Field;
 
 import org.apache.logging.log4j.Logger;
@@ -91,7 +92,7 @@ public class LoadMapper extends Mapper {
         for (Map.Entry<String, Object> entry : localRow.entrySet()) {
             String sfdcNameList = getMapping(entry.getKey(), true);
             if (StringUtils.hasText(sfdcNameList)) {
-                String sfdcNameArray[] = sfdcNameList.split(",");
+                String sfdcNameArray[] = sfdcNameList.split(AppUtil.COMMA);
                 for (String sfdcName : sfdcNameArray) {
                     mappedData.put(sfdcName.trim(), entry.getValue());
                 }
@@ -107,7 +108,7 @@ public class LoadMapper extends Mapper {
         for (Map.Entry<String, String> entry : getMappingWithUnmappedColumns(false).entrySet()) {
             String sfdcNameList = entry.getValue();
             if(StringUtils.hasText(sfdcNameList)) {
-                String sfdcNameArray[] = sfdcNameList.split(",");
+                String sfdcNameArray[] = sfdcNameList.split(AppUtil.COMMA);
                 for (String sfdcName : sfdcNameArray) {
                     final Field f = getClient().getField(sfdcName.trim());
                     if (f == null)

--- a/src/main/java/com/salesforce/dataloader/mapping/Mapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/Mapper.java
@@ -47,6 +47,7 @@ import com.salesforce.dataloader.client.PartnerClient;
 import com.salesforce.dataloader.config.Messages;
 import com.salesforce.dataloader.exception.MappingInitializationException;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.util.AppUtil;
 
 /**
  * Base class for field name mappers. Used by data loader operations to map between local field names and sfdc field
@@ -108,7 +109,7 @@ public abstract class Mapper {
 
     public final void putMapping(String src, String dest) {
         // destination can be multiple field names for upload operations
-        StringTokenizer st = new StringTokenizer(dest, ",");
+        StringTokenizer st = new StringTokenizer(dest, AppUtil.COMMA);
         String originalDestList = null;
         while(st.hasMoreElements()) {
             String v = st.nextToken();
@@ -128,7 +129,7 @@ public abstract class Mapper {
     }
 
     private void handleMultipleValuesFromConstant(String name, String value) {
-        StringTokenizer st = new StringTokenizer(name, ",");
+        StringTokenizer st = new StringTokenizer(name, AppUtil.COMMA);
         while(st.hasMoreElements()) {
             String v = st.nextToken();
             v = v.trim();

--- a/src/main/java/com/salesforce/dataloader/mapping/SOQLInfo.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/SOQLInfo.java
@@ -29,6 +29,8 @@ package com.salesforce.dataloader.mapping;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.salesforce.dataloader.util.AppUtil;
+
 /**
  * Class to parse information used by DataLoader from a soql expression
  * 
@@ -135,7 +137,7 @@ class SOQLInfo {
 
         String rawFields = soql.substring(SELECT_KEYWORD.length(), fromIdx).trim();
         AtomicInteger aggIdx = new AtomicInteger();
-        for (String fieldString : rawFields.split(",")) {
+        for (String fieldString : rawFields.split(AppUtil.COMMA)) {
             SOQLFieldInfo soqlFieldInfo = new SOQLFieldInfo(fieldString, aggIdx);
             this.selectedFields.add(soqlFieldInfo);
         }

--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -471,28 +471,28 @@ public class AdvancedSettingsDialog extends Dialog {
         data = new GridData(GridData.HORIZONTAL_ALIGN_END);
         labelCsvCommand.setLayoutData(data);
         buttonCsvComma = new Button(restComp, SWT.CHECK);
-        buttonCsvComma.setSelection(config.getBoolean(Config.CSV_DELIMETER_COMMA));
+        buttonCsvComma.setSelection(config.getBoolean(Config.CSV_DELIMITER_COMMA));
 
         Label labelTabCommand = new Label(restComp, SWT.RIGHT | SWT.WRAP);
         labelTabCommand.setText(Labels.getString("AdvancedSettingsDialog.useTabAsCsvDelimiter"));
         data = new GridData(GridData.HORIZONTAL_ALIGN_END);
         labelTabCommand.setLayoutData(data);
         buttonCsvTab = new Button(restComp, SWT.CHECK);
-        buttonCsvTab.setSelection(config.getBoolean(Config.CSV_DELIMETER_TAB));
+        buttonCsvTab.setSelection(config.getBoolean(Config.CSV_DELIMITER_TAB));
 
         Label labelOtherCommand = new Label(restComp, SWT.RIGHT | SWT.WRAP);
         labelOtherCommand.setText(Labels.getString("AdvancedSettingsDialog.useOtherAsCsvDelimiter"));
         data = new GridData(GridData.HORIZONTAL_ALIGN_END);
         labelOtherCommand.setLayoutData(data);
         buttonCsvOther = new Button(restComp, SWT.CHECK);
-        buttonCsvOther.setSelection(config.getBoolean(Config.CSV_DELIMETER_OTHER));
+        buttonCsvOther.setSelection(config.getBoolean(Config.CSV_DELIMITER_OTHER));
 
         Label labelOtherDelimiterValue = new Label(restComp, SWT.RIGHT | SWT.WRAP);
         labelOtherDelimiterValue.setText(Labels.getString("AdvancedSettingsDialog.csvOtherDelimiterValue"));
         data = new GridData(GridData.HORIZONTAL_ALIGN_END);
         labelOtherDelimiterValue.setLayoutData(data);
         textSplitterValue = new Text(restComp, SWT.BORDER);
-        textSplitterValue.setText(config.getString(Config.CSV_DELIMETER_OTHER_VALUE));
+        textSplitterValue.setText(config.getString(Config.CSV_DELIMITER_OTHER_VALUE));
         data = new GridData();
         data.widthHint = 15 * textSize.x;
         textSplitterValue.setLayoutData(data);
@@ -807,15 +807,15 @@ public class AdvancedSettingsDialog extends Dialog {
                         || textSplitterValue.getText().length() == 0)) {
                     return;
                 }
-                config.setValue(Config.CSV_DELIMETER_OTHER_VALUE, textSplitterValue.getText());
+                config.setValue(Config.CSV_DELIMITER_OTHER_VALUE, textSplitterValue.getText());
                 String queryResultsDelimiterStr = queryResultsDelimiterValue.getText();
                 if (queryResultsDelimiterStr.length() == 0) {
-                    queryResultsDelimiterStr = ","; // set to default
+                    queryResultsDelimiterStr = AppUtil.COMMA; // set to default
                 }
                 config.setValue(Config.CSV_DELIMITER_FOR_QUERY_RESULTS, queryResultsDelimiterStr);
-                config.setValue(Config.CSV_DELIMETER_COMMA, buttonCsvComma.getSelection());
-                config.setValue(Config.CSV_DELIMETER_TAB, buttonCsvTab.getSelection());
-                config.setValue(Config.CSV_DELIMETER_OTHER, buttonCsvOther.getSelection());
+                config.setValue(Config.CSV_DELIMITER_COMMA, buttonCsvComma.getSelection());
+                config.setValue(Config.CSV_DELIMITER_TAB, buttonCsvTab.getSelection());
+                config.setValue(Config.CSV_DELIMITER_OTHER, buttonCsvOther.getSelection());
 
                 config.setValue(Config.EXTRACT_REQUEST_SIZE, textQueryBatch.getText());
                 config.setValue(Config.ENDPOINT, currentTextEndpoint);

--- a/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
@@ -51,6 +51,7 @@ import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.mapping.LoadMapper;
 import com.salesforce.dataloader.ui.mapping.*;
+import com.salesforce.dataloader.util.AppUtil;
 import com.sforce.soap.partner.Field;
 
 /**
@@ -583,7 +584,7 @@ public class MappingDialog extends Dialog {
     }
 
     public void replenishMappedSforceFields(String fieldNameList) {
-        String[] fieldNameListArray = fieldNameList.split(",");
+        String[] fieldNameListArray = fieldNameList.split(AppUtil.COMMA);
         ArrayList<Field> fieldList = new ArrayList<Field>(Arrays.asList(this.sforceFields));
         for (String fieldNameToReplenish : fieldNameListArray) {
             fieldNameToReplenish = fieldNameToReplenish.strip();

--- a/src/main/java/com/salesforce/dataloader/util/AppUtil.java
+++ b/src/main/java/com/salesforce/dataloader/util/AppUtil.java
@@ -74,7 +74,8 @@ public class AppUtil {
         INSTALL,
         ENCRYPT
     }
-    
+    public static final String COMMA = ",";
+    public static final String TAB = "\t";
     public static final String DATALOADER_VERSION;
     public static final String DATALOADER_SHORT_VERSION;
     public static final String MIN_JAVA_VERSION;

--- a/src/main/java/com/salesforce/dataloader/util/ExceptionUtil.java
+++ b/src/main/java/com/salesforce/dataloader/util/ExceptionUtil.java
@@ -36,7 +36,7 @@ public class ExceptionUtil {
         StringBuilder stackTrace = new StringBuilder();
         if (e.getStackTrace() != null) {
             for (StackTraceElement elem : e.getStackTrace()) {
-                stackTrace.append("\t" + elem.toString() + "\n");
+                stackTrace.append(AppUtil.TAB + elem.toString() + "\n");
             }
         }
         return stackTrace.toString();

--- a/src/test/java/com/salesforce/dataloader/dao/CsvTest.java
+++ b/src/test/java/com/salesforce/dataloader/dao/CsvTest.java
@@ -37,6 +37,7 @@ import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.dao.csv.CSVFileReader;
 import com.salesforce.dataloader.dao.csv.CSVFileWriter;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.util.AppUtil;
 
 import org.junit.Assert;
 
@@ -121,7 +122,7 @@ public class CsvTest extends ConfigTestBase {
 
     @Test
     public void testCSVWriteBasic() throws Exception {
-        doTestCSVWriteBasic(",");
+        doTestCSVWriteBasic(AppUtil.COMMA);
     }
     
     @Test
@@ -136,7 +137,7 @@ public class CsvTest extends ConfigTestBase {
     
     @Test
     public void testCSVWriteBasicWithTabDelimiter() throws Exception {
-        doTestCSVWriteBasic("   ");
+        doTestCSVWriteBasic(AppUtil.TAB);
     }
     
     private void doTestCSVWriteBasic(String delimiter) throws Exception {
@@ -229,22 +230,22 @@ public class CsvTest extends ConfigTestBase {
             storedDelimiter = config.getString(Config.CSV_DELIMITER_FOR_QUERY_RESULTS);
             config.setValue(Config.CSV_DELIMITER_FOR_QUERY_RESULTS, delimiterStr);
         } else {
-            storedDelimiter = config.getString(Config.CSV_DELIMETER_OTHER_VALUE);
-            storedCsvDelimiterComma = config.getBoolean(Config.CSV_DELIMETER_COMMA);
-            storedCsvDelimiterTab = config.getBoolean(Config.CSV_DELIMETER_TAB);
-            storedCsvDelimiterOther = config.getBoolean(Config.CSV_DELIMETER_OTHER);
-            config.setValue(Config.CSV_DELIMETER_COMMA, false);
-            config.setValue(Config.CSV_DELIMETER_TAB, false);
-            config.setValue(Config.CSV_DELIMETER_OTHER, false);
-            config.setValue(Config.CSV_DELIMETER_OTHER_VALUE, delimiterStr);
-            if (",".equals(delimiterStr)) {
-                config.setValue(Config.CSV_DELIMETER_COMMA, true);
+            storedDelimiter = config.getString(Config.CSV_DELIMITER_OTHER_VALUE);
+            storedCsvDelimiterComma = config.getBoolean(Config.CSV_DELIMITER_COMMA);
+            storedCsvDelimiterTab = config.getBoolean(Config.CSV_DELIMITER_TAB);
+            storedCsvDelimiterOther = config.getBoolean(Config.CSV_DELIMITER_OTHER);
+            config.setValue(Config.CSV_DELIMITER_COMMA, false);
+            config.setValue(Config.CSV_DELIMITER_TAB, false);
+            config.setValue(Config.CSV_DELIMITER_OTHER, false);
+            config.setValue(Config.CSV_DELIMITER_OTHER_VALUE, delimiterStr);
+            if (AppUtil.COMMA.equals(delimiterStr)) {
+                config.setValue(Config.CSV_DELIMITER_COMMA, true);
             } else if ("    ".equals(delimiterStr)) {
-                config.setValue(Config.CSV_DELIMETER_TAB, true);
+                config.setValue(Config.CSV_DELIMITER_TAB, true);
             } else {
-                config.setValue(Config.CSV_DELIMETER_OTHER, true);
-                storedDelimiter = config.getString(Config.CSV_DELIMETER_OTHER_VALUE);
-                config.setValue(Config.CSV_DELIMETER_OTHER_VALUE, delimiterStr);
+                config.setValue(Config.CSV_DELIMITER_OTHER, true);
+                storedDelimiter = config.getString(Config.CSV_DELIMITER_OTHER_VALUE);
+                config.setValue(Config.CSV_DELIMITER_OTHER_VALUE, delimiterStr);
             }
         }
         config.setValue(Config.CSV_DELIMITER_FOR_QUERY_RESULTS, delimiterStr);
@@ -252,7 +253,7 @@ public class CsvTest extends ConfigTestBase {
         try {
             csv.open();
         } catch (Exception e) {
-            assertTrue("Exception reading header row: " + e.getMessage(), ignoreDelimiterConfig && !delimiterStr.equals(","));
+            assertTrue("Exception reading header row: " + e.getMessage(), ignoreDelimiterConfig && !delimiterStr.equals(AppUtil.COMMA));
             csv.close();
             return;
         }
@@ -277,10 +278,10 @@ public class CsvTest extends ConfigTestBase {
         if (isQueryResultsCSV) {
             config.setValue(Config.CSV_DELIMITER_FOR_QUERY_RESULTS, storedDelimiter);
         } else {
-            config.setValue(Config.CSV_DELIMETER_OTHER_VALUE, storedDelimiter);
-            config.setValue(Config.CSV_DELIMETER_COMMA, storedCsvDelimiterComma);
-            config.setValue(Config.CSV_DELIMETER_TAB, storedCsvDelimiterTab);
-            config.setValue(Config.CSV_DELIMETER_OTHER, storedCsvDelimiterOther);
+            config.setValue(Config.CSV_DELIMITER_OTHER_VALUE, storedDelimiter);
+            config.setValue(Config.CSV_DELIMITER_COMMA, storedCsvDelimiterComma);
+            config.setValue(Config.CSV_DELIMITER_TAB, storedCsvDelimiterTab);
+            config.setValue(Config.CSV_DELIMITER_OTHER, storedCsvDelimiterOther);
         }
     }
 }

--- a/src/test/java/com/salesforce/dataloader/process/BulkCsvProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/BulkCsvProcessTest.java
@@ -41,6 +41,7 @@ import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.dao.csv.CSVFileWriter;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.util.AppUtil;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -121,7 +122,7 @@ public class BulkCsvProcessTest extends ProcessTestBase {
 
         CSVFileWriter writer = null;
         try {
-            writer = new CSVFileWriter(CSV_FILE_PATH, getController().getConfig(), ",");
+            writer = new CSVFileWriter(CSV_FILE_PATH, getController().getConfig(), AppUtil.COMMA);
             writer.open();
             writer.setColumnNames(new ArrayList<String>(rows[0].keySet()));
             writer.writeRowList(Arrays.asList(rows));

--- a/src/test/java/com/salesforce/dataloader/process/CsvProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvProcessTest.java
@@ -48,6 +48,7 @@ import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.dao.csv.CSVFileReader;
 import com.salesforce.dataloader.dyna.DateTimeConverter;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.util.AppUtil;
 import com.sforce.soap.partner.sobject.SObject;
 
 import static org.junit.Assert.assertEquals;
@@ -256,7 +257,7 @@ public class CsvProcessTest extends ProcessTestBase {
         // query them and verify that they have the values
         StringBuilder fields = new StringBuilder("id");
         for(String field : accountFieldsToReturn) {
-            fields.append(",").append(field);
+            fields.append(AppUtil.COMMA).append(field);
         }
 
         SObject[] sobjects = getBinding().retrieve(fields.toString(), "Account", ids.toArray(new String[ids.size()]));

--- a/src/test/java/com/salesforce/dataloader/process/NAProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/NAProcessTest.java
@@ -47,6 +47,7 @@ import com.salesforce.dataloader.dao.csv.CSVFileReader;
 import com.salesforce.dataloader.dao.csv.CSVFileWriter;
 import com.salesforce.dataloader.model.NATextValue;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.util.AppUtil;
 import com.sforce.soap.partner.QueryResult;
 import com.sforce.soap.partner.SaveResult;
 import com.sforce.soap.partner.sobject.SObject;
@@ -256,7 +257,7 @@ public class NAProcessTest extends ProcessTestBase {
 
         CSVFileWriter writer = null;
         try {
-            writer = new CSVFileWriter(CSV_FILE_PATH, getController().getConfig(), ",");
+            writer = new CSVFileWriter(CSV_FILE_PATH, getController().getConfig(), AppUtil.COMMA);
             writer.open();
             writer.setColumnNames(new ArrayList<String>(row.keySet()));
             writer.writeRow(row);

--- a/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
@@ -49,6 +49,7 @@ import com.salesforce.dataloader.dao.csv.CSVFileWriter;
 import com.salesforce.dataloader.exception.*;
 import com.salesforce.dataloader.exception.UnsupportedOperationException;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.util.AppUtil;
 import com.salesforce.dataloader.util.Base64;
 import com.sforce.soap.partner.*;
 import com.sforce.soap.partner.fault.ApiFault;
@@ -643,7 +644,7 @@ public abstract class ProcessTestBase extends ConfigTestBase {
                 idx++;
             }
             final String inputPath = new File(getTestDataDir(), inputFileName).getAbsolutePath();
-            final CSVFileWriter inputWriter = new CSVFileWriter(inputPath, getController().getConfig(), ",");
+            final CSVFileWriter inputWriter = new CSVFileWriter(inputPath, getController().getConfig(), AppUtil.COMMA);
             try {
                 inputWriter.open();
                 inputWriter.setColumnNames(templateReader.getColumnNames());


### PR DESCRIPTION
- spelling correction: replace 'DELIMETER'  in constant names by 'DELIMITER'.
- use constant instead of string literal for comma and tab characters.