### PR TITLE
minor cleanup of variable/method names

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -75,8 +75,8 @@ public class AdvancedSettingsDialog extends Dialog {
     private Controller controller;
     private Text textBatch;
     private Text textQueryBatch;
-    private Text textSplitterValue;
-    private Text queryResultsDelimiterValue;
+    private Text textUploadCSVDelimiterValue;
+    private Text textQueryResultsDelimiterValue;
     private Button buttonNulls;
     private Text textRule;
     private Text textEndpoint;
@@ -491,22 +491,22 @@ public class AdvancedSettingsDialog extends Dialog {
         labelOtherDelimiterValue.setText(Labels.getString("AdvancedSettingsDialog.csvOtherDelimiterValue"));
         data = new GridData(GridData.HORIZONTAL_ALIGN_END);
         labelOtherDelimiterValue.setLayoutData(data);
-        textSplitterValue = new Text(restComp, SWT.BORDER);
-        textSplitterValue.setText(config.getString(Config.CSV_DELIMITER_OTHER_VALUE));
+        textUploadCSVDelimiterValue = new Text(restComp, SWT.BORDER);
+        textUploadCSVDelimiterValue.setText(config.getString(Config.CSV_DELIMITER_OTHER_VALUE));
         data = new GridData();
         data.widthHint = 15 * textSize.x;
-        textSplitterValue.setLayoutData(data);
+        textUploadCSVDelimiterValue.setLayoutData(data);
 
         Label labelQueryResultsDelimiter = new Label(restComp, SWT.RIGHT | SWT.WRAP);
         labelQueryResultsDelimiter.setText(Labels.getString("AdvancedSettingsDialog.queryResultsDelimiterValue"));
         data = new GridData(GridData.HORIZONTAL_ALIGN_END);
         labelQueryResultsDelimiter.setLayoutData(data);
-        queryResultsDelimiterValue = new Text(restComp, SWT.BORDER);
-        queryResultsDelimiterValue.setText(config.getString(Config.CSV_DELIMITER_FOR_QUERY_RESULTS));
-        queryResultsDelimiterValue.setTextLimit(1);
+        textQueryResultsDelimiterValue = new Text(restComp, SWT.BORDER);
+        textQueryResultsDelimiterValue.setText(config.getString(Config.CSV_DELIMITER_FOR_QUERY_RESULTS));
+        textQueryResultsDelimiterValue.setTextLimit(1);
         data = new GridData();
         data.widthHint = 5 * textSize.x;
-        queryResultsDelimiterValue.setLayoutData(data);
+        textQueryResultsDelimiterValue.setLayoutData(data);
         
         // Enable Bulk API Setting
         Label labelUseBulkApi = new Label(restComp, SWT.RIGHT | SWT.WRAP);
@@ -803,12 +803,12 @@ public class AdvancedSettingsDialog extends Dialog {
                 if (!buttonCsvComma.getSelection()
                         && !buttonCsvTab.getSelection()
                         && (!buttonCsvOther.getSelection()
-                        || textSplitterValue.getText() == null
-                        || textSplitterValue.getText().length() == 0)) {
+                        || textUploadCSVDelimiterValue.getText() == null
+                        || textUploadCSVDelimiterValue.getText().length() == 0)) {
                     return;
                 }
-                config.setValue(Config.CSV_DELIMITER_OTHER_VALUE, textSplitterValue.getText());
-                String queryResultsDelimiterStr = queryResultsDelimiterValue.getText();
+                config.setValue(Config.CSV_DELIMITER_OTHER_VALUE, textUploadCSVDelimiterValue.getText());
+                String queryResultsDelimiterStr = textQueryResultsDelimiterValue.getText();
                 if (queryResultsDelimiterStr.length() == 0) {
                     queryResultsDelimiterStr = AppUtil.COMMA; // set to default
                 }

--- a/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
+++ b/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
@@ -251,7 +251,7 @@ public class DateConverterTest {
      * @expectedResults Assert that the calendar and the string will evaluate to the same instant.
      */
     @Test
-    public void testNotInDelimeterPattern() {
+    public void testNotInDelimiterPattern() {
 
         // use this as the expected calendar instance
         Calendar expCalDate = Calendar.getInstance(TZ);
@@ -517,7 +517,7 @@ public class DateConverterTest {
      *
      */
     @Test
-    public void testSlashAndNoTDelimeterFormat() {
+    public void testSlashAndNoTDelimiterFormat() {
 
         Calendar expCalDate = Calendar.getInstance(TZ);
 
@@ -543,7 +543,7 @@ public class DateConverterTest {
      *
      */
     @Test
-    public void testSlashWithTimeZoneDelimeterFormat() {
+    public void testSlashWithTimeZoneDelimiterFormat() {
 
         TimeZone wst = TimeZone.getTimeZone("Australia/Perth");
         Calendar calDateWST = Calendar.getInstance(wst);
@@ -551,16 +551,16 @@ public class DateConverterTest {
         calDateWST.clear();
         calDateWST.set(2009, 7 - 1, 16, 12, 14, 45);
 
-        for (String delimeter : new String[] { " ", "T" }) {
+        for (String delimiter : new String[] { " ", "T" }) {
 
             //vanilla cases that don't cross into different days
-            assertValidDate("07/16/2009" + delimeter + "12:14:45+0800", calDateWST,    false);
-            assertValidDate("07/16/2009" + delimeter + "02:14:45-0200", calDateWST, false); // offset case
-            assertValidDate("07/16/2009" + delimeter + "16:14:45+1200", calDateWST, false); // offset case
+            assertValidDate("07/16/2009" + delimiter + "12:14:45+0800", calDateWST,    false);
+            assertValidDate("07/16/2009" + delimiter + "02:14:45-0200", calDateWST, false); // offset case
+            assertValidDate("07/16/2009" + delimiter + "16:14:45+1200", calDateWST, false); // offset case
 
             //cross-day cases
-            assertValidDate("07/16/2009" + delimeter + "03:14:45-0100", calDateWST,    false);
-            assertValidDate("07/16/2009" + delimeter + "12:14:45+0800", calDateWST, false); // offset case
+            assertValidDate("07/16/2009" + delimiter + "03:14:45-0100", calDateWST,    false);
+            assertValidDate("07/16/2009" + delimiter + "12:14:45+0800", calDateWST, false); // offset case
         }
     }
 
@@ -573,7 +573,7 @@ public class DateConverterTest {
      *
      */
     @Test
-    public void testSlashWithTimeZoneDelimeterFormatEuropeanFormat() {
+    public void testSlashWithTimeZoneDelimiterFormatEuropeanFormat() {
 
         TimeZone wst = TimeZone.getTimeZone("Australia/Perth");
         Calendar calDateWST = Calendar.getInstance(wst);
@@ -581,16 +581,16 @@ public class DateConverterTest {
         calDateWST.clear();
         calDateWST.set(2009, 7 - 1, 16, 12, 14, 45);
 
-        for (String delimeter : new String[] { " ", "T" }) {
+        for (String delimiter : new String[] { " ", "T" }) {
 
             //vanilla cases that don't cross into different days
-            assertValidDate("16/07/2009" + delimeter + "12:14:45+0800", calDateWST,    true);
-            assertValidDate("16/07/2009" + delimeter + "02:14:45-0200", calDateWST, true); // offset case
-            assertValidDate("16/07/2009" + delimeter + "16:14:45+1200", calDateWST, true); // offset case
+            assertValidDate("16/07/2009" + delimiter + "12:14:45+0800", calDateWST,    true);
+            assertValidDate("16/07/2009" + delimiter + "02:14:45-0200", calDateWST, true); // offset case
+            assertValidDate("16/07/2009" + delimiter + "16:14:45+1200", calDateWST, true); // offset case
 
             //cross-day cases
-            assertValidDate("16/07/2009" + delimeter + "03:14:45-0100", calDateWST,    true);
-            assertValidDate("16/07/2009" + delimeter + "12:14:45+0800", calDateWST, true); // offset case
+            assertValidDate("16/07/2009" + delimiter + "03:14:45-0100", calDateWST,    true);
+            assertValidDate("16/07/2009" + delimiter + "12:14:45+0800", calDateWST, true); // offset case
         }
     }
 


### PR DESCRIPTION
- consistent naming: replace "textSplitterValue" with "textUploadCSVDelimiterValue" for clarity.
- fix spelling: replace "delimeter" with "delimiter".