### PR TITLE
minor cleanup of install prompts

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -108,7 +108,7 @@ import org.apache.logging.log4j.Logger;
  * - Properties set in Settings dialog and saved in config.properties file
  * 
  * - Properties set during actions and saved in config.properties/<operation | "ui">_lastRun.properties file.
- *   Some properties are set during actions such as login, specifying results directory for an operation, and so on.
+ *   Some properties are set during actions such as login, specifying results folder for an operation, and so on.
  *   For example, "process.operation" property is set when user clicks on the operation button.
  *   These properties may not get saved depending on whether they are designated as "read-only" properties.
  *   
@@ -743,7 +743,7 @@ public class Config {
      *
      * @param configFileProperty property containing a config filename
      * @return Config filename path based on config property value. Config file is assumed to reside
-     * in the global config directory
+     * in the global config folder
      */
     public String getConfigFilename(String configFileProperty) {
         String value = getParamValue(configFileProperty);
@@ -757,10 +757,10 @@ public class Config {
 
 
     /**
-     * Constructs config file path based on the configuration directory and the passed in config
+     * Constructs config file path based on the configuration folder and the passed in config
      * filename
      *
-     * @param configFilename Config filename that resides in the config directory
+     * @param configFilename Config filename that resides in the config folder
      * @return Full path to the config file
      */
     public String constructConfigFilePath(String configFilename) {
@@ -1448,23 +1448,23 @@ public class Config {
     }
     
     /**
-     * Create directory provided from the parameter
+     * Create folder provided from the parameter
      *
-     * @param dirPath - directory to be created
-     * @return True if directory was created successfully or directory already existed False if
-     * directory was failed to create
+     * @param dirPath - folder to be created
+     * @return True if folder was created successfully or folder already existed False if
+     * folder was failed to create
      */
     private static boolean createDir(File dirPath) {
         boolean isSuccessful = true;
         if (!dirPath.exists() || !dirPath.isDirectory()) {
             isSuccessful = dirPath.mkdirs();
             if (isSuccessful) {
-                logger.info("Created config directory: " + dirPath);
+                logger.info("Created config folder: " + dirPath);
             } else {
-                logger.info("Unable to create config directory: " + dirPath);
+                logger.info("Unable to create config folder: " + dirPath);
             }
         } else {
-            logger.info("Config directory already exists: " + dirPath);
+            logger.info("Config folder already exists: " + dirPath);
         }
         return isSuccessful;
     }

--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -84,7 +84,7 @@ import java.util.Properties;
 public class Controller {
 
     /**
-     * the system property name used to determine the config directory
+     * the system property name used to determine the config folder
      */
 
     public static String APP_VERSION = ""; //$NON-NLS-1$
@@ -393,13 +393,13 @@ public class Controller {
     public void setStatusFiles(String statusDirName, boolean createDir, boolean generateFiles)
             throws ProcessInitializationException {
         File statusDir = new File(statusDirName);
-        // if status directory unspecified, create one based on config path
+        // if status folder unspecified, create one based on config path
         if (statusDirName == null || statusDirName.length() == 0) {
             statusDir = new File(new File(AppUtil.getConfigurationsDir()), "../status");
             statusDirName = statusDir.getAbsolutePath();
         }
-        // it's an error if directory files exists but not a directory
-        // or if directory doesn't exist and cannot be created (determined by caller)
+        // it's an error if folder files exists but not a folder
+        // or if folder doesn't exist and cannot be created (determined by caller)
         if (statusDir.exists() && !statusDir.isDirectory()) {
             throw new ProcessInitializationException(Messages.getFormattedString("Controller.invalidOutputDir",
                     statusDirName));

--- a/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
@@ -194,7 +194,7 @@ public class DataLoaderRunner extends Thread {
           logger.debug("    " + args[i]);
         }
         
-        // add the argument to indicate that JAVA_LIB_PATH has the directory containing SWT native libraries
+        // add the argument to indicate that JAVA_LIB_PATH has the folder containing SWT native libraries
         jvmArgs.add(AppUtil.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH + "=true");
         logger.debug("    " + AppUtil.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH + "=true");
         ProcessBuilder processBuilder = new ProcessBuilder(jvmArgs);
@@ -262,7 +262,7 @@ public class DataLoaderRunner extends Thread {
             return null;
         }
         if (parentDirStr.contains("*")) {
-            // path to the file has a wildcard. Assume that it is present only at the parent directory level
+            // path to the file has a wildcard. Assume that it is present only at the parent folder level
             String[] subpaths = parentDirStr.split("\\*");
             File grandparentDir = new File(subpaths[0]);
             File[] possibleParentDirs = grandparentDir.listFiles();

--- a/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
@@ -303,7 +303,7 @@ public class ProcessRunner implements InitializingBean, IProcess {
             logger.info(Config.PROCESS_NAME 
                         + "is specified in the command line. Loading DynaBean with id " 
                         + dynaBeanID 
-                        + " from process-conf.xml located in directory "
+                        + " from process-conf.xml located in folder "
                         + AppUtil.getConfigurationsDir());
             runner = ProcessConfig.getProcessInstance(dynaBeanID);
         }

--- a/src/main/java/com/salesforce/dataloader/security/EncryptionAesUtil.java
+++ b/src/main/java/com/salesforce/dataloader/security/EncryptionAesUtil.java
@@ -137,7 +137,7 @@ public class EncryptionAesUtil {
 
         } else {
             LOGGER.error(customDir + " was not created");
-            throw new RuntimeException("Cannot create directory:" + path);
+            throw new RuntimeException("Cannot create folder:" + path);
         }
         return Paths.get(path, DEFAULT_KEYFILE_NAME).toString();
     }

--- a/src/main/java/com/salesforce/dataloader/ui/LoadWizard.java
+++ b/src/main/java/com/salesforce/dataloader/ui/LoadWizard.java
@@ -75,7 +75,7 @@ public abstract class LoadWizard extends BaseWizard {
         String outputDirName = getFinishPage().getOutputDir();
         File statusDir = new File(outputDirName);
         if (!statusDir.exists() || !statusDir.isDirectory()) {
-            UIUtils.errorMessageBox(getShell(), Labels.getString("LoadWizard.errorValidDirectory")); //$NON-NLS-1$
+            UIUtils.errorMessageBox(getShell(), Labels.getString("LoadWizard.errorValidFolder")); //$NON-NLS-1$
             return false;
         }
         // set the files for status output

--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionFinishPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionFinishPage.java
@@ -35,7 +35,7 @@ import com.salesforce.dataloader.ui.Labels;
 import com.salesforce.dataloader.ui.UIUtils;
 
 /**
- * Last page of extraction wizard which lets the user select directory for status files (currently, only error status is
+ * Last page of extraction wizard which lets the user select folder for status files (currently, only error status is
  * generated in case of extract)
  * 
  * @author Alex Warshavsky
@@ -53,7 +53,7 @@ public class ExtractionFinishPage extends FinishPage {
         String outputDirName = getOutputDir();
         File statusDir = new File(outputDirName);
         if (!statusDir.exists() || !statusDir.isDirectory()) {
-            UIUtils.errorMessageBox(getShell(), Labels.getString("LoadWizard.errorValidDirectory")); //$NON-NLS-1$
+            UIUtils.errorMessageBox(getShell(), Labels.getString("LoadWizard.errorValidFolder")); //$NON-NLS-1$
             return false;
         }
         // set the files for status output

--- a/src/main/java/com/salesforce/dataloader/util/AppUtil.java
+++ b/src/main/java/com/salesforce/dataloader/util/AppUtil.java
@@ -308,11 +308,11 @@ public class AppUtil {
     
     private static void processArgsForBatchMode(String[] args, Map<String,String> argsMap) {
         if (!argsMap.containsKey(AppUtil.CLI_OPTION_CONFIG_DIR_PROP) && args.length < 2) {
-            // config directory must be specified in the first argument
+            // config folder must be specified in the first argument
             System.err.println(
-                    "Usage: process <configuration directory> [batch process bean id]\n"
+                    "Usage: process <configuration folder> [batch process bean id]\n"
                     + "\n"
-                    + "      configuration directory -- required -- directory that contains configuration files,\n"
+                    + "      configuration folder -- required -- folder that contains configuration files,\n"
                     + "          i.e. config.properties, process-conf.xml, database-conf.xml\n"
                     + "\n"
                     + "      batch process bean id -- optional -- id of a batch process bean in process-conf.xml,\n"

--- a/src/main/resources/labels.properties
+++ b/src/main/resources/labels.properties
@@ -97,7 +97,7 @@ AdvancedSettingsDialog.loginFromBrowser=Enable OAuth login from browser:
 AdvancedSettingsDialog.clientIdInProduction=Client ID in Production:
 AdvancedSettingsDialog.clientIdInSandbox=Client ID in Sandbox:
 AdvancedSettingsDialog.loggingLevel=Current logging level:
-AdvancedSettingsDialog.configDir=Directory containing configuration files:\n(config.properties, log4j2.properties, ...)
+AdvancedSettingsDialog.configDir=Folder containing configuration files:\n(config.properties, log4j2.properties, ...)
 AdvancedSettingsDialog.latestLoggingFile=Logging output file:
 AdvancedSettingsDialog.loggingConfigFile=Logging configuration file:
 
@@ -123,7 +123,7 @@ LoadFinishDialog.viewErrors=View Errors
 LoadFinishDialog.title=Operation Finished
 
 LoadWizard.errorAction=Error Running Action
-LoadWizard.errorValidDirectory=Please select a valid directory for the status output files.  \n\nIf you clicked 'Back' button to reach this page, click Next to continue to the next step.
+LoadWizard.errorValidFolder=Please select a valid folder for the status output files.  \n\nIf you clicked 'Back' button to reach this page, click Next to continue to the next step.
 
 LogoutUIAction.toolTip=Log out from the current session.
 
@@ -232,17 +232,17 @@ ExtractionSOQLPage.clearAllFields=Clear all fields
 ExtractionSOQLPage.clearAllConditions=Clear all conditions
 
 FinishPage.title=Step 4: Finish
-FinishPage.description=Select the directory where your success and error files will be saved.
+FinishPage.description=Select the folder where your success and error files will be saved.
 FinishPage.overwritten=
 FinishPage.output=Output
-FinishPage.chooseDir=Directory:
+FinishPage.chooseDir=Folder:
 
 ForeignKeyExternalIdPage.title=Step 2b: Choose your related objects
 ForeignKeyExternalIdPage.description=For each related object, select the relationship lookup field to use for matching.  Otherwise, leave the selection blank.
 ForeignKeyExternalIdPage.defaultComboText=<Not selected>
 
 HardDeleteFinishPage.title=Step 4: Finish
-HardDeleteFinishPage.description=Select the directory where your success and error files will be saved.
+HardDeleteFinishPage.description=Select the folder where your success and error files will be saved.
 
 MappingPage.title=Step 3: Mapping
 MappingPage.fieldName=Salesforce Object Field Name
@@ -285,7 +285,7 @@ ExtractionDataSelectionDialog.success=Initialization succeeded.
 
 ExtractionFinishDialog.viewExtraction=View Extraction
 ExtractionFinishPage.title=Step 4: Finish
-ExtractionFinishPage.description=Select the directory where your success and error files will be saved.
+ExtractionFinishPage.description=Select the folder where your success and error files will be saved.
 
 ExitUIAction.menuText=E&xit@Alt+F4
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -130,8 +130,8 @@ Controller.errorDatabaseNotSupportedInTheUI=Error getting database configuration
 Controller.errorDAOCreate=Error creating data access object
 Controller.errorOperationInfoLoad=Error loading custom action configuration.  Custom actions will not be available for execution.
 Controller.errorDaoFactoryLoad=Error loading custom data access object configuration.  Custom data access objects will not be available for execution.
-Config.errorCreatingOutputDir=Error creating output directory: {0}
-Controller.invalidOutputDir=Invalid output directory specified: {0}.  Please make sure that the directory exists and has a write permission.
+Config.errorCreatingOutputDir=Error creating output folder: {0}
+Controller.invalidOutputDir=Invalid output folder specified: {0}.  Please make sure that the folder exists and has a write permission.
 Controller.errorFileCreate=Error creating file: {0}
 Controller.errorFileWrite=Error writing to file: {0}.  Please make sure that the file has a write permission.
 Controller.errorSameFile=Data access CSV: {0} is the same as the output file: {1}
@@ -198,16 +198,16 @@ DataAccessObjectFactory.daoTypeNotSupported=The specified data access object typ
 DataAccessObjectFactory.creatingDao=Instantiating data access object: {0} of type: {1}
 FinishPage.cannotMapBase64ForBulkApi=Data Loader cannot map "{0}" field using Bulk API and CSV content type.  Please enable the ZIP_CSV content type for Bulk API.
 
-Installer.initialMessage= Data Loader installation requires you to provide an installation directory\n\
-to create a version-specific child directory for the installation artifacts.\n\
-It uses "{0}<relative path>" as the installation directory if you provide \n\
-a relative path for the installation directory.
+Installer.initialMessage= Data Loader installation requires you to provide an installation folder\n\
+to create a version-specific child folder for the installation artifacts.\n\
+It uses "{0}<relative path>" as the installation folder if you provide \n\
+a relative path for the installation folder.
 
 Installer.installationDirConfirmation=Data Loader v{0} will be installed in {1}
 Installer.overwriteInstallationDirPrompt=Do you want to overwrite previously installed Data Loader\n\
 v{0} and its configuration in {1}?\n\n\
 If not, installation will quit and you can restart installation using\n\
-another directory. [Yes/No] 
+another folder. [Yes/No] 
 Installer.deletionInProgressMessage=Deleting existing Data Loader v{0}...
 Installer.promptAnswerYes=Yes
 Installer.promptAnswerNo=No
@@ -215,8 +215,11 @@ Installer.reprompt=Type Yes or No.
 Installer.responseReadError=Can't read your response. Try again.
 Installer.shortcutCreateError=Unable to create shortcut
 Installer.createDesktopShortcutPrompt=Do you want to create a Desktop shortcut? [Yes/No] 
-Installer.createApplicationsDirShortcutPrompt=Do you want to create a shortcut in Applications directory? [Yes/No] 
+Installer.successCreateDesktopShortcut=Desktop shortcut created. 
+Installer.createApplicationsDirShortcutPrompt=Do you want to create a shortcut in Applications folder? [Yes/No] 
+Installer.successCreateApplicationsDirShortcut=A shortcut in Applications folder created. 
 Installer.createStartMenuShortcutPrompt=Do you want to create a Start menu shortcut? [Yes/No] 
+Installer.successCreateStartMenuShortcut=Start menu shortcut created. 
 Installer.exitMessage=Data Loader installation is quitting.
 
 AppUtil.banner=\

--- a/src/test/java/com/salesforce/dataloader/process/CsvExtractProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvExtractProcessTest.java
@@ -114,21 +114,21 @@ public class CsvExtractProcessTest extends ProcessExtractTestBase {
     }
 
     /**
-     * Test output of last run files. 1. Output is enabled, directory is not set (use default) 2. Output is enabled,
-     * directory is set 3. Output is disabled
+     * Test output of last run files. 1. Output is enabled, folder is not set (use default) 2. Output is enabled,
+     * folder is set 3. Output is disabled
      * 
      * @hierarchy API.dataloader Csv Process Tests
      * @userstory Commenting existing data loader tests and uploading into QA force
      */
     @Test
     public void testLastRunOutput() throws Exception {
-        // 1. Output is enabled (use default), directory is not set (use
+        // 1. Output is enabled (use default), folder is not set (use
         // default)
         String baseName = this.baseName;
         upsertSfdcAccounts(1);
         testLastRunOutput(true, baseName + "_default", true, null);
 
-        // 2. Output is enabled, directory is set
+        // 2. Output is enabled, folder is set
         testLastRunOutput(false, baseName + "_dirSet", true, System.getProperty("java.io.tmpdir"));
 
         // 3. Output is disabled


### PR DESCRIPTION
- Do not proceed further if the user enters <return> key without answering the prompt to install in a folder or create shortcuts.

- Display a completion message upon successful creation of a desktop or menu shortcut.

- Change the term "directory" as "folder" in user prompts, variable names, and comments to be consistent with its usage on Mac and Windows.