### PR TITLE
fix for W-13612705

### DIFF
--- a/src/main/resources/mac/util/util.sh
+++ b/src/main/resources/mac/util/util.sh
@@ -8,11 +8,11 @@ initVars() {
     DATALOADER_VERSION="@@FULL_VERSION@@"
     DATALOADER_SHORT_VERSION=$(echo ${DATALOADER_VERSION} | cut -d'.' -f 1)
     MIN_JAVA_VERSION=@@MIN_JAVA_VERSION@@
-    include ${HOME}/.profile
-    include ${HOME}/.bash_profile
-    include ${HOME}/.bashrc
-    include ${HOME}/.zsh_profile
-    include ${HOME}/.zshrc
+#    include ${HOME}/.profile
+#    include ${HOME}/.bash_profile
+#   include ${HOME}/.bashrc
+#   include ${HOME}/.zsh_profile
+#   include ${HOME}/.zshrc
 }
 
 checkJavaVersion() {


### PR DESCRIPTION
W-13612705: [Data Loader v58 Regression] The rest of the field values are not updated if the field value of 1st data line in CSV file is blank when updating data via Data Loader Bulk API option

The regression was introduced in BulkLoadVisitor.java during the change made in PR #594 to optimize determining the header fields for each load batch. The fix is to revert the relevant code to the prior implementation.