### PR TITLE
partial fix for issue #740

### DIFF
--- a/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
@@ -102,15 +102,13 @@ public class DataLoaderRunner extends Thread {
             } catch (Throwable t) {
                 ProcessRunner.logErrorAndExitProcess("Unable to run process", t);
             }
-        } else if (AppUtil.getAppRunMode() == AppUtil.APP_RUN_MODE.INSTALL) {
-            Installer.install(args);
         } else if (AppUtil.getAppRunMode() == AppUtil.APP_RUN_MODE.ENCRYPT) {
             EncryptionUtil.main(args);
         } else {
             Map<String, String> argsMap = AppUtil.convertCommandArgsArrayToArgMap(args);
             /* Run in the UI mode, get the controller instance with batchMode == false */
             logger = LogManager.getLogger(DataLoaderRunner.class);
-            extractInstallationArtifacts();
+            Installer.install(args);
             if (argsMap.containsKey(AppUtil.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH) 
                 && "true".equalsIgnoreCase(argsMap.get(AppUtil.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH))){
                 try {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -221,6 +221,8 @@ Installer.successCreateApplicationsDirShortcut=A shortcut in Applications folder
 Installer.createStartMenuShortcutPrompt=Do you want to create a Start menu shortcut? [Yes/No] 
 Installer.successCreateStartMenuShortcut=Start menu shortcut created. 
 Installer.exitMessage=Data Loader installation is quitting.
+Installer.promptInstallationFolder=Provide the installation folder [default: dataloader] : 
+Installer.promptCurrentInstallationFolder=Do you want to install Data Loader in the current folder ({0})? [Yes/No]  
 
 AppUtil.banner=\
 \n\


### PR DESCRIPTION
Give the user choice to install data loader in the folder where it is unzipped. Doing so lets avoids the situation described in the comment https://github.com/forcedotcom/dataloader/issues/740#issuecomment-1664026175:

When I double click the dataloader-58.0.3 jar file in the extracted folder, a dataloader.bat file appears and when clicking that, I could access Data Loader, but there's no shortcut on the desktop or start menu where I could access Data Loader from, see screenshot below.