### PR TITLE
code cleanup - one constructor for CSVFileReader

### DIFF
--- a/src/main/java/com/salesforce/dataloader/dao/DataAccessObjectFactory.java
+++ b/src/main/java/com/salesforce/dataloader/dao/DataAccessObjectFactory.java
@@ -26,6 +26,9 @@
 package com.salesforce.dataloader.dao;
 
 import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+
 import org.apache.logging.log4j.LogManager;
 
 import com.salesforce.dataloader.config.Config;
@@ -52,7 +55,7 @@ public class DataAccessObjectFactory {
         logger.info(Messages.getFormattedString("DataAccessObjectFactory.creatingDao", new String[] {config.getString(Config.DAO_NAME), daoType}));
 
         if (CSV_READ_TYPE.equalsIgnoreCase(daoType)) {
-            dao = new CSVFileReader(config, false);
+            dao = new CSVFileReader(new File(config.getString(Config.DAO_NAME)), config, false, false);
         } else if (CSV_WRITE_TYPE.equalsIgnoreCase(daoType)) {
             dao = new CSVFileWriter(config.getString(Config.DAO_NAME), config, config.getString(Config.CSV_DELIMITER_FOR_QUERY_RESULTS));
         } else if (DATABASE_READ_TYPE.equalsIgnoreCase(daoType)) {

--- a/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileReader.java
@@ -72,18 +72,6 @@ public class CSVFileReader implements DataReader {
     private char[] csvDelimiters;
     private Config config;
 
-    public CSVFileReader(Config config, boolean isQueryOperationResult) {
-        this(new File(config.getString(Config.DAO_NAME)), config, false, isQueryOperationResult);
-    }
-
-    // used only in tests
-    public CSVFileReader(String filePath, Controller controller) {
-        // Assume comma char as the delimiter => set 3rd param to true.
-        // Assume load operation by setting 4th param to false.
-        // 4th param setting is ignored if 3rd param is set to true. 
-        this(new File(filePath), controller.getConfig(), true, false);  
-    }
-
     // Handles 3 types of CSV files:
     // 1. CSV files provided by the user for upload operations: ignoreDelimiterConfig = false, isQueryOperationResult = false
     // 2. CSV files that are results of query operations: ignoreDelimiterConfig = false, isQueryOperationResult = true

--- a/src/test/java/com/salesforce/dataloader/process/CsvProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvProcessTest.java
@@ -241,7 +241,7 @@ public class CsvProcessTest extends ProcessTestBase {
 
         List<String> ids = new ArrayList<String>();
         String fileName = resultController.getConfig().getString(Config.OUTPUT_SUCCESS);
-        final CSVFileReader successRdr = new CSVFileReader(fileName, getController());
+        final CSVFileReader successRdr = new CSVFileReader(new File(fileName), getController().getConfig(), true, false);
         try {
             // TODO: revise the use of Integer.MAX_VALUE
             for (Row row : successRdr.readRowList(Integer.MAX_VALUE)) {

--- a/src/test/java/com/salesforce/dataloader/process/NAProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/NAProcessTest.java
@@ -211,7 +211,7 @@ public class NAProcessTest extends ProcessTestBase {
     }
 
     private String getCsvFieldValue(String csvFile, String fieldName) throws Exception {
-        CSVFileReader reader = new CSVFileReader(csvFile, getController());
+        CSVFileReader reader = new CSVFileReader(new File(csvFile), getController().getConfig(), true, false);
         reader.open();
         assertEquals(1, reader.getTotalRows());
         String fieldValue = (String)reader.readRow().get(fieldName);

--- a/src/test/java/com/salesforce/dataloader/process/ProcessExtractTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessExtractTestBase.java
@@ -28,6 +28,7 @@ package com.salesforce.dataloader.process;
 
 import static org.junit.Assert.*;
 
+import java.io.File;
 import java.util.*;
 
 import org.junit.Assert;
@@ -142,7 +143,7 @@ public abstract class ProcessExtractTestBase extends ProcessTestBase {
         final Set<String> unexpectedIds = new HashSet<String>();
         final Set<String> expectedIds = new HashSet<String>(Arrays.asList(ids));
         String fileName = control.getConfig().getString(Config.OUTPUT_SUCCESS);
-        final DataReader resultReader = new CSVFileReader(fileName, getController());
+        final DataReader resultReader = new CSVFileReader(new File(fileName), getController().getConfig(), true, false);
         try {
             resultReader.open();
 
@@ -300,7 +301,7 @@ public abstract class ProcessExtractTestBase extends ProcessTestBase {
         final Map<String, String> argMap = getTestConfig(soql, "Contact", true);
 
         runProcess(argMap, 1);
-        final CSVFileReader resultReader = new CSVFileReader(argMap.get(Config.DAO_NAME), getController());
+        final CSVFileReader resultReader = new CSVFileReader(new File(argMap.get(Config.DAO_NAME)), getController().getConfig(), true, false);
         try {
             final Row resultRow = resultReader.readRow();
             assertEquals("Query returned incorrect Contact ID", contactId, resultRow.get("CONTACT_ID"));
@@ -356,7 +357,7 @@ public abstract class ProcessExtractTestBase extends ProcessTestBase {
                 // run the extract
                 runProcess(argmap, 1);
                 // open the results of the extraction
-                final CSVFileReader rdr = new CSVFileReader(argmap.get(Config.DAO_NAME), getController());
+                final CSVFileReader rdr = new CSVFileReader(new File(argmap.get(Config.DAO_NAME)), getController().getConfig(), true, false);
                 rdr.open();
                 Row row = rdr.readRow();
                 assertNotNull(row);
@@ -417,7 +418,7 @@ public abstract class ProcessExtractTestBase extends ProcessTestBase {
                     "Aggregate Relationships not supported in Bulk Query");
         } else {
             runProcess(argMap, 1, true);
-            final CSVFileReader resultReader = new CSVFileReader(argMap.get(Config.DAO_NAME), getController());
+            final CSVFileReader resultReader = new CSVFileReader(new File(argMap.get(Config.DAO_NAME)), getController().getConfig(), true, false);
             try {
                 assertEquals(String.valueOf(numRecords - 1), resultReader.readRow().get("MAX(NUMBEROFEMPLOYEES)"));
             } finally {

--- a/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
@@ -86,7 +86,7 @@ public abstract class ProcessTestBase extends ConfigTestBase {
 
     protected void verifyErrors(Controller controller, String expectedErrorMessage) throws DataAccessObjectException {
         String fileName = controller.getConfig().getString(Config.OUTPUT_ERROR);
-        final CSVFileReader errReader = new CSVFileReader(fileName, controller);
+        final CSVFileReader errReader = new CSVFileReader(new File(fileName), getController().getConfig(), true, false);
         try {
             errReader.open();
             for (Row errorRow : errReader.readRowList(errReader.getTotalRows())) {
@@ -106,7 +106,7 @@ public abstract class ProcessTestBase extends ConfigTestBase {
 
     protected void verifySuccessIds(Controller ctl, Set<String> ids) throws DataAccessObjectException {
         String fileName = ctl.getConfig().getString(Config.OUTPUT_SUCCESS);
-        final CSVFileReader successRdr = new CSVFileReader(fileName, ctl);
+        final CSVFileReader successRdr = new CSVFileReader(new File(fileName), ctl.getConfig(), true, false);
         final Set<String> remaining = new HashSet<String>(ids);
         final Set<String> unexpected = new HashSet<String>();
         try {
@@ -616,7 +616,7 @@ public abstract class ProcessTestBase extends ConfigTestBase {
             TemplateListener... listeners) throws DataAccessObjectException {
 
         String fileName = new File(getTestDataDir(), templateFileName).getAbsolutePath();
-        final CSVFileReader templateReader = new CSVFileReader(fileName, getController());
+        final CSVFileReader templateReader = new CSVFileReader(new File(fileName), getController().getConfig(), true, false);
         try {
             templateReader.open();
 
@@ -810,7 +810,7 @@ public abstract class ProcessTestBase extends ConfigTestBase {
         assertNumRowsInCSVFile(successFile, numInserts + numUpdates);
 
         Row row = null;
-        CSVFileReader rdr = new CSVFileReader(successFile, getController());
+        CSVFileReader rdr = new CSVFileReader(new File(successFile), getController().getConfig(), true, false);
         String updateMsg = UPDATE_MSGS.get(ctl.getConfig().getOperationInfo());
         int insertsFound = 0;
         int updatesFound = 0;
@@ -917,7 +917,7 @@ public abstract class ProcessTestBase extends ConfigTestBase {
     }
 
     private void assertNumRowsInCSVFile(String fName, int expectedRows) throws DataAccessObjectException {
-        CSVFileReader rdr = new CSVFileReader(fName, getController());
+        CSVFileReader rdr = new CSVFileReader(new File(fName), getController().getConfig(), true, false);
         rdr.open();
         int actualRows = rdr.getTotalRows();
         assertEquals("Wrong number of rows in file :" + fName, expectedRows, actualRows);


### PR DESCRIPTION
Keeping one constructor to improve the readability of how calling code is setting the parameters.