### PR TITLE
bulk v2 tweaks

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/BulkLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/BulkLoadVisitor.java
@@ -180,6 +180,7 @@ public class BulkLoadVisitor extends DAOLoadVisitor {
         int processedRecordsCount = 0;
         final List<String> userColumns = getController().getDao().getColumnNames();
         List<String> headerColumns = null;
+        int maxBatchBytes = this.getConfig().isBulkV2APIEnabled() ? Config.MAX_BULKV2_API_JOB_BYTES : Config.MAX_BULK_API_BATCH_BYTES;
         for (int i = 0; i < rows.size(); i++) {
             final DynaBean row = rows.get(i);
 
@@ -189,7 +190,7 @@ public class BulkLoadVisitor extends DAOLoadVisitor {
             writeRow(row, out, processedRecordsCount, headerColumns);
             processedRecordsCount++;
 
-            if (os.size() > Config.MAX_BULK_API_BATCH_BYTES) {
+            if (os.size() > maxBatchBytes) {
             	createBatch(os, processedRecordsCount); // resets outputstream
                 // reset for the next batch
             	processedRecordsCount = 0;

--- a/src/main/java/com/salesforce/dataloader/action/visitor/BulkV2Connection.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/BulkV2Connection.java
@@ -410,6 +410,9 @@ public class BulkV2Connection  {
         	headers = getHeaders(JSON_CONTENT_TYPE, JSON_CONTENT_TYPE);
         	requestBodyMap.put("object", job.getObject());
         	requestBodyMap.put("contentType", "CSV");
+        	if (operation.equals(OperationEnum.upsert)) {
+        	    requestBodyMap.put("externalIdFieldName", job.getExternalIdFieldName());
+        	}
         }
         return doSendJobRequestToServer(urlString, 
 										headers,

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -140,6 +140,8 @@ public class Config {
     public static final int MAX_DAO_WRITE_BATCH_SIZE = 2000;
     public static final int MAX_BULK_API_BATCH_BYTES = 10000000;
     public static final int MAX_BULK_API_BATCH_SIZE = 10000;
+    public static final int MAX_BULKV2_API_JOB_BYTES = 150000000;
+    public static final int MAX_BULKV2_API_JOB_SIZE = 150000000;
     public static final int DEFAULT_BULK_API_BATCH_SIZE = 2000;
     public static final long DEFAULT_BULK_API_CHECK_STATUS_INTERVAL = 5000L;
     public static final String DEFAULT_ENDPOINT_URL = "https://login.salesforce.com";
@@ -301,6 +303,8 @@ public class Config {
     public static final String DAO_READ_BATCH_SIZE = "dataAccess.readBatchSize";
     public static final String DAO_WRITE_BATCH_SIZE = "dataAccess.writeBatchSize";
     public static final String DAO_SKIP_TOTAL_COUNT = "dataAccess.skipTotalCount";
+    public static final String DAO_READ_PREPROCESSOR_SCRIPT = "dataAccess.read.preProcessorScript";
+    public static final String DAO_WRITE_POSTPROCESSOR_SCRIPT = "dataAccess.write.postProcessorScript";
 
     /*
      * TODO: when batching is introduced to the DataAccess, these parameters will become useful
@@ -433,7 +437,9 @@ public class Config {
             API_VERSION_PROP,
             READ_CHARSET,
             READ_ONLY_CONFIG_PROPERTIES,
-            RICH_TEXT_FIELD_REGEX
+            RICH_TEXT_FIELD_REGEX,
+            DAO_READ_PREPROCESSOR_SCRIPT,
+            DAO_WRITE_POSTPROCESSOR_SCRIPT
     };
     
     /**
@@ -587,6 +593,8 @@ public class Config {
         setDefaultValue(PROCESS_KEEP_ACCOUNT_TEAM, false);
         setDefaultValue(WIZARD_WIDTH, DEFAULT_WIZARD_WIDTH);
         setDefaultValue(WIZARD_HEIGHT, DEFAULT_WIZARD_HEIGHT);
+        setDefaultValue(DAO_READ_PREPROCESSOR_SCRIPT, "");
+        setDefaultValue(DAO_WRITE_POSTPROCESSOR_SCRIPT, "");
     }
 
     /**
@@ -1136,7 +1144,7 @@ public class Config {
 
     private void removeUnsupportedProperties() {
         // do not save a value for enabling Bulk V2 
-        this.properties.remove(BULKV2_API_ENABLED);
+        //this.properties.remove(BULKV2_API_ENABLED);
     }
     
     private void removeDecryptedProperties() {
@@ -1328,6 +1336,12 @@ public class Config {
 
     public int getLoadBatchSize() {
         boolean bulkApi = isBulkAPIEnabled();
+        boolean bulkV2Api = this.isBulkV2APIEnabled();
+        
+        if (bulkApi && bulkV2Api) {
+            return MAX_BULKV2_API_JOB_SIZE;
+        }
+        
         int bs = -1;
         try {
             bs = getInt(LOAD_BATCH_SIZE);
@@ -1338,6 +1352,10 @@ public class Config {
     }
 
     public int getDefaultBatchSize(boolean bulkApi) {
+        boolean bulkV2Api = this.isBulkV2APIEnabled();
+        if (bulkApi && bulkV2Api) {
+            return MAX_BULKV2_API_JOB_SIZE;
+        }
         return bulkApi ? DEFAULT_BULK_API_BATCH_SIZE : DEFAULT_LOAD_BATCH_SIZE;
     }
 


### PR DESCRIPTION
- set bulk v2 job size and job byte limits that match bulk v2 api limits

- ignore user settings for batch size for bulk v2 job.

- set external id value in the request body when creating bulk v2 job.