### PR TITLE
Redo PR #774 - preserve the upload field order in upload CSV

### DIFF
--- a/src/main/java/com/salesforce/dataloader/mapping/CaseInsensitiveMap.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/CaseInsensitiveMap.java
@@ -25,39 +25,37 @@
  */
 package com.salesforce.dataloader.mapping;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 
-public class CaseInsensitiveSet {
-    private final CaseInsensitiveMap originalMap = new CaseInsensitiveMap();
+public class CaseInsensitiveMap extends LinkedHashMap<String, String> {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    private final HashMap<String, String> lowercaseKeyToFirstTimeUseKeyMap = new HashMap<String, String>();
 
-    public CaseInsensitiveSet(){
+    @Override
+    public String put(String key, String value) {
+        return super.put(getFirstTimeUseKey(key), value);
     }
 
-    public CaseInsensitiveSet(Set<String> values){
-        this();
-        for(String value: values){
-            add(value);
-        }
+    // not @Override because that would require the key parameter to be of type Object
+    public String get(String key) {
+        return super.get(getFirstTimeUseKey(key));
     }
-
-    public void add(String value) {
-        originalMap.put(value, value);
-    }
-
+    
     public boolean containsKey(String key) {
-        return key != null ? originalMap.containsKey(key): false;
+        return super.containsKey(getFirstTimeUseKey(key));
+    }
+    
+    private String getFirstTimeUseKey(String suppliedKey) {
+        String firstTimeUseKey = lowercaseKeyToFirstTimeUseKeyMap.get(suppliedKey.toLowerCase());
+        if (firstTimeUseKey == null)  {
+            firstTimeUseKey = suppliedKey;
+            lowercaseKeyToFirstTimeUseKeyMap.put(firstTimeUseKey.toLowerCase(), firstTimeUseKey);
+        }
+        return firstTimeUseKey;
     }
 
-    public String getOriginal(String key){
-        return containsKey(key) ? (String) originalMap.get(key): key;
-    }
-
-    public boolean isEmpty(){
-        return originalMap.isEmpty();
-    }
-
-    public Set<String> getOriginalValues() {
-        return new LinkedHashSet<String>(originalMap.values());
-    }
 }

--- a/src/main/java/com/salesforce/dataloader/mapping/LoadMapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/LoadMapper.java
@@ -37,8 +37,9 @@ import org.apache.logging.log4j.LogManager;
 import org.springframework.util.StringUtils;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.Map.Entry;
 
 /**
@@ -66,7 +67,7 @@ public class LoadMapper extends Mapper {
     }
 
     public Map<String, String> getMappingWithUnmappedColumns(boolean includeUnmapped) {
-        final Map<String, String> result = new HashMap<String, String>();
+        final CaseInsensitiveMap result = new CaseInsensitiveMap();
         
         // get mappings in the same order as DAO column order
         for (String daoColumn : getDaoColumns()) {
@@ -77,8 +78,7 @@ public class LoadMapper extends Mapper {
         }
         
         // Make sure to not miss existing mappings even if they are not in DAO.
-        final Map<String, String> currentMap = new HashMap<String, String>(getMap());
-        for (Map.Entry<String, String> currentMapEntry : currentMap.entrySet()) {
+        for (Map.Entry<String, String> currentMapEntry : getMap().entrySet()) {
             if (!result.containsKey(currentMapEntry.getKey())) {
                 result.put(currentMapEntry.getKey(), currentMapEntry.getValue());
             }
@@ -116,6 +116,26 @@ public class LoadMapper extends Mapper {
                 }
             }
         }
+    }
+    
+    
+    public Set<String> getMappedDaoColumns() {
+        Map<String, String> possibleMappings = this.getMappingWithUnmappedColumns(true);
+        LinkedHashSet<String> mappedColSet = new LinkedHashSet<String>();
+        for (String daoCol : possibleMappings.keySet()) {
+            String mappedName = this.map.get(daoCol);
+            if (mappedName != null) {
+                if (mappedName.contains(",")) {
+                    String[] mappedNameList = mappedName.split(",");
+                    for (int i=0; i<mappedNameList.length; i++) {
+                        mappedColSet.add(mappedNameList[i]);
+                    }
+                } else {
+                    mappedColSet.add(daoCol);
+                }
+            }
+        }
+        return mappedColSet;
     }
 
 }

--- a/src/main/java/com/salesforce/dataloader/mapping/Mapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/Mapper.java
@@ -37,7 +37,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
-import java.util.TreeSet;
 
 import com.sforce.soap.partner.Field;
 import org.apache.logging.log4j.Logger;
@@ -61,6 +60,11 @@ public abstract class Mapper {
     private static final Logger logger = LogManager.getLogger(Mapper.class);
 
     public static class InvalidMappingException extends RuntimeException {
+        /**
+         * 
+         */
+        private static final long serialVersionUID = 1L;
+
         public InvalidMappingException(String msg, Throwable e) {
             super(msg, e);
         }
@@ -71,21 +75,17 @@ public abstract class Mapper {
     }
 
     private final CaseInsensitiveSet daoColumns;
-    private final Map<String, String> constants = caseInsensitiveMap();
+    private final CaseInsensitiveMap constants = new CaseInsensitiveMap();
 
-    private final Map<String, String> map = caseInsensitiveMap();
+    protected final CaseInsensitiveMap map = new CaseInsensitiveMap();
     private final PartnerClient client;
     private final CaseInsensitiveSet fields;
-
-    private <V> Map<String, V> caseInsensitiveMap() {
-        return new TreeMap<String, V>(String.CASE_INSENSITIVE_ORDER);
-    }
 
     protected Mapper(PartnerClient client, Collection<String> columnNames, Field[] fields, String mappingFileName)
             throws MappingInitializationException {
         this.client = client;
         this.fields = new CaseInsensitiveSet();
-        Set<String> daoColumns = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
+        CaseInsensitiveSet daoColumns = new CaseInsensitiveSet();
         if (columnNames != null) {
             int i = 0;
             for (String colName : columnNames) {
@@ -95,10 +95,10 @@ public abstract class Mapper {
                     logger.error(errorMsg);
                     throw new MappingInitializationException(errorMsg);
                 }
+                daoColumns.add(colName);
             }
-            daoColumns.addAll(columnNames);
         }
-        this.daoColumns = new CaseInsensitiveSet(Collections.unmodifiableSet(daoColumns));
+        this.daoColumns = daoColumns;
         if (fields != null) {
             for (Field field : fields) {
                 this.fields.add(field.getName());
@@ -234,7 +234,7 @@ public abstract class Mapper {
     }
 
     public boolean hasDaoColumn(String localName) {
-        return this.daoColumns.contains(localName);
+        return this.daoColumns.containsKey(localName);
     }
 
     public void removeMapping(String srcName) {


### PR DESCRIPTION
 preserve the upload field order in upload CSV by introducing CaseInsensitiveMap as a subclass of LinkedHashMap to keep the fields in the same order as found in the upload CSV.