### PR TITLE
Specify Spring 2 DTD in database-conf.xml

### DIFF
--- a/src/main/resources/samples/conf/database-conf.xml
+++ b/src/main/resources/samples/conf/database-conf.xml
@@ -1,4 +1,5 @@
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" 
+    "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
 <beans>
 <bean id="dbDataSource"
       class="org.apache.commons.dbcp2.BasicDataSource"

--- a/src/test/resources/testfiles/conf/database-conf.xml
+++ b/src/test/resources/testfiles/conf/database-conf.xml
@@ -1,4 +1,5 @@
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" 
+    "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
 <beans>
 <bean id="testDbDataSource"
       class="org.apache.commons.dbcp2.BasicDataSource"


### PR DESCRIPTION
Replace Spring 1 DTD with Spring 2 DTD in database-conf.xml to prevent IDE from showing "attribute scope must be defined for type bean" errors.