### PR TITLE
Specify Spring 2 DTD in process-conf.xml

### DIFF
--- a/src/main/resources/samples/conf/process-conf.xml
+++ b/src/main/resources/samples/conf/process-conf.xml
@@ -1,4 +1,5 @@
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" 
+    "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
 <beans>
     <bean id="accountMasterProcess"
           class="com.salesforce.dataloader.process.ProcessRunner"

--- a/src/test/resources/testfiles/conf/process-conf.xml
+++ b/src/test/resources/testfiles/conf/process-conf.xml
@@ -1,4 +1,5 @@
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" 
+    "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
 <beans>
     <!-- For the absolute paths below, replace with a better mechanism, eg. config.properties param for base location -->
     <bean id="maximumBatchRowsDbProcess"


### PR DESCRIPTION
Replace Spring 1 DTD with Spring 2 DTD in process-conf.xml to prevent IDE from showing "attribute scope must be defined for type bean" errors.