### PR TITLE
Don't show lookup field mapping page if it is empty

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/OperationPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/OperationPage.java
@@ -27,6 +27,7 @@ package com.salesforce.dataloader.ui;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
@@ -134,5 +135,29 @@ public abstract class OperationPage extends WizardPage {
    // concrete subclasses must override this method if they allow Finish operation
    public boolean finishAllowed() {
        return false;
+   }
+   
+   public IWizardPage getNextPage() {
+       OperationPage nextPage = (OperationPage)super.getNextPage();
+       if (nextPage != null) {
+           nextPage = nextPage.getNextPageOverride();
+       }
+       return nextPage;
+   }
+   
+   protected OperationPage getNextPageOverride() {
+       return this;
+   }
+   
+   public IWizardPage getPreviousPage() {
+       OperationPage prevPage = (OperationPage)super.getPreviousPage();
+       if (prevPage != null) {
+           prevPage = prevPage.getPreviousPageOverride();
+       }
+       return prevPage;
+   }
+   
+   protected OperationPage getPreviousPageOverride() {
+       return this;
    }
 }


### PR DESCRIPTION
Do not show parent object's lookup field mapping page if the list of such possible mappings is empty.