### PR TITLE
log mapping field exceptions instead of stopping during extract

### DIFF
--- a/src/main/java/com/salesforce/dataloader/mapping/Mapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/Mapper.java
@@ -79,6 +79,7 @@ public abstract class Mapper {
     protected final CaseInsensitiveMap map = new CaseInsensitiveMap();
     private final PartnerClient client;
     private final CaseInsensitiveSet fields;
+    protected final String mappingFileName;
 
     protected Mapper(PartnerClient client, Collection<String> columnNames, Field[] fields, String mappingFileName)
             throws MappingInitializationException {
@@ -103,6 +104,7 @@ public abstract class Mapper {
                 this.fields.add(field.getName());
             }
         }
+        this.mappingFileName = mappingFileName;
         putPropertyFileMappings(mappingFileName);
     }
 

--- a/src/main/java/com/salesforce/dataloader/mapping/SOQLMapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/SOQLMapper.java
@@ -116,12 +116,17 @@ public class SOQLMapper extends Mapper {
     protected void putPropertyEntry(Entry<Object, Object> entry) {
         String dao = (String)entry.getValue();
         String sfdc = (String)entry.getKey();
-        if (isConstant(sfdc))
+        if (isConstant(sfdc)) {
             putConstant(dao, sfdc);
-        else if (!hasDaoColumns() || hasDaoColumn(dao)) try {
-            addSoqlFieldMapping((String)entry.getValue(), new SOQLFieldInfo(sfdc));
-        } catch (SOQLParserException e) {
-            throw new InvalidMappingException(e.getMessage(), e);
+        } else if (!hasDaoColumns() || hasDaoColumn(dao)) {
+            try {
+                addSoqlFieldMapping((String)entry.getValue(), new SOQLFieldInfo(sfdc));
+            } catch (SOQLParserException e) {
+                throw new InvalidMappingException(e.getMessage(), e);
+            } catch (InvalidMappingException e) {
+                logger.warn("Unable to find Salesforce object field " + sfdc + " specified in the mapping file " + this.mappingFileName);
+                logger.warn(e.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
log mapping field exceptions instead of stopping during extract because the mapping file in config.properties may be configured for a different operation on a different object.