### PR TITLE
allow 5 test failures instead of 1 to allow for sporadic test failures

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -23,7 +23,7 @@ doClean="No"
 encryptionFile=
 
 password=""
-failfast="-Dsurefire.skipAfterFailureCount=1"
+failfast="-Dsurefire.skipAfterFailureCount=5"
 
 while getopts ":dicv:t:f:" flag
 do


### PR DESCRIPTION
Too many test failures due to a systematic issue can result in a temporary lockout for the user. However, stopping on 1 test failure means a sporadic test failure can halt an entire test suite.