### PR TITLE
skip local validation to support newer soql features

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/AbstractExtractAction.java
+++ b/src/main/java/com/salesforce/dataloader/action/AbstractExtractAction.java
@@ -137,8 +137,13 @@ abstract class AbstractExtractAction extends AbstractAction {
     @Override
     protected void initOperation() throws DataAccessObjectInitializationException, OperationException {
         // get columns that will be output from the query and open the outputs
-        final List<String> daoColumns = getDaoColumns();
-        getDao().setColumnNames(daoColumns);
+        if (getController().getConfig().getBoolean(Config.SKIP_LOCAL_SOQL_VERIFICATION)) {
+            getDao().setColumnNamesFromResults(true);
+        } else {
+            getDao().setColumnNamesFromResults(false);
+            final List<String> daoColumns = getDaoColumns();
+            getDao().setColumnNames(daoColumns);
+        }
     }
 
     @Override

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -344,7 +344,7 @@ public class Config {
     public static final String DUPLICATE_RULE_INCLUDE_RECORD_DETAILS = PILOT_PROPERTY_PREFIX + "sfdc.duplicateRule.includeRecordDetails"; //$NON-NLS-1$
     public static final String DUPLICATE_RULE_RUN_AS_CURRENT_USER = PILOT_PROPERTY_PREFIX + "sfdc.duplicateRule.runAsCurrentUser"; //$NON-NLS-1$
     public static final String BULKV2_API_ENABLED = PILOT_PROPERTY_PREFIX + "sfdc.useBulkV2Api";
-
+    public static final String SKIP_LOCAL_SOQL_VERIFICATION = "loader.query.skipLocalVerification";
     /*
      * ===============================
      * End of config properties
@@ -600,6 +600,7 @@ public class Config {
         setDefaultValue(WIZARD_HEIGHT, DEFAULT_WIZARD_HEIGHT);
         setDefaultValue(DAO_READ_PREPROCESSOR_SCRIPT, "");
         setDefaultValue(DAO_WRITE_POSTPROCESSOR_SCRIPT, "");
+        setDefaultValue(SKIP_LOCAL_SOQL_VERIFICATION, false);
     }
 
     /**

--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -261,9 +261,9 @@ public class Controller {
                 && !mappingFile.isBlank() && !Files.exists(Path.of(mappingFile))) {
             throw new MappingInitializationException("Mapping file " + mappingFile + " does not exist");
         }
-        // Initialize mapping 
+        // Initialize mapping
         this.mapper = getConfig().getOperationInfo().isExtraction() ? 
-                new SOQLMapper(getPartnerClient(), dao.getColumnNames(), getFieldTypes().getFields(), mappingFile) 
+                new SOQLMapper(getPartnerClient(), dao.getColumnNames(), getFieldTypes().getFields(), mappingFile, getConfig().getBoolean(Config.SKIP_LOCAL_SOQL_VERIFICATION)) 
               : new LoadMapper(getPartnerClient(), dao.getColumnNames(), getFieldTypes().getFields(), mappingFile);
     }
 

--- a/src/main/java/com/salesforce/dataloader/dao/DataWriter.java
+++ b/src/main/java/com/salesforce/dataloader/dao/DataWriter.java
@@ -62,4 +62,6 @@ public interface DataWriter extends DataAccessObject {
      * @throws DataAccessObjectException
      */
     boolean writeRowList(List<Row> inputRowList) throws DataAccessObjectException;
+    
+    public void setColumnNamesFromResults(boolean flag);
 }

--- a/src/main/java/com/salesforce/dataloader/dao/database/DatabaseWriter.java
+++ b/src/main/java/com/salesforce/dataloader/dao/database/DatabaseWriter.java
@@ -281,4 +281,7 @@ public class DatabaseWriter implements DataWriter {
         // TODO: Ordered column names can possibly used for ordered output from the write. Currently, this is not used
         // since writeRow will contain column information anyway and order doesn't matter in database
     }
+    
+    public void setColumnNamesFromResults(boolean flag) {
+    }
 }

--- a/src/main/java/com/salesforce/dataloader/mapping/Mapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/Mapper.java
@@ -143,7 +143,7 @@ public abstract class Mapper {
     }
 
     protected void mapConstants(Row rowMap) {
-        rowMap.putAll(this.constants);
+        rowMap.putAll(constants);
     }
 
     private Properties loadProperties(String fileName) throws MappingInitializationException {

--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionSOQLPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionSOQLPage.java
@@ -91,6 +91,7 @@ public class ExtractionSOQLPage extends ExtractionPage {
     private ArrayList<Field> selectedFieldsInFieldViewer = new ArrayList<Field>();
     private Button addWhereClause;
     private Button clearAllWhereClauses;
+    private Button skipLocalChecksButton;
 
     public ExtractionSOQLPage(Controller controller) {
         super("ExtractionSOQLPage", controller); //$NON-NLS-1$ //$NON-NLS-2$
@@ -497,6 +498,16 @@ public class ExtractionSOQLPage extends ExtractionPage {
             @Override
             public void modifyText(ModifyEvent arg0) {
                 setPageComplete();
+            }
+        });
+        
+        // skip local checks
+        skipLocalChecksButton = new Button(comp, SWT.CHECK);
+        skipLocalChecksButton.setText(Labels.getString(this.getClass().getSimpleName() + ".skipLocalValidation"));
+        skipLocalChecksButton.setSelection(controller.getConfig().getBoolean(Config.SKIP_LOCAL_SOQL_VERIFICATION));
+        skipLocalChecksButton.addSelectionListener(new SelectionAdapter() {
+            public void widgetSelected(SelectionEvent event) {
+                controller.getConfig().setValue(Config.SKIP_LOCAL_SOQL_VERIFICATION, skipLocalChecksButton.getSelection());
             }
         });
         labelSeparator = new Label(comp, SWT.SEPARATOR | SWT.HORIZONTAL);

--- a/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
@@ -66,6 +66,7 @@ import com.sforce.ws.util.FileUtil;
 public abstract class ProcessTestBase extends ConfigTestBase {
 
     private static Logger logger = LogManager.getLogger(ProcessTestBase.class);
+    private int serverApiInvocationThreshold = 50;
 
     protected ProcessTestBase() {
         super(Collections.<String, String>emptyMap());
@@ -775,7 +776,7 @@ public abstract class ProcessTestBase extends ConfigTestBase {
             verifyFailureFile(controller, numFailures);        //A.S.: To be removed and replaced
             verifySuccessFile(controller, numInserts, numUpdates, emptyId);
             long serverAPIInvocations = HttpClientTransport.getServerInvocationCount();
-            assertTrue("Number of server invocations (" + serverAPIInvocations + ") have exceeded the threshold of 50", serverAPIInvocations <= 50);
+            assertTrue("Number of server invocations (" + serverAPIInvocations + ") have exceeded the threshold of " + serverApiInvocationThreshold, serverAPIInvocations <= serverApiInvocationThreshold);
         } else {
             assertFalse("Expected process to fail but got success: " + actualMessage, monitor.isSuccess());
         }
@@ -787,6 +788,10 @@ public abstract class ProcessTestBase extends ConfigTestBase {
 
         // return the controller used by the process so that the tests can validate success/error output files, etc
         return controller;
+    }
+    
+    protected void setServerApiInvocationThreshold(int threshold) {
+        serverApiInvocationThreshold = threshold;
     }
 
     private static final String INSERT_MSG = "Item Created";


### PR DESCRIPTION
As SoQL adds more features such as Select FIELDS(), data loader cannot keep up with them with local checks. Adding option to skip local checks to support this.