### PR TITLE
setting to keep wizard page open when an operation finishes

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -412,6 +412,7 @@ public class Config {
     public static final String READ_ONLY_CONFIG_PROPERTIES = "config.properties.readonly";
     public static final String WIZARD_WIDTH = "sfdc.ui.wizard.width";
     public static final String WIZARD_HEIGHT = "sfdc.ui.wizard.height";
+    public static final String WIZARD_CLOSE_ON_FINISH = "sfdc.ui.wizard.closeOnFinish";
     public static final int DEFAULT_WIZARD_WIDTH = 600;
     public static final int DEFAULT_WIZARD_HEIGHT = 700;
     
@@ -601,6 +602,7 @@ public class Config {
         setDefaultValue(DAO_READ_PREPROCESSOR_SCRIPT, "");
         setDefaultValue(DAO_WRITE_POSTPROCESSOR_SCRIPT, "");
         setDefaultValue(SKIP_LOCAL_SOQL_VERIFICATION, false);
+        setDefaultValue(WIZARD_CLOSE_ON_FINISH, true);
     }
 
     /**

--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -106,6 +106,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
     private Button buttonCsvComma;
     private Button buttonCsvTab;
     private Button buttonLoginFromBrowser;
+    private Button buttonCloseWizardOnFinish;
     private static final String[] LOGGING_LEVEL = { "ALL", "DEBUG", "INFO", "WARN", "ERROR", "FATAL" };
     private Combo comboLoggingLevelDropdown;
     
@@ -689,6 +690,18 @@ public class AdvancedSettingsDialog extends BaseDialog {
         data.horizontalSpan = 2;
         blankAgain.setLayoutData(data);
         
+        Label closeWizardOnFinishCheckboxText = new Label(restComp, SWT.RIGHT | SWT.WRAP);
+        closeWizardOnFinishCheckboxText.setText(Labels.getString("AdvancedSettingsDialog.closeWizardOnFinish"));
+        closeWizardOnFinishCheckboxText.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_END));
+        boolean closeWizardOnFinish = config.getBoolean(Config.WIZARD_CLOSE_ON_FINISH);
+        buttonCloseWizardOnFinish = new Button(restComp, SWT.CHECK);
+        buttonCloseWizardOnFinish.setSelection(closeWizardOnFinish);
+
+        blankAgain = new Label(restComp, SWT.NONE);
+        data = new GridData();
+        data.horizontalSpan = 2;
+        blankAgain.setLayoutData(data);
+        
         Label labelLoggingConfigFile = new Label(restComp, SWT.RIGHT | SWT.WRAP);
         labelLoggingConfigFile.setText(Labels.getString("AdvancedSettingsDialog.loggingConfigFile")); //$NON-NLS-1$
         data = new GridData(GridData.HORIZONTAL_ALIGN_END);
@@ -828,6 +841,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
                 config.setValue(Config.BULK_API_ZIP_CONTENT, buttonBulkApiZipContent.getSelection());
                 config.setValue(Config.BULKV2_API_ENABLED, buttonUseBulkV2Api.getSelection());
                 config.setValue(Config.OAUTH_LOGIN_FROM_BROWSER, buttonLoginFromBrowser.getSelection());
+                config.setValue(Config.WIZARD_CLOSE_ON_FINISH, buttonCloseWizardOnFinish.getSelection());
                 LoggingUtil.setLoggingLevel(LOGGING_LEVEL[comboLoggingLevelDropdown.getSelectionIndex()]);
                 String clientIdVal = textProductionClientID.getText();
                 if (clientIdVal != null && !clientIdVal.strip().isEmpty()) {

--- a/src/main/java/com/salesforce/dataloader/ui/BaseWizard.java
+++ b/src/main/java/com/salesforce/dataloader/ui/BaseWizard.java
@@ -77,5 +77,9 @@ public abstract class BaseWizard extends Wizard {
     protected WizardPage getFinishPage() {
         return finishPage;
     }
+    
+    protected boolean closeWizardPagePostSuccessfulFinish() {
+        return getConfig().getBoolean(Config.WIZARD_CLOSE_ON_FINISH);
+    }
 
 }

--- a/src/main/java/com/salesforce/dataloader/ui/LoadWizard.java
+++ b/src/main/java/com/salesforce/dataloader/ui/LoadWizard.java
@@ -107,7 +107,7 @@ public abstract class LoadWizard extends BaseWizard {
             return false;
         }
 
-        return true;
+        return closeWizardPagePostSuccessfulFinish();
     }
 
     @Override

--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionWizard.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionWizard.java
@@ -149,7 +149,7 @@ public class ExtractionWizard extends BaseWizard {
             return false;
         }
 
-        return getController().isLastOperationSuccessful();
+        return getController().isLastOperationSuccessful() && closeWizardPagePostSuccessfulFinish();
     }
 
     @Override

--- a/src/main/resources/labels.properties
+++ b/src/main/resources/labels.properties
@@ -111,6 +111,7 @@ AdvancedSettingsDialog.configDir=Folder containing configuration files:\n(config
 AdvancedSettingsDialog.latestLoggingFile=Logging output file:
 AdvancedSettingsDialog.loggingConfigFile=Logging configuration file:
 AdvancedSettingsDialog.checkUploadDelimiterCheckbox=Specify delimiter(s) for upload operations.
+AdvancedSettingsDialog.closeWizardOnFinish=Close UI Wizard dialog when an operation is completed.
 
 InsertWizard.windowTitle=Load Inserts
 InsertWizard.confFirstLine=You have chosen to insert new records.  Click Yes to begin.


### PR DESCRIPTION
keeping wizard page open when an operation completes can help the user tweak a few things and re-execute the operation more easily than having to start from the scratch.