### PR TITLE
Output all sobject fields in the query result if output column names not set

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/AbstractExtractAction.java
+++ b/src/main/java/com/salesforce/dataloader/action/AbstractExtractAction.java
@@ -136,7 +136,6 @@ abstract class AbstractExtractAction extends AbstractAction {
 
     @Override
     protected void initOperation() throws DataAccessObjectInitializationException, OperationException {
-        getDao().setColumnNamesFromResults(!getController().getConfig().getBoolean(Config.LIMIT_OUTPUT_TO_QUERY_FIELDS));
         if (getController().getConfig().getBoolean(Config.LIMIT_OUTPUT_TO_QUERY_FIELDS)) {
             final List<String> daoColumns = getDaoColumnsFromMapper();
             getDao().setColumnNames(daoColumns);

--- a/src/main/java/com/salesforce/dataloader/dao/DataWriter.java
+++ b/src/main/java/com/salesforce/dataloader/dao/DataWriter.java
@@ -62,6 +62,4 @@ public interface DataWriter extends DataAccessObject {
      * @throws DataAccessObjectException
      */
     boolean writeRowList(List<Row> inputRowList) throws DataAccessObjectException;
-    
-    public void setColumnNamesFromResults(boolean flag);
 }

--- a/src/main/java/com/salesforce/dataloader/dao/database/DatabaseWriter.java
+++ b/src/main/java/com/salesforce/dataloader/dao/database/DatabaseWriter.java
@@ -281,7 +281,4 @@ public class DatabaseWriter implements DataWriter {
         // TODO: Ordered column names can possibly used for ordered output from the write. Currently, this is not used
         // since writeRow will contain column information anyway and order doesn't matter in database
     }
-    
-    public void setColumnNamesFromResults(boolean flag) {
-    }
 }


### PR DESCRIPTION
Output all sobject fields in the query result if output column names not set either through a mapping file, or through a mappings list provided in the UI (currently does not exist), or through extraction of query fields.