### PR TITLE
field mappings when fields are not explicitly specified in a query

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/AbstractExtractAction.java
+++ b/src/main/java/com/salesforce/dataloader/action/AbstractExtractAction.java
@@ -46,7 +46,7 @@ import com.salesforce.dataloader.util.AppUtil;
  * @author Colin jarvis
  * @since 21.0
  */
-abstract class AbstractExtractAction extends AbstractAction {
+abstract public class AbstractExtractAction extends AbstractAction {
 
     protected AbstractExtractAction(Controller controller, ILoaderProgress monitor)
             throws DataAccessObjectInitializationException {
@@ -61,7 +61,7 @@ abstract class AbstractExtractAction extends AbstractAction {
 
     @Override
     protected boolean writeStatus() {
-        return getConfig().getBoolean(Config.ENABLE_EXTRACT_STATUS_OUTPUT);
+        return getConfig().getBoolean(Config.LIMIT_OUTPUT_TO_QUERY_FIELDS) && getConfig().getBoolean(Config.ENABLE_EXTRACT_STATUS_OUTPUT);
     }
 
     @Override

--- a/src/main/java/com/salesforce/dataloader/action/BulkExtractAction.java
+++ b/src/main/java/com/salesforce/dataloader/action/BulkExtractAction.java
@@ -49,9 +49,9 @@ class BulkExtractAction extends AbstractExtractAction {
     @Override
     protected IVisitor createVisitor() {
     	if (getController().getConfig().isBulkV2APIEnabled() ) {
-    		return new BulkV2QueryVisitor(getController(), getMonitor(), getDao(), getSuccessWriter(), getErrorWriter());
+    		return new BulkV2QueryVisitor(this, getController(), getMonitor(), getDao(), getSuccessWriter(), getErrorWriter());
     	}
-        return new BulkV1QueryVisitor(getController(), getMonitor(), getDao(), getSuccessWriter(), getErrorWriter());
+        return new BulkV1QueryVisitor(this, getController(), getMonitor(), getDao(), getSuccessWriter(), getErrorWriter());
     }
 
 }

--- a/src/main/java/com/salesforce/dataloader/action/PartnerExtractAction.java
+++ b/src/main/java/com/salesforce/dataloader/action/PartnerExtractAction.java
@@ -45,7 +45,7 @@ class PartnerExtractAction extends AbstractExtractAction {
 
     @Override
     protected IQueryVisitor createVisitor() {
-        return new PartnerQueryVisitor(getController(), getMonitor(), getDao(), getSuccessWriter(), getErrorWriter());
+        return new PartnerQueryVisitor(this, getController(), getMonitor(), getDao(), getSuccessWriter(), getErrorWriter());
     }
 
 }

--- a/src/main/java/com/salesforce/dataloader/action/PartnerExtractAllAction.java
+++ b/src/main/java/com/salesforce/dataloader/action/PartnerExtractAllAction.java
@@ -47,7 +47,7 @@ class PartnerExtractAllAction extends AbstractExtractAction {
 
     @Override
     protected IVisitor createVisitor() {
-        return new PartnerQueryAllVisitor(getController(), getMonitor(), getDao(), getSuccessWriter(), getErrorWriter());
+        return new PartnerQueryAllVisitor(this, getController(), getMonitor(), getDao(), getSuccessWriter(), getErrorWriter());
     }
 
 }

--- a/src/main/java/com/salesforce/dataloader/action/visitor/AbstractQueryVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/AbstractQueryVisitor.java
@@ -26,6 +26,7 @@
 
 package com.salesforce.dataloader.action.visitor;
 
+import com.salesforce.dataloader.action.AbstractExtractAction;
 import com.salesforce.dataloader.action.progress.ILoaderProgress;
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.config.Messages;
@@ -59,8 +60,9 @@ abstract class AbstractQueryVisitor extends AbstractVisitor implements IQueryVis
     private final List<Row> batchRows;
     private final List<String> batchIds;
     private final int batchSize;
+    protected final AbstractExtractAction action;
 
-    public AbstractQueryVisitor(Controller controller, ILoaderProgress monitor, DataWriter queryWriter,
+    public AbstractQueryVisitor(AbstractExtractAction action, Controller controller, ILoaderProgress monitor, DataWriter queryWriter,
             DataWriter successWriter, DataWriter errorWriter) {
         super(controller, monitor, successWriter, errorWriter);
         this.queryWriter = queryWriter;
@@ -68,6 +70,7 @@ abstract class AbstractQueryVisitor extends AbstractVisitor implements IQueryVis
         this.batchRows = new LinkedList<Row>();
         this.batchIds = new LinkedList<String>();
         this.batchSize = getWriteBatchSize();
+        this.action = action;
     }
 
     @Override

--- a/src/main/java/com/salesforce/dataloader/action/visitor/AbstractVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/AbstractVisitor.java
@@ -47,8 +47,8 @@ public abstract class AbstractVisitor implements IVisitor {
 
     protected final Controller controller;
     private final ILoaderProgress monitor;
-    private final DataWriter successWriter;
-    private final DataWriter errorWriter;
+    private DataWriter successWriter;
+    private DataWriter errorWriter;
     private long errors;
     private long successes;
     private final LoadRateCalculator rateCalculator;
@@ -64,6 +64,13 @@ public abstract class AbstractVisitor implements IVisitor {
     }
 
     protected abstract boolean writeStatus();
+    
+    protected void setSuccessWriter(DataWriter successWriter) {
+        this.successWriter = successWriter;
+    }
+    protected void setErrorWriter(DataWriter errorWriter) {
+        this.errorWriter = errorWriter;
+    }
 
     protected void addSuccess() {
         this.successes++;

--- a/src/main/java/com/salesforce/dataloader/action/visitor/BulkV1QueryVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/BulkV1QueryVisitor.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 
+import com.salesforce.dataloader.action.AbstractExtractAction;
 import com.salesforce.dataloader.action.progress.ILoaderProgress;
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.controller.Controller;
@@ -54,9 +55,9 @@ public class BulkV1QueryVisitor extends AbstractBulkQueryVisitor {
 
     private BatchInfo[] batches;
 
-    public BulkV1QueryVisitor(Controller controller, ILoaderProgress monitor, DataWriter queryWriter,
+    public BulkV1QueryVisitor(AbstractExtractAction action, Controller controller, ILoaderProgress monitor, DataWriter queryWriter,
             DataWriter successWriter, DataWriter errorWriter) {
-        super(controller, monitor, queryWriter, successWriter, errorWriter);
+        super(action, controller, monitor, queryWriter, successWriter, errorWriter);
     }
 
     @Override

--- a/src/main/java/com/salesforce/dataloader/action/visitor/BulkV2QueryVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/BulkV2QueryVisitor.java
@@ -29,6 +29,7 @@ package com.salesforce.dataloader.action.visitor;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.salesforce.dataloader.action.AbstractExtractAction;
 import com.salesforce.dataloader.action.progress.ILoaderProgress;
 import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.dao.DataWriter;
@@ -48,9 +49,9 @@ public class BulkV2QueryVisitor extends AbstractBulkQueryVisitor {
 
     private String jobId;
 
-    public BulkV2QueryVisitor(Controller controller, ILoaderProgress monitor, DataWriter queryWriter,
+    public BulkV2QueryVisitor(AbstractExtractAction action, Controller controller, ILoaderProgress monitor, DataWriter queryWriter,
             DataWriter successWriter, DataWriter errorWriter) {
-        super(controller, monitor, queryWriter, successWriter, errorWriter);
+        super(action, controller, monitor, queryWriter, successWriter, errorWriter);
     }
 
     @Override

--- a/src/main/java/com/salesforce/dataloader/action/visitor/PartnerQueryAllVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/PartnerQueryAllVisitor.java
@@ -26,6 +26,7 @@
 
 package com.salesforce.dataloader.action.visitor;
 
+import com.salesforce.dataloader.action.AbstractExtractAction;
 import com.salesforce.dataloader.action.progress.ILoaderProgress;
 import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.dao.DataWriter;
@@ -40,9 +41,9 @@ import com.sforce.ws.ConnectionException;
  */
 public class PartnerQueryAllVisitor extends PartnerQueryVisitor {
 
-    public PartnerQueryAllVisitor(Controller controller, ILoaderProgress monitor, DataWriter queryWriter,
+    public PartnerQueryAllVisitor(AbstractExtractAction action, Controller controller, ILoaderProgress monitor, DataWriter queryWriter,
             DataWriter successWriter, DataWriter errorWriter) {
-        super(controller, monitor, queryWriter, successWriter, errorWriter);
+        super(action, controller, monitor, queryWriter, successWriter, errorWriter);
     }
 
     @Override

--- a/src/test/java/com/salesforce/dataloader/process/ProcessExtractTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessExtractTestBase.java
@@ -349,7 +349,9 @@ public abstract class ProcessExtractTestBase extends ProcessTestBase {
                     .getSOQL("ID, BILLINGADDRESS, NAME, TYPE, PHONE, ACCOUNTNUMBER__C, WEBSITE, ANNUALREVENUE, LASTMODIFIEDDATE, ORACLE_ID__C");
             
         }
-        Controller control = runProcess(getTestConfig(soql, "Account", true), numRecords);
+        Map<String, String> testConfig = getTestConfig(soql, "Account", true);
+        testConfig.put(Config.DAO_WRITE_BATCH_SIZE, "10"); // total 100 entries in the results file, write in chunks of 10
+        Controller control = runProcess(testConfig, numRecords);
         // verify IDs and phone format 
         verifyIdsInCSV(control, accountIds, true);
         


### PR DESCRIPTION
Fix the issue that field mappings are not used when fields are not explicitly specified in a query.