### PR TITLE
test cleanup improvements

### DIFF
--- a/src/test/java/com/salesforce/dataloader/TestBase.java
+++ b/src/test/java/com/salesforce/dataloader/TestBase.java
@@ -223,10 +223,6 @@ abstract class TestBase {
         return controller;
     }
 
-    protected void setController(Controller controller) {
-        this.controller = controller;
-    }
-    
     String apiVersionForTheSession = null;
     /**
      * @return PartnerConnection - binding to use to call the salesforce API

--- a/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
@@ -77,12 +77,6 @@ public abstract class ProcessTestBase extends ConfigTestBase {
         HttpClientTransport.resetServerInvocationCount();
     }
 
-    @After
-    public void cleanRecords() {
-        // cleanup the records that might've been created on previous tests
-        this.getBinding().cleanup();
-    }
-
     protected void verifyErrors(Controller controller, String expectedErrorMessage) throws DataAccessObjectException {
         String fileName = controller.getConfig().getString(Config.OUTPUT_ERROR);
         final CSVFileReader errReader = new CSVFileReader(new File(fileName), getController().getConfig(), true, false);
@@ -718,7 +712,8 @@ public abstract class ProcessTestBase extends ConfigTestBase {
         {
             args[i++] = entry.getKey() + "=" + entry.getValue();
         }
-        final TestProgressMontitor monitor = new TestProgressMontitor();        
+        this.getBinding(); // establish the test connection if not done so already
+        final TestProgressMontitor monitor = new TestProgressMontitor();
         return DataLoaderRunner.runApp(args, monitor);
     }
 


### PR DESCRIPTION
Create a PartnerConnectionForTest instance for all test runs including for those where batch processing is used to create sobjects. This ensures full clean up of sobjects created during a test run.