### PR TITLE
Fix for W-14287051

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
@@ -292,9 +292,6 @@ public abstract class DAOLoadVisitor extends AbstractVisitor implements DAORowVi
 
     public static String convertToHTMLFormatting(String fvalue, String regex) {
         String[] outsideHTMLTags = fvalue.split(regex);
-        if (outsideHTMLTags.length == 0) {
-            return escapeHTMLChars(fvalue);
-        }
         Pattern htmlTagInRichTextPattern = Pattern.compile(regex);
         Matcher matcher = htmlTagInRichTextPattern.matcher(fvalue);
         String htmlEscapedValue = "";


### PR DESCRIPTION
Fix for W-14287051 - Unable to insert/update a file preview image into a rich text field after data loader version 58.0.3 and higher.

The issue is due to the code skipping the check for HTML tag if there are characters outside a HTML tag. Fix is to do the HTML tag check even if there are no chars outside a HTML tag.