### PR TITLE
ignore mapping file config property in the UI mode

### DIFF
--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -261,6 +261,9 @@ public class Controller {
                 && !mappingFile.isBlank() && !Files.exists(Path.of(mappingFile))) {
             throw new MappingInitializationException("Mapping file " + mappingFile + " does not exist");
         }
+        if (AppUtil.getAppRunMode() == AppUtil.APP_RUN_MODE.UI) {
+            mappingFile = null;  // Do not use mapping file value set in config.properties in the interactive (UI) mode
+        }
         // Initialize mapping
         this.mapper = getConfig().getOperationInfo().isExtraction() ? 
                 new SOQLMapper(getPartnerClient(), dao.getColumnNames(), getFieldTypes().getFields(), mappingFile) 

--- a/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
@@ -288,7 +288,6 @@ public class MappingDialog extends BaseDialog {
                 }
 
                 if (!cancel) {
-                    config.setValue(Config.MAPPING_FILE, filename);
                     try {
                         mapper.save(filename);
                     } catch (IOException e1) {


### PR DESCRIPTION
UI mode enables the user to perform multiple operations on multiple objects in a single run (sequentially, but without having to rerun data loader). Using mapping file config property in the UI mode can result in unexpected results such as error thrown when performing extract operation or incorrect field mappings for an upload operation. The fix is to ignore mapping file property "process.mappingFile" in the UI mode.