### PR TITLE
Fix for a bug in setting lookup relationship field's attributes

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/ForeignKeyExternalIdPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/ForeignKeyExternalIdPage.java
@@ -199,8 +199,8 @@ public class ForeignKeyExternalIdPage extends LoadPage {
                 String childFieldLabel = childField.getLabel();
                 String[] childFieldLabelParts = childFieldLabel.split(" \\(.+\\)$");
                 relatedField.setLabel(childFieldLabelParts[0] + " (" + parentField.getLabel() + ")");
-                relatedField.setCreateable(parentField.isCreateable());
-                relatedField.setUpdateable(parentField.isUpdateable());
+                relatedField.setCreateable(childField.isCreateable());
+                relatedField.setUpdateable(childField.isUpdateable());
                 relatedField.setType(FieldType.reference);
                 String[] refToArray = new String[1];
                 refToArray[0] = refObjectInfo.getParentObjectName();


### PR DESCRIPTION
lookup relationship field's attributes such as isCreateable and isUpdateable should be based on child object's lookup field, not the parent object's isLookup field.