### PR TITLE
support lookup using non-createable/non-modifiable parent field

### DIFF
--- a/src/main/java/com/salesforce/dataloader/client/DescribeRefObject.java
+++ b/src/main/java/com/salesforce/dataloader/client/DescribeRefObject.java
@@ -49,7 +49,7 @@ public class DescribeRefObject {
         this.childField = childField;
     }
 
-    public Map<String, Field> getFieldInfoMap() {
+    public Map<String, Field> getParentObjectFieldMap() {
         return parentFieldInfoMap;
     }
 

--- a/src/main/java/com/salesforce/dataloader/dyna/SObjectReference.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/SObjectReference.java
@@ -71,7 +71,7 @@ public class SObjectReference {
         // set entity type, has to be set before all others
         sObjRef.setType(entityRefInfo.getParentObjectName());
         // set external id, do type conversion as well
-        Class typeClass = SforceDynaBean.getConverterClass(entityRefInfo.getFieldInfoMap().get(fieldName));
+        Class typeClass = SforceDynaBean.getConverterClass(entityRefInfo.getParentObjectFieldMap().get(fieldName));
         Object extIdValue = ConvertUtils.convert(this.referenceExtIdValue.toString(), typeClass);
         sObjRef.setField(fieldName, extIdValue);
         // Add the sObject reference as a child elemetn, name set to relationshipName
@@ -101,7 +101,7 @@ public class SObjectReference {
 
     public static String getRelationshipField(Controller controller, String refFieldName) {
         final String relName = new ObjectField(refFieldName).getObjectName();
-        controller.getReferenceDescribes().get(relName).getFieldInfoMap();
+        controller.getReferenceDescribes().get(relName).getParentObjectFieldMap();
         for (Field f : controller.getFieldTypes().getFields()) {
             if (f != null) {
                 if (relName.equals(f.getRelationshipName())) { return f.getName(); }

--- a/src/main/java/com/salesforce/dataloader/dyna/SforceDynaBean.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/SforceDynaBean.java
@@ -90,7 +90,7 @@ public class SforceDynaBean {
 
                 DescribeRefObject refInfo = controller.getReferenceDescribes().get(relationshipName);
                 if(refInfo != null) {
-                    for(String refFieldName : refInfo.getFieldInfoMap().keySet()) {
+                    for(String refFieldName : refInfo.getParentObjectFieldMap().keySet()) {
                         // property name contains information for mapping
                         dynaProps.add(new DynaProperty(ObjectField.formatAsString(relationshipName, refFieldName),
                                 SObjectReference.class));

--- a/src/main/java/com/salesforce/dataloader/ui/ForeignKeyExternalIdPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/ForeignKeyExternalIdPage.java
@@ -151,7 +151,7 @@ public class ForeignKeyExternalIdPage extends LoadPage {
 
         // get object's ext id info & set combo box to list of external id fields
         // set the objects reference information
-        List<String> fieldList = new ArrayList<String>(extIdInfo.getFieldInfoMap().keySet());
+        List<String> fieldList = new ArrayList<String>(extIdInfo.getParentObjectFieldMap().keySet());
         // add default selection "not selected" to the list to allow users to go back to it
         fieldList.add(Labels.getString("ForeignKeyExternalIdPage.defaultComboText"));
         UIUtils.setComboItems(extIdCombo, fieldList, Labels.getString("ForeignKeyExternalIdPage.defaultComboText"));
@@ -193,7 +193,7 @@ public class ForeignKeyExternalIdPage extends LoadPage {
                 DescribeRefObject refObjectInfo = referenceObjects.get(relationshipName);
                 extIdReferences.put(relationshipName, ObjectField.formatAsString(refObjectInfo.getParentObjectName(), extIdFieldName));
                 Field relatedField = new Field();
-                Field parentField = refObjectInfo.getFieldInfoMap().get(extIdFieldName);
+                Field parentField = refObjectInfo.getParentObjectFieldMap().get(extIdFieldName);
                 Field childField = refObjectInfo.getChildField();
                 relatedField.setName(relationshipName + ":" + parentField.getName());
                 String childFieldLabel = childField.getLabel();


### PR DESCRIPTION
support relationship lookup using non-createable/non-modifiable parent field such as an autonumber field marked as an external id.