### PR TITLE
check SoQL syntax when skipping field extraction from query

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/AbstractExtractAction.java
+++ b/src/main/java/com/salesforce/dataloader/action/AbstractExtractAction.java
@@ -139,6 +139,10 @@ abstract public class AbstractExtractAction extends AbstractAction {
         if (getController().getConfig().getBoolean(Config.LIMIT_OUTPUT_TO_QUERY_FIELDS)) {
             final List<String> daoColumns = getDaoColumnsFromMapper();
             getDao().setColumnNames(daoColumns);
+        } else {
+            // check for syntactical correctness and presence of nested soql.
+            // nested soql is currently not supported.
+            ((SOQLMapper)getController().getMapper()).parseSoql(getConfig().getString(Config.EXTRACT_SOQL));
         }
     }
 

--- a/src/main/java/com/salesforce/dataloader/mapping/SOQLMapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/SOQLMapper.java
@@ -191,6 +191,15 @@ public class SOQLMapper extends Mapper {
         mapConstants(resultRow);
         return resultRow;
     }
+    
+    public boolean parseSoql(String soql) throws InvalidMappingException {
+        try {
+            new SOQLInfo(soql);
+        } catch (SOQLParserException e) {
+            throw new InvalidMappingException(e.getMessage(), e);
+        }
+        return true;
+    }
 
     public void initSoqlMapping(String soql) {
         if (this.isInitialized) {


### PR DESCRIPTION
check SoQL syntax when skipping field extraction from query. It also checks for the presence of nested queries, not currently supported.