### PR TITLE
more specific error message for nested soql support

### DIFF
--- a/src/main/java/com/salesforce/dataloader/mapping/SOQLInfo.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/SOQLInfo.java
@@ -54,7 +54,7 @@ class SOQLInfo {
             fieldString = getTrimmed(fieldString);
             int lparenIdx = fieldString.indexOf('(');
             // no nested queries!
-            if (lparenIdx == 0) throw invalidSoql("Nested queries are not supported");
+            if (lparenIdx == 0) throw invalidSoql("Nested queries are not supported in SOQL SELECT clause");
             if (lparenIdx < 0) {
                 // normal field
                 this.fieldName = fieldString;


### PR DESCRIPTION
The "nested queries are not supported" error message needs to be more specific because Data Loader does not support nested queries in SELECT clause. However, it supports nested queries in WHERE clause.