### PR TITLE
update tests related to unsupported nested queries

### DIFF
--- a/src/test/java/com/salesforce/dataloader/mapping/SoqlInfoTest.java
+++ b/src/test/java/com/salesforce/dataloader/mapping/SoqlInfoTest.java
@@ -175,7 +175,7 @@ public class SoqlInfoTest {
     @Test
     public void testNestedQuery() {
         runInvalidQueryTest("select id, (select name from contacts) from account blarney",
-                "Nested queries are not supported");
+                "Nested queries are not supported in SOQL SELECT clause");
     }
 
     @Test

--- a/src/test/java/com/salesforce/dataloader/process/ProcessExtractTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessExtractTestBase.java
@@ -217,7 +217,7 @@ public abstract class ProcessExtractTestBase extends ProcessTestBase {
         soql = "Select Account.Name, (Select Contact.LastName FROM Account.Contacts) FROM Account";
         argmap = getTestConfig(soql, "Account", false);
         // this error message to change
-        runProcessNegative(argmap, "Invalid soql: Nested queries are not supported");
+        runProcessNegative(argmap, "Invalid soql: Nested queries are not supported in SOQL SELECT clause");
     }
 
     public abstract void testSoqlWithRelationships() throws Exception;


### PR DESCRIPTION
The message about unsupported nested queries has changed to be more specific to nested queries in SOQL SELECT clause. Tests that check for the message need to be updated too.