### PR TITLE
clear mapping when initializing ExtractAction

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/AbstractExtractAction.java
+++ b/src/main/java/com/salesforce/dataloader/action/AbstractExtractAction.java
@@ -136,6 +136,7 @@ abstract public class AbstractExtractAction extends AbstractAction {
 
     @Override
     protected void initOperation() throws DataAccessObjectInitializationException, OperationException {
+        ((SOQLMapper)getController().getMapper()).clearMap();
         if (getController().getConfig().getBoolean(Config.LIMIT_OUTPUT_TO_QUERY_FIELDS)) {
             final List<String> daoColumns = getDaoColumnsFromMapper();
             getDao().setColumnNames(daoColumns);

--- a/src/main/java/com/salesforce/dataloader/mapping/SOQLMapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/SOQLMapper.java
@@ -281,7 +281,6 @@ public class SOQLMapper extends Mapper {
     }
     
     public void clearMap() {
-        super.clearMap();
         this.extractionMap.clear();
         this.isInitialized = false;
     }


### PR DESCRIPTION
clear mapping when initializing ExtractAction to support correct display of soql results without closing the extraction wizard.