### PR TITLE
code cleanup to reduce compiler warnings

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/OperationInfoUIHelper.java
+++ b/src/main/java/com/salesforce/dataloader/action/OperationInfoUIHelper.java
@@ -33,7 +33,6 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.swt.graphics.Image;
 
-import com.salesforce.dataloader.action.progress.ILoaderProgress;
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.config.Messages;
 import com.salesforce.dataloader.controller.Controller;

--- a/src/main/java/com/salesforce/dataloader/action/visitor/DAOSizeVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/DAOSizeVisitor.java
@@ -28,7 +28,6 @@ package com.salesforce.dataloader.action.visitor;
 
 import com.salesforce.dataloader.model.Row;
 
-import java.util.Map;
 
 /**
  * Visitor to calculate the size of a DataAccessObject

--- a/src/main/java/com/salesforce/dataloader/action/visitor/PartnerLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/PartnerLoadVisitor.java
@@ -28,7 +28,6 @@ package com.salesforce.dataloader.action.visitor;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 import com.salesforce.dataloader.model.Row;
 import org.apache.commons.beanutils.DynaBean;

--- a/src/main/java/com/salesforce/dataloader/client/DefaultSimplePost.java
+++ b/src/main/java/com/salesforce/dataloader/client/DefaultSimplePost.java
@@ -49,7 +49,6 @@ import org.apache.http.message.BasicNameValuePair;
 import java.io.*;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.zip.GZIPInputStream;
 

--- a/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
+++ b/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
@@ -791,7 +791,6 @@ public class PartnerClient extends ClientBase<PartnerConnection> {
         }
         if (getDescribeGlobalResults() != null) {
             Field[] entityFields = getFieldTypes().getFields();
-            String entityName = this.config.getString(Config.ENTITY);
 
             for (Field childObjectField : entityFields) {
                 // upsert on references (aka foreign keys) is supported only

--- a/src/main/java/com/salesforce/dataloader/client/SessionInfo.java
+++ b/src/main/java/com/salesforce/dataloader/client/SessionInfo.java
@@ -29,6 +29,7 @@ import java.util.Calendar;
 
 import com.sforce.soap.partner.GetUserInfoResult;
 
+@SuppressWarnings("serial")
 public class SessionInfo {
 
     public static class NotLoggedInException extends RuntimeException {

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -41,7 +41,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -1199,19 +1198,6 @@ public class Config {
     }
 
     /**
-     * @param propName name of the property
-     * @return old value of the property
-     */
-    private String encryptProperty(String propName) throws GeneralSecurityException, UnsupportedEncodingException {
-        String oldValue = getString(propName);
-        if (oldValue != null && oldValue.length() > 0) {
-
-            putValue(propName, encrypter.encryptMsg(oldValue));
-        }
-        return oldValue;
-    }
-
-    /**
      * Saves this config to the given output stream. The given string is inserted as header
      * information.
      *
@@ -1261,10 +1247,6 @@ public class Config {
         setValue(name, value, false);
     }
     
-    private void setDefaultValue(String name, Date value) {
-        setValue(name, value, true);
-    }
-    
     private void setValue(String name, Date value, boolean skipIfAlreadySet) {
         setProperty(name, DATE_FORMATTER.format(value), skipIfAlreadySet);
     }
@@ -1274,10 +1256,6 @@ public class Config {
      */
     public void setValue(String name, String... values) {
         setValue(name, false, values);
-    }
-    
-    private void setDefaultValue(String name, String... values) {
-        setValue(name, true, values);
     }
     
     private void setValue(String name,  boolean skipIfAlreadySet, String... values) {

--- a/src/main/java/com/salesforce/dataloader/config/LinkedProperties.java
+++ b/src/main/java/com/salesforce/dataloader/config/LinkedProperties.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 /**
  * A simple replacement for properties that will allow us to maintain order on a proprties object
  */
+@SuppressWarnings("serial")
 public class LinkedProperties extends Properties {
     private final LinkedHashMap<Object, Object> sorted =new LinkedHashMap<>();
 

--- a/src/main/java/com/salesforce/dataloader/dao/DataReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/DataReader.java
@@ -27,7 +27,6 @@
 package com.salesforce.dataloader.dao;
 
 import java.util.List;
-import java.util.Map;
 
 import com.salesforce.dataloader.exception.DataAccessObjectException;
 import com.salesforce.dataloader.model.Row;

--- a/src/main/java/com/salesforce/dataloader/dao/DataWriter.java
+++ b/src/main/java/com/salesforce/dataloader/dao/DataWriter.java
@@ -27,7 +27,6 @@
 package com.salesforce.dataloader.dao;
 
 import java.util.List;
-import java.util.Map;
 
 import com.salesforce.dataloader.exception.DataAccessObjectException;
 import com.salesforce.dataloader.exception.DataAccessObjectInitializationException;

--- a/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileReader.java
@@ -43,7 +43,6 @@ import org.apache.logging.log4j.LogManager;
 
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.config.Messages;
-import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.dao.DataReader;
 import com.salesforce.dataloader.exception.DataAccessObjectException;
 import com.salesforce.dataloader.exception.DataAccessObjectInitializationException;

--- a/src/main/java/com/salesforce/dataloader/dao/database/DatabaseConfig.java
+++ b/src/main/java/com/salesforce/dataloader/dao/database/DatabaseConfig.java
@@ -51,7 +51,8 @@ public class DatabaseConfig {
         	dbConfigFileLocation = "file://".concat(dbConfigFileLocation);
         }
         
-    	ApplicationContext  configFactory = new FileSystemXmlApplicationContext(dbConfigFileLocation);
+    	@SuppressWarnings("resource")
+        ApplicationContext  configFactory = new FileSystemXmlApplicationContext(dbConfigFileLocation);
         return (DatabaseConfig)configFactory.getBean(dbConnectionName);
     }
 

--- a/src/main/java/com/salesforce/dataloader/dyna/BooleanConverter.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/BooleanConverter.java
@@ -87,6 +87,7 @@ public final class BooleanConverter implements Converter {
      *  successfully
      */
     @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Object convert(Class type, Object value) {
 
         if (value == null || value instanceof Boolean) {

--- a/src/main/java/com/salesforce/dataloader/dyna/DateTimeConverter.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/DateTimeConverter.java
@@ -120,6 +120,7 @@ public class DateTimeConverter implements Converter {
 
 
     @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Object convert(Class type, Object value) {
         if (value == null) {
             return null;

--- a/src/main/java/com/salesforce/dataloader/dyna/DoubleConverter.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/DoubleConverter.java
@@ -78,6 +78,7 @@ public final class DoubleConverter implements Converter {
      *                if conversion cannot be performed successfully
      */
     @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Object convert(Class type, Object value) {
         if (value == null || String.valueOf(value).length() == 0) {
             return null;

--- a/src/main/java/com/salesforce/dataloader/dyna/FileByteArrayConverter.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/FileByteArrayConverter.java
@@ -87,6 +87,7 @@ public final class FileByteArrayConverter implements Converter {
      *                if conversion cannot be performed successfully
      */
     @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Object convert(Class type, Object value) {
 
         if (value == null || String.valueOf(value).length() == 0) { return null; }

--- a/src/main/java/com/salesforce/dataloader/dyna/IntegerConverter.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/IntegerConverter.java
@@ -77,6 +77,7 @@ public final class IntegerConverter implements Converter {
      *                if conversion cannot be performed successfully
      */
     @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Object convert(Class type, Object value) {
         if (value == null || String.valueOf(value).length() == 0) {
             return null;

--- a/src/main/java/com/salesforce/dataloader/dyna/SObjectReference.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/SObjectReference.java
@@ -71,7 +71,7 @@ public class SObjectReference {
         // set entity type, has to be set before all others
         sObjRef.setType(entityRefInfo.getParentObjectName());
         // set external id, do type conversion as well
-        Class typeClass = SforceDynaBean.getConverterClass(entityRefInfo.getParentObjectFieldMap().get(fieldName));
+        Class<?> typeClass = SforceDynaBean.getConverterClass(entityRefInfo.getParentObjectFieldMap().get(fieldName));
         Object extIdValue = ConvertUtils.convert(this.referenceExtIdValue.toString(), typeClass);
         sObjRef.setField(fieldName, extIdValue);
         // Add the sObject reference as a child elemetn, name set to relationshipName

--- a/src/main/java/com/salesforce/dataloader/dyna/SObjectReferenceConverter.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/SObjectReferenceConverter.java
@@ -83,6 +83,7 @@ public class SObjectReferenceConverter implements Converter {
      *  successfully
      */
     @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Object convert(Class type, Object value) {
         try {
             Object refValue = value;

--- a/src/main/java/com/salesforce/dataloader/dyna/StringConverter.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/StringConverter.java
@@ -93,6 +93,7 @@ public final class StringConverter implements Converter {
      *  successfully
      */
     @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Object convert(Class type, Object value) {
 
         if (value == null || String.valueOf(value).isEmpty()) {

--- a/src/main/java/com/salesforce/dataloader/exception/OAuthBrowserLoginRunnerException.java
+++ b/src/main/java/com/salesforce/dataloader/exception/OAuthBrowserLoginRunnerException.java
@@ -26,6 +26,7 @@
 
 package com.salesforce.dataloader.exception;
 
+@SuppressWarnings("serial")
 public class OAuthBrowserLoginRunnerException extends Exception{
 
     /**

--- a/src/main/java/com/salesforce/dataloader/mapping/SOQLInfo.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/SOQLInfo.java
@@ -37,6 +37,7 @@ import com.salesforce.dataloader.util.AppUtil;
  * @author Colin Jarvis
  * @since 21.0
  */
+@SuppressWarnings("serial")
 class SOQLInfo {
 
     static class SOQLParserException extends Exception {

--- a/src/main/java/com/salesforce/dataloader/model/LoginCriteria.java
+++ b/src/main/java/com/salesforce/dataloader/model/LoginCriteria.java
@@ -95,11 +95,11 @@ public class LoginCriteria {
     }
 
     public void updateConfig(Config config) {
-        config.setValue(Config.USERNAME, config.STRING_DEFAULT);
-        config.setValue(Config.PASSWORD, config.STRING_DEFAULT);
+        config.setValue(Config.USERNAME, Config.STRING_DEFAULT);
+        config.setValue(Config.PASSWORD, Config.STRING_DEFAULT);
         config.setValue(Config.SFDC_INTERNAL_IS_SESSION_ID_LOGIN, false);
-        config.setValue(Config.SFDC_INTERNAL_SESSION_ID, config.STRING_DEFAULT);
-        config.setValue(Config.OAUTH_ENVIRONMENT, config.STRING_DEFAULT);
+        config.setValue(Config.SFDC_INTERNAL_SESSION_ID, Config.STRING_DEFAULT);
+        config.setValue(Config.OAUTH_ENVIRONMENT, Config.STRING_DEFAULT);
 
         switch (getMode()){
             case LoginCriteria.UsernamePasswordLoginStandard:

--- a/src/main/java/com/salesforce/dataloader/model/NACalendarValue.java
+++ b/src/main/java/com/salesforce/dataloader/model/NACalendarValue.java
@@ -30,6 +30,7 @@ import java.util.GregorianCalendar;
 /**
  * Represents a null value for a datetime field.
  */
+@SuppressWarnings("serial")
 public class NACalendarValue extends GregorianCalendar {
 
     private static final NACalendarValue INSTANCE = new NACalendarValue();

--- a/src/main/java/com/salesforce/dataloader/model/NADateOnlyCalendarValue.java
+++ b/src/main/java/com/salesforce/dataloader/model/NADateOnlyCalendarValue.java
@@ -27,6 +27,7 @@ package com.salesforce.dataloader.model;
 
 import com.salesforce.dataloader.util.DateOnlyCalendar;
 
+@SuppressWarnings("serial")
 public class NADateOnlyCalendarValue  extends DateOnlyCalendar {
 
     private static final NADateOnlyCalendarValue INSTANCE = new NADateOnlyCalendarValue();

--- a/src/main/java/com/salesforce/dataloader/model/Row.java
+++ b/src/main/java/com/salesforce/dataloader/model/Row.java
@@ -27,7 +27,6 @@ package com.salesforce.dataloader.model;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;

--- a/src/main/java/com/salesforce/dataloader/ui/BaseWizard.java
+++ b/src/main/java/com/salesforce/dataloader/ui/BaseWizard.java
@@ -27,7 +27,6 @@ package com.salesforce.dataloader.ui;
 
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.jface.wizard.WizardPage;
-import org.eclipse.swt.graphics.Image;
 
 import com.salesforce.dataloader.action.OperationInfo;
 import com.salesforce.dataloader.config.Config;

--- a/src/main/java/com/salesforce/dataloader/ui/CSVViewerDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/CSVViewerDialog.java
@@ -27,7 +27,6 @@
 package com.salesforce.dataloader.ui;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -63,7 +62,6 @@ import com.salesforce.dataloader.ui.csvviewer.CSVContentProvider;
 import com.salesforce.dataloader.ui.csvviewer.CSVLabelProvider;
 import com.salesforce.dataloader.util.AppUtil;
 import com.salesforce.dataloader.util.DAORowUtil;
-import com.salesforce.dataloader.util.StreamGobbler;
 
 /**
  * This class creates the mapping dialog

--- a/src/main/java/com/salesforce/dataloader/ui/EntitySelectionListViewerUtil.java
+++ b/src/main/java/com/salesforce/dataloader/ui/EntitySelectionListViewerUtil.java
@@ -28,15 +28,12 @@ package com.salesforce.dataloader.ui;
 
 import org.eclipse.jface.viewers.ListViewer;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.events.ControlEvent;
 import org.eclipse.swt.events.ControlListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
@@ -45,11 +42,10 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 
 import com.salesforce.dataloader.config.Config;
-import com.salesforce.dataloader.exception.ParameterLoadException;
 import com.salesforce.dataloader.ui.entitySelection.EntityContentProvider;
 import com.salesforce.dataloader.ui.entitySelection.EntityFilter;
 import com.salesforce.dataloader.ui.entitySelection.EntityLabelProvider;
-import com.salesforce.dataloader.ui.entitySelection.EntityViewerSorter;
+import com.salesforce.dataloader.ui.entitySelection.EntityViewerComparator;
 
 public class EntitySelectionListViewerUtil {
     private static final String PROPERTIES_PREFIX_STR = "DataSelectionPage";
@@ -94,7 +90,7 @@ public class EntitySelectionListViewerUtil {
             
         });
         listViewer.addFilter(filter);
-        listViewer.setSorter(new EntityViewerSorter());
+        listViewer.setComparator(new EntityViewerComparator());
         
         filterAll.addSelectionListener(new SelectionAdapter() {
             @Override

--- a/src/main/java/com/salesforce/dataloader/ui/LoaderWizardDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/LoaderWizardDialog.java
@@ -323,25 +323,6 @@ public class LoaderWizardDialog extends LoaderTitleAreaDialog implements IWizard
         }
     }
 
-    /**
-     * Calculates the difference in size between the given page and the page container. A larger page results in a
-     * positive delta.
-     *
-     * @param page
-     *            the page
-     * @return the size difference encoded as a <code>new Point(deltaWidth,deltaHeight)</code>
-     */
-    private Point calculatePageSizeDelta(IWizardPage page) {
-        Control pageControl = page.getControl();
-        if (pageControl == null)
-            // control not created yet
-            return new Point(0, 0);
-        Point contentSize = pageControl.computeSize(SWT.DEFAULT, SWT.DEFAULT, true);
-        Rectangle rect = pageContainerLayout.getClientArea(pageContainer);
-        Point containerSize = new Point(rect.width, rect.height);
-        return new Point(Math.max(0, contentSize.x - containerSize.x), Math.max(0, contentSize.y - containerSize.y));
-    }
-
     /*
      * (non-Javadoc) Method declared on Dialog.
      */
@@ -1047,14 +1028,15 @@ public class LoaderWizardDialog extends LoaderTitleAreaDialog implements IWizard
      *            the saved UI state as returned by <code>aboutToStart</code>
      * @see #aboutToStart
      */
+    @SuppressWarnings("unchecked")
     private void stopped(Object savedState) {
         if (getShell() != null) {
             if (wizard.needsProgressMonitor()) {
                 progressMonitorPart.setVisible(false);
                 progressMonitorPart.removeFromCancelComponent(cancelButton);
             }
-            Map state = (Map)savedState;
-            restoreUIState(state);
+            Map<?,?> state = (Map<?,?>)savedState;
+            restoreUIState((Map<String, Boolean>)state);
             cancelButton.addSelectionListener(cancelListener);
             setDisplayCursor(null);
             cancelButton.setCursor(null);

--- a/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
@@ -265,7 +265,6 @@ public class MappingDialog extends BaseDialog {
             @Override
             public void widgetSelected(SelectionEvent event) {
                 FileDialog dlg = new FileDialog(shell, SWT.SAVE);
-                Config config = getController().getConfig();
                 dlg.setFilterExtensions(new String[] { "*.sdl" });
                 String filename = dlg.open();
                 boolean cancel = false;
@@ -335,7 +334,7 @@ public class MappingDialog extends BaseDialog {
         mappingTblViewer = new TableViewer(shell, SWT.FULL_SELECTION);
         mappingTblViewer.setContentProvider(new MappingContentProvider());
         mappingTblViewer.setLabelProvider(new MappingLabelProvider());
-        mappingTblViewer.setSorter(new MappingViewerSorter());
+        mappingTblViewer.setComparator(new MappingViewerComparator());
 
         data = new GridData(GridData.FILL_BOTH);
 
@@ -360,7 +359,7 @@ public class MappingDialog extends BaseDialog {
                 //\u007f is delete
                 if (event.character == '\u007f' || event.character == '\b') {
                     IStructuredSelection selection = (IStructuredSelection)mappingTblViewer.getSelection();
-                    for (Iterator it = selection.iterator(); it.hasNext();) {
+                    for (Iterator<?> it = selection.iterator(); it.hasNext();) {
                         @SuppressWarnings("unchecked")
                         Map.Entry<String, String> elem = (Entry<String, String>)it.next();
                         String oldSforce = elem.getValue();
@@ -385,7 +384,7 @@ public class MappingDialog extends BaseDialog {
         csvFieldsCol.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent event) {
-                ((MappingViewerSorter)mappingTblViewer.getSorter()).doSort(MAPPING_DAO);
+                ((MappingViewerComparator)mappingTblViewer.getComparator()).doSort(MAPPING_DAO);
                 mappingTblViewer.refresh();
             }
         });
@@ -396,7 +395,7 @@ public class MappingDialog extends BaseDialog {
         sforceFieldNamesCol.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent event) {
-                ((MappingViewerSorter)mappingTblViewer.getSorter()).doSort(MAPPING_SFORCE);
+                ((MappingViewerComparator)mappingTblViewer.getComparator()).doSort(MAPPING_SFORCE);
                 mappingTblViewer.refresh();
             }
         });
@@ -424,7 +423,7 @@ public class MappingDialog extends BaseDialog {
         sforceTblViewer = new TableViewer(shell, SWT.FULL_SELECTION);
         sforceTblViewer.setContentProvider(new SforceContentProvider());
         sforceTblViewer.setLabelProvider(new SforceLabelProvider(this.getController()));
-        sforceTblViewer.setSorter(new SforceViewerSorter());
+        sforceTblViewer.setComparator(new SforceViewerComparator());
         sforceTblViewer.addFilter(new SforceFieldsFilter(sforceFieldsSearch));
 
         //add drag support
@@ -447,7 +446,7 @@ public class MappingDialog extends BaseDialog {
         tc.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent event) {
-                ((SforceViewerSorter)sforceTblViewer.getSorter()).doSort(FIELD_NAME);
+                ((SforceViewerComparator)sforceTblViewer.getComparator()).doSort(FIELD_NAME);
                 sforceTblViewer.refresh();
             }
         });
@@ -458,7 +457,7 @@ public class MappingDialog extends BaseDialog {
         tc.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent event) {
-                ((SforceViewerSorter)sforceTblViewer.getSorter()).doSort(FIELD_LABEL);
+                ((SforceViewerComparator)sforceTblViewer.getComparator()).doSort(FIELD_LABEL);
                 sforceTblViewer.refresh();
             }
         });
@@ -469,7 +468,7 @@ public class MappingDialog extends BaseDialog {
         tc.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent event) {
-                ((SforceViewerSorter)sforceTblViewer.getSorter()).doSort(FIELD_TYPE);
+                ((SforceViewerComparator)sforceTblViewer.getComparator()).doSort(FIELD_TYPE);
                 sforceTblViewer.refresh();
             }
         });

--- a/src/main/java/com/salesforce/dataloader/ui/OAuthFlow.java
+++ b/src/main/java/com/salesforce/dataloader/ui/OAuthFlow.java
@@ -25,11 +25,8 @@
  */
 package com.salesforce.dataloader.ui;
 
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+
 import com.salesforce.dataloader.config.Config;
-import com.salesforce.dataloader.model.OAuthToken;
 
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.Logger;
@@ -41,10 +38,6 @@ import org.eclipse.swt.widgets.Dialog;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.util.HashMap;

--- a/src/main/java/com/salesforce/dataloader/ui/OAuthLoginDefaultControl.java
+++ b/src/main/java/com/salesforce/dataloader/ui/OAuthLoginDefaultControl.java
@@ -61,6 +61,7 @@ public class OAuthLoginDefaultControl extends Composite {
 
         grid.createPadding(2);
 
+        @SuppressWarnings("unused")
         Label emptyLabel = grid.createLabel(8, "");
         loginButton = grid.createButton(2, SWT.PUSH | SWT.FILL | SWT.FLAT, Labels.getString("SettingsPage.login"));
         loginButton.addListener(SWT.Selection, this::loginButton_Clicked);

--- a/src/main/java/com/salesforce/dataloader/ui/OAuthTokenFlow.java
+++ b/src/main/java/com/salesforce/dataloader/ui/OAuthTokenFlow.java
@@ -28,11 +28,8 @@ package com.salesforce.dataloader.ui;
 
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.model.OAuthToken;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.browser.ProgressEvent;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 
 import java.io.UnsupportedEncodingException;

--- a/src/main/java/com/salesforce/dataloader/ui/OperationPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/OperationPage.java
@@ -29,7 +29,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.WizardPage;
-import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;

--- a/src/main/java/com/salesforce/dataloader/ui/UsernamePasswordLoginStandardControl.java
+++ b/src/main/java/com/salesforce/dataloader/ui/UsernamePasswordLoginStandardControl.java
@@ -86,6 +86,7 @@ public class UsernamePasswordLoginStandardControl extends Composite {
         instanceUrl = grid.createText(6, SWT.BORDER, authentication.getConfig().getString(Config.ENDPOINT));
         grid.createPadding(2);
 
+        @SuppressWarnings("unused")
         Label emptyLabel = grid.createLabel(8, "");
         loginButton = grid.createButton(2, SWT.PUSH | SWT.FILL | SWT.FLAT, Labels.getString("SettingsPage.login"));
         loginButton.addListener(SWT.Selection, this::loginButton_Clicked);

--- a/src/main/java/com/salesforce/dataloader/ui/csvviewer/CSVContentProvider.java
+++ b/src/main/java/com/salesforce/dataloader/ui/csvviewer/CSVContentProvider.java
@@ -44,9 +44,8 @@ public class CSVContentProvider implements IStructuredContentProvider {
      * @return Object[]
      */
     @Override
-    @SuppressWarnings("unchecked")
     public Object[] getElements(Object arg0) {
-        List rowList = (List) arg0;
+        List<?> rowList = (List<?>) arg0;
         return rowList.toArray(new List[rowList.size()]);
 
     }

--- a/src/main/java/com/salesforce/dataloader/ui/csvviewer/CSVLabelProvider.java
+++ b/src/main/java/com/salesforce/dataloader/ui/csvviewer/CSVLabelProvider.java
@@ -57,7 +57,7 @@ public class CSVLabelProvider implements ITableLabelProvider {
      */
     @Override
     public String getColumnText(Object arg0, int arg1) {
-        List elem = (List)arg0;
+        List<?> elem = (List<?>)arg0;
         if (elem.size() > arg1) {
             Object obj = elem.get(arg1);
             return obj != null ? obj.toString() : "";

--- a/src/main/java/com/salesforce/dataloader/ui/entitySelection/EntityContentProvider.java
+++ b/src/main/java/com/salesforce/dataloader/ui/entitySelection/EntityContentProvider.java
@@ -46,7 +46,7 @@ public class EntityContentProvider implements IStructuredContentProvider {
      */
     @Override
     public Object[] getElements(Object arg0) {
-        return ((HashMap)arg0).values().toArray();
+        return ((HashMap<?, ?>)arg0).values().toArray();
     }
 
     /**

--- a/src/main/java/com/salesforce/dataloader/ui/entitySelection/EntityViewerComparator.java
+++ b/src/main/java/com/salesforce/dataloader/ui/entitySelection/EntityViewerComparator.java
@@ -24,67 +24,28 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.salesforce.dataloader.ui.mapping;
+package com.salesforce.dataloader.ui.entitySelection;
 
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 
-import com.salesforce.dataloader.ui.MappingDialog;
-import com.sforce.soap.partner.Field;
+import com.sforce.soap.partner.DescribeGlobalSObjectResult;
 
 /**
- * This class implements the sorting for the SforceTable
+ * Sorts the Entity Lists
+ *
+ * @author Lexi Viripaeff
+ * @since 6.0
  */
-public class SforceViewerSorter extends ViewerSorter {
-    private static final int ASCENDING = 0;
-    private static final int DESCENDING = 1;
-
-    private int column = 0;
-    private int direction = ASCENDING;
-
-    /**
-     * Does the sort. If it's a different column from the previous sort, do an ascending sort. If it's the same column
-     * as the last sort, toggle the sort direction.
-     *
-     * @param column
-     */
-    public void doSort(int column) {
-        if (column == this.column) {
-            // Same column as last sort; toggle the direction
-            direction = 1 - direction;
-        } else {
-            // New column; do an ascending sort
-            this.column = column;
-            direction = ASCENDING;
-        }
-    }
-
-    /**
-     * Compares the object for sorting
-     */
+public class EntityViewerComparator extends ViewerComparator {
     @Override
     public int compare(Viewer viewer, Object e1, Object e2) {
-        int rc = 0;
-        Field f1 = (Field)e1;
-        Field f2 = (Field)e2;
+        DescribeGlobalSObjectResult d1 = (DescribeGlobalSObjectResult)e1;
+        DescribeGlobalSObjectResult d2 = (DescribeGlobalSObjectResult)e2;
 
         // Determine which column and do the appropriate sort
-        switch (column) {
-        case MappingDialog.FIELD_LABEL:
-            rc = collator.compare(f1.getLabel(), f2.getLabel());
-            break;
-        case MappingDialog.FIELD_NAME:
-            rc = collator.compare(f1.getName(), f2.getName());
-            break;
-        case MappingDialog.FIELD_TYPE:
-            rc = collator.compare(f1.getType().toString(), f2.getType().toString());
-            break;
-        }
-
-
-        // If descending order, flip the direction
-        if (direction == DESCENDING) rc = -rc;
-
-        return rc;
+        return d1.getLabel().compareToIgnoreCase(d2.getLabel());
     }
+
+
 }

--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtrFieldLabelProvider.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtrFieldLabelProvider.java
@@ -50,6 +50,7 @@ public class ExtrFieldLabelProvider extends CellLabelProvider {
     @Override
     public void addListener(ILabelProviderListener arg0) {
         // Throw it away
+        @SuppressWarnings("unused")
         ILabelProviderListener listener = arg0;
     }
 

--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionDataSelectionPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionDataSelectionPage.java
@@ -38,7 +38,6 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.*;
 
-import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.dao.DataAccessObjectFactory;
 import com.salesforce.dataloader.exception.MappingInitializationException;

--- a/src/main/java/com/salesforce/dataloader/ui/mapping/MappingDragListener.java
+++ b/src/main/java/com/salesforce/dataloader/ui/mapping/MappingDragListener.java
@@ -63,7 +63,7 @@ public class MappingDragListener extends DragSourceAdapter {
                 IStructuredSelection selection = (IStructuredSelection)viewer.getSelection();
                 Field[] fields = (Field[])viewer.getInput();
                 ArrayList<Field> fieldList = new ArrayList<Field>(Arrays.asList(fields));
-                for (Iterator it = selection.iterator(); it.hasNext();) {
+                for (Iterator<?> it = selection.iterator(); it.hasNext();) {
                     Field eventField = (Field)it.next();
                     fieldList.remove(eventField);
                 }

--- a/src/main/java/com/salesforce/dataloader/ui/mapping/MappingViewerComparator.java
+++ b/src/main/java/com/salesforce/dataloader/ui/mapping/MappingViewerComparator.java
@@ -29,14 +29,14 @@ package com.salesforce.dataloader.ui.mapping;
 import java.util.Map.Entry;
 
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 
 import com.salesforce.dataloader.ui.MappingDialog;
 
 /**
  * This class implements the sorting for the SforceTable
  */
-public class MappingViewerSorter extends ViewerSorter {
+public class MappingViewerComparator extends ViewerComparator {
     private static final int ASCENDING = 0;
     private static final int DESCENDING = 1;
 
@@ -68,7 +68,7 @@ public class MappingViewerSorter extends ViewerSorter {
             return -1;
         if (s2 == null)
             return 1;
-        return collator.compare(s1, s2);
+        return s1.compareToIgnoreCase(s2);
     }
 
     /**

--- a/src/main/java/com/salesforce/dataloader/ui/mapping/SforceDragListener.java
+++ b/src/main/java/com/salesforce/dataloader/ui/mapping/SforceDragListener.java
@@ -61,7 +61,7 @@ public class SforceDragListener extends DragSourceAdapter {
         try {
             if (event.detail == DND.DROP_MOVE) {
                 IStructuredSelection selection = (IStructuredSelection)viewer.getSelection();
-                for (Iterator it = selection.iterator(); it.hasNext();) {
+                for (Iterator<?> it = selection.iterator(); it.hasNext();) {
                     @SuppressWarnings("unchecked")
                     Map.Entry<String, String> eventElem = (Entry<String, String>)it.next();
                     eventElem.setValue("");

--- a/src/main/java/com/salesforce/dataloader/ui/mapping/SforceLabelProvider.java
+++ b/src/main/java/com/salesforce/dataloader/ui/mapping/SforceLabelProvider.java
@@ -26,8 +26,6 @@
 
 package com.salesforce.dataloader.ui.mapping;
 
-import java.util.Map;
-
 import org.eclipse.jface.viewers.ILabelProviderListener;
 import org.eclipse.jface.viewers.ITableLabelProvider;
 import org.eclipse.swt.graphics.Image;
@@ -35,23 +33,17 @@ import org.eclipse.swt.graphics.Image;
 import com.salesforce.dataloader.client.DescribeRefObject;
 import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.ui.MappingDialog;
-import com.sforce.soap.partner.DescribeSObjectResult;
 import com.sforce.soap.partner.Field;
-import com.sforce.soap.partner.FieldType;
-import com.sforce.ws.ConnectionException;
+
 
 /**
  * This class provides the labels for PlayerTable
  */
 public class SforceLabelProvider implements ITableLabelProvider {
-    private Controller controller;
-    private Map<String, DescribeRefObject> referenceObjects;
 
 
     // Constructs a PlayerLabelProvider
     public SforceLabelProvider(Controller controller) {
-        this.controller = controller;
-        this.referenceObjects = controller.getReferenceDescribes();
     }
 
 

--- a/src/main/java/com/salesforce/dataloader/ui/mapping/SforceViewerComparator.java
+++ b/src/main/java/com/salesforce/dataloader/ui/mapping/SforceViewerComparator.java
@@ -24,28 +24,67 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.salesforce.dataloader.ui.entitySelection;
+package com.salesforce.dataloader.ui.mapping;
 
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.jface.viewers.ViewerSorter;
+import org.eclipse.jface.viewers.ViewerComparator;
 
-import com.sforce.soap.partner.DescribeGlobalSObjectResult;
+import com.salesforce.dataloader.ui.MappingDialog;
+import com.sforce.soap.partner.Field;
 
 /**
- * Sorts the Entity Lists
- *
- * @author Lexi Viripaeff
- * @since 6.0
+ * This class implements the sorting for the SforceTable
  */
-public class EntityViewerSorter extends ViewerSorter {
-    @Override
-    public int compare(Viewer viewer, Object e1, Object e2) {
-        DescribeGlobalSObjectResult d1 = (DescribeGlobalSObjectResult)e1;
-        DescribeGlobalSObjectResult d2 = (DescribeGlobalSObjectResult)e2;
+public class SforceViewerComparator extends ViewerComparator {
+    private static final int ASCENDING = 0;
+    private static final int DESCENDING = 1;
 
-        // Determine which column and do the appropriate sort
-        return collator.compare(d1.getLabel(), d2.getLabel());
+    private int column = 0;
+    private int direction = ASCENDING;
+
+    /**
+     * Does the sort. If it's a different column from the previous sort, do an ascending sort. If it's the same column
+     * as the last sort, toggle the sort direction.
+     *
+     * @param column
+     */
+    public void doSort(int column) {
+        if (column == this.column) {
+            // Same column as last sort; toggle the direction
+            direction = 1 - direction;
+        } else {
+            // New column; do an ascending sort
+            this.column = column;
+            direction = ASCENDING;
+        }
     }
 
+    /**
+     * Compares the object for sorting
+     */
+    @Override
+    public int compare(Viewer viewer, Object e1, Object e2) {
+        int rc = 0;
+        Field f1 = (Field)e1;
+        Field f2 = (Field)e2;
 
+        // Determine which column and do the appropriate sort
+        switch (column) {
+        case MappingDialog.FIELD_LABEL:
+            rc = f1.getLabel().compareToIgnoreCase(f2.getLabel());
+            break;
+        case MappingDialog.FIELD_NAME:
+            rc = f1.getName().compareToIgnoreCase(f2.getName());
+            break;
+        case MappingDialog.FIELD_TYPE:
+            rc = f1.getType().toString().compareToIgnoreCase(f2.getType().toString());
+            break;
+        }
+
+
+        // If descending order, flip the direction
+        if (direction == DESCENDING) rc = -rc;
+
+        return rc;
+    }
 }

--- a/src/main/java/com/salesforce/dataloader/util/OAuthBrowserLoginRunner.java
+++ b/src/main/java/com/salesforce/dataloader/util/OAuthBrowserLoginRunner.java
@@ -26,13 +26,11 @@
 
 package com.salesforce.dataloader.util;
 
-import java.awt.Desktop;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/com/salesforce/dataloader/ConfigTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/ConfigTestBase.java
@@ -26,8 +26,6 @@
 package com.salesforce.dataloader;
 
 import com.salesforce.dataloader.config.Config;
-import com.salesforce.dataloader.exception.ConfigInitializationException;
-import com.salesforce.dataloader.exception.ParameterLoadException;
 import com.salesforce.dataloader.util.AppUtil;
 
 import org.junit.Before;

--- a/src/test/java/com/salesforce/dataloader/PartnerConnectionForTest.java
+++ b/src/test/java/com/salesforce/dataloader/PartnerConnectionForTest.java
@@ -35,7 +35,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 
-import com.salesforce.dataloader.controller.Controller;
 import com.sforce.soap.partner.DeleteResult;
 import com.sforce.soap.partner.GetUserInfoResult;
 import com.sforce.soap.partner.PartnerConnection;

--- a/src/test/java/com/salesforce/dataloader/TestBase.java
+++ b/src/test/java/com/salesforce/dataloader/TestBase.java
@@ -45,7 +45,6 @@ import org.apache.logging.log4j.LogManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.springframework.util.StringUtils;

--- a/src/test/java/com/salesforce/dataloader/client/PartnerClientTest.java
+++ b/src/test/java/com/salesforce/dataloader/client/PartnerClientTest.java
@@ -62,6 +62,7 @@ import static org.junit.Assert.assertTrue;
  * @author Alex Warshavsky
  * @since 8.0
  */
+@SuppressWarnings("unused")
 public class PartnerClientTest extends ProcessTestBase {
 
     @Test

--- a/src/test/java/com/salesforce/dataloader/dao/CsvTest.java
+++ b/src/test/java/com/salesforce/dataloader/dao/CsvTest.java
@@ -39,8 +39,6 @@ import com.salesforce.dataloader.dao.csv.CSVFileWriter;
 import com.salesforce.dataloader.model.Row;
 import com.salesforce.dataloader.util.AppUtil;
 
-import org.junit.Assert;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/com/salesforce/dataloader/dao/database/DatabaseTestUtil.java
+++ b/src/test/java/com/salesforce/dataloader/dao/database/DatabaseTestUtil.java
@@ -55,6 +55,7 @@ import java.util.Map;
  * @author Alex Warshavsky
  * @since 8.0
  */
+@SuppressWarnings("serial")
 public class DatabaseTestUtil {
 
     private static final Logger logger = LogManager.getLogger(DatabaseTestUtil.class);

--- a/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
+++ b/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
@@ -29,10 +29,8 @@ import org.apache.commons.beanutils.ConversionException;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.util.AppUtil;
 
-import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;

--- a/src/test/java/com/salesforce/dataloader/mapping/LoadMapperTest.java
+++ b/src/test/java/com/salesforce/dataloader/mapping/LoadMapperTest.java
@@ -50,6 +50,7 @@ import static org.junit.Assert.assertTrue;
  * @author Federico Recio
  * @since 8.0
  */
+@SuppressWarnings("unused")
 public class LoadMapperTest extends ConfigTestBase {
 
     private static final String[] SOURCE_NAMES = { "sourceOne", "sourceTwo", "sourceThree" };

--- a/src/test/java/com/salesforce/dataloader/mapping/SOQLMapperTest.java
+++ b/src/test/java/com/salesforce/dataloader/mapping/SOQLMapperTest.java
@@ -47,6 +47,7 @@ import static org.junit.Assert.assertTrue;
  * @author Federico Recio
  * @since 27.0
  */
+@SuppressWarnings("unused")
 public class SOQLMapperTest extends ConfigTestBase {
 
     private SOQLMapper soqlMapper;

--- a/src/test/java/com/salesforce/dataloader/process/BulkV1CsvProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/BulkV1CsvProcessTest.java
@@ -26,13 +26,10 @@
 package com.salesforce.dataloader.process;
 
 import java.io.File;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/src/test/java/com/salesforce/dataloader/process/CsvEncodingProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvEncodingProcessTest.java
@@ -29,8 +29,6 @@ package com.salesforce.dataloader.process;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/test/java/com/salesforce/dataloader/process/CsvExtractAllProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvExtractAllProcessTest.java
@@ -44,6 +44,7 @@ import java.util.Map;
  * @author Aleksandr Shulman, Colin Jarvis
  * @since 21.0
  */
+@SuppressWarnings("unused")
 @RunWith(Parameterized.class)
 public class CsvExtractAllProcessTest extends ProcessExtractTestBase {
 

--- a/src/test/java/com/salesforce/dataloader/process/CsvExtractProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvExtractProcessTest.java
@@ -54,6 +54,7 @@ import static org.junit.Assert.assertTrue;
  * @since 21.0
  */
 @RunWith(Parameterized.class)
+@SuppressWarnings("unused")
 public class CsvExtractProcessTest extends ProcessExtractTestBase {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> getParameters() {

--- a/src/test/java/com/salesforce/dataloader/process/CsvHardDeleteTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvHardDeleteTest.java
@@ -55,6 +55,7 @@ import static org.junit.Assert.assertTrue;
  * @userstory Commenting existing data loader tests and uploading into QA force
  */
 @RunWith(Parameterized.class)
+@SuppressWarnings("unused")
 public class CsvHardDeleteTest extends ProcessTestBase {
 
     public CsvHardDeleteTest(Map<String, String> config) {

--- a/src/test/java/com/salesforce/dataloader/process/CsvProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvProcessTest.java
@@ -63,6 +63,7 @@ import static org.junit.Assert.assertNull;
  * @userstory Commenting existing data loader tests and uploading into QA force
  */
 @RunWith(Parameterized.class)
+@SuppressWarnings("unused")
 public class CsvProcessTest extends ProcessTestBase {
 
     public CsvProcessTest(Map<String, String> config) {

--- a/src/test/java/com/salesforce/dataloader/process/NAProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/NAProcessTest.java
@@ -26,15 +26,12 @@
 package com.salesforce.dataloader.process;
 
 import java.io.File;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
@@ -33,7 +33,6 @@ import java.util.*;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.junit.After;
 import org.junit.Assert;
 
 import com.salesforce.dataloader.*;

--- a/src/test/java/com/salesforce/dataloader/ui/OAuthSecretFlowTests.java
+++ b/src/test/java/com/salesforce/dataloader/ui/OAuthSecretFlowTests.java
@@ -137,6 +137,7 @@ public class OAuthSecretFlowTests extends ConfigTestBase {
             when(mockSimplePost.getInput()).thenAnswer(i -> input);
             when(mockSimplePost.isSuccessful()).thenReturn(true);
 
+            @SuppressWarnings("unused")
             SimplePost simplePost = OAuthSecretFlow.OAuthSecretBrowserListener.handleSecondPost("simplePost", config);
 
             String expected = "ACCESS";
@@ -164,6 +165,7 @@ public class OAuthSecretFlowTests extends ConfigTestBase {
             when(mockSimplePost.getInput()).thenAnswer(i -> input);
             when(mockSimplePost.isSuccessful()).thenReturn(true);
 
+            @SuppressWarnings("unused")
             SimplePost simplePost = OAuthSecretFlow.OAuthSecretBrowserListener.handleSecondPost("simplePost", config);
 
             String expected = "REFRESHTOKEN";
@@ -190,6 +192,7 @@ public class OAuthSecretFlowTests extends ConfigTestBase {
             when(mockSimplePost.getInput()).thenAnswer(i -> input);
             when(mockSimplePost.isSuccessful()).thenReturn(true);
 
+            @SuppressWarnings("unused")
             SimplePost simplePost = OAuthSecretFlow.OAuthSecretBrowserListener.handleSecondPost("simplePost", config);
 
             String expected = "http://INSTANCEURL";

--- a/src/test/java/com/salesforce/dataloader/util/AccountRowComparator.java
+++ b/src/test/java/com/salesforce/dataloader/util/AccountRowComparator.java
@@ -30,7 +30,6 @@ import com.salesforce.dataloader.model.Row;
 import static com.salesforce.dataloader.dao.database.DatabaseTestUtil.NAME_COL;
 
 import java.util.Comparator;
-import java.util.Map;
 
 /**
  * Comparator for the account rows from the database reader.

--- a/src/test/java/com/salesforce/dataloader/util/Base64.java
+++ b/src/test/java/com/salesforce/dataloader/util/Base64.java
@@ -1386,7 +1386,7 @@ public class Base64
                     @Override
                     public Class<?> resolveClass(java.io.ObjectStreamClass streamClass)
                     throws java.io.IOException, ClassNotFoundException {
-                        Class c = Class.forName(streamClass.getName(), false, loader);
+                        Class<?> c = Class.forName(streamClass.getName(), false, loader);
                         if( c == null ){
                             return super.resolveClass(streamClass);
                         } else {


### PR DESCRIPTION
reduce compiler warnings for
- unused variables
- unused imports
- use of deprecated apis
- raw/unchecked types
- missing serial number for serializable objects
- referencing static fields using an instance handle.