### PR TITLE
fix for maven-shade-plugin not executing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,6 @@
       </testResource>
     </testResources>
 
-	<pluginManagement>
     <plugins>
 <!-- https://mvnrepository.com/artifact/org.codehaus.mojo/versions-maven-plugin -->
       <plugin>
@@ -524,6 +523,5 @@
         </executions>
       </plugin>
     </plugins>
-    </pluginManagement>
   </build>
 </project>


### PR DESCRIPTION
Per the issue reported at https://stackoverflow.com/questions/53918867/pluginmanagement-interferes-with-shade-plugin, <pluginManagement> tags prevent maven-shade-plugin from executing, which in turn prevents creation of shaded jar. The fix is to remove <pluginManagement> tag.