### PR TITLE
sfdc.formatPhoneFields property to enable/disable formatting of phone field values

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
@@ -346,7 +346,9 @@ public abstract class DAOLoadVisitor extends AbstractVisitor implements DAORowVi
 
     private Object getPhoneFieldValue(String fieldName, Object fieldValue) {
         getHtmlFormattedAndPhoneSforceFieldList();
-        if (this.phoneSforceFieldList == null || !this.phoneSforceFieldList.contains(fieldName)) {
+        if (this.phoneSforceFieldList == null
+                || !this.phoneSforceFieldList.contains(fieldName)
+                || !this.getConfig().getBoolean(Config.FORMAT_PHONE_FIELDS)) {
             return fieldValue;
         }
         String localeStr = Locale.getDefault().toString();

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -237,6 +237,7 @@ public class Config {
     public static final String DEBUG_MESSAGES_FILE = "sfdc.debugMessagesFile"; //$NON-NLS-1$
     public static final String RESET_URL_ON_LOGIN = "sfdc.resetUrlOnLogin"; //$NON-NLS-1$
     public static final String TRUNCATE_FIELDS = "sfdc.truncateFields";//$NON-NLS-1$
+    public static final String FORMAT_PHONE_FIELDS = "sfdc.formatPhoneFields";//$NON-NLS-1$
     public static final String BULK_API_ENABLED = "sfdc.useBulkApi";
     public static final String BULK_API_SERIAL_MODE = "sfdc.bulkApiSerialMode";
     public static final String BULK_API_CHECK_STATUS_INTERVAL = "sfdc.bulkApiCheckStatusInterval";
@@ -549,6 +550,7 @@ public class Config {
         setDefaultValue(DAO_WRITE_BATCH_SIZE, DEFAULT_DAO_WRITE_BATCH_SIZE);
         setDefaultValue(DAO_READ_BATCH_SIZE, DEFAULT_DAO_READ_BATCH_SIZE);
         setDefaultValue(TRUNCATE_FIELDS, true);
+        setDefaultValue(FORMAT_PHONE_FIELDS, false);
         // TODO: When we're ready, make Bulk API turned on by default.
         setDefaultValue(BULK_API_ENABLED, useBulkApiByDefault());
         setDefaultValue(BULK_API_SERIAL_MODE, false);

--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -100,6 +100,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
     private Button buttonWriteUtf8;
     private Button buttonEuroDates;
     private Button buttonTruncateFields;
+    private Button buttonFormatPhoneFields;
     private Button buttonKeepAccountTeam;
     private Button buttonUseBulkApi;
     private Button buttonUseBulkV2Api;
@@ -444,6 +445,15 @@ public class AdvancedSettingsDialog extends BaseDialog {
 
         buttonTruncateFields = new Button(restComp, SWT.CHECK);
         buttonTruncateFields.setSelection(config.getBoolean(Config.TRUNCATE_FIELDS));
+
+        //format phone fields on the client side
+        Label labelFormatPhoneFields = new Label(restComp, SWT.RIGHT | SWT.WRAP);
+        labelFormatPhoneFields.setText(Labels.getString("AdvancedSettingsDialog.formatPhoneFields"));
+        data = new GridData(GridData.HORIZONTAL_ALIGN_END);
+        labelTruncateFields.setLayoutData(data);
+
+        buttonFormatPhoneFields = new Button(restComp, SWT.CHECK);
+        buttonFormatPhoneFields.setSelection(config.getBoolean(Config.FORMAT_PHONE_FIELDS));
 
         Label labelCsvCommand = new Label(restComp, SWT.RIGHT | SWT.WRAP);
         labelCsvCommand.setText(Labels.getString("AdvancedSettingsDialog.useCommaAsCsvDelimiter"));
@@ -851,6 +861,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
                 config.setValue(Config.RESET_URL_ON_LOGIN, buttonResetUrl.getSelection());
                 config.setValue(Config.NO_COMPRESSION, buttonCompression.getSelection());
                 config.setValue(Config.TRUNCATE_FIELDS, buttonTruncateFields.getSelection());
+                config.setValue(Config.FORMAT_PHONE_FIELDS, buttonFormatPhoneFields.getSelection());
                 config.setValue(Config.TIMEOUT_SECS, textTimeout.getText());
                 config.setValue(Config.SORT_EXTRACT_FIELDS, buttonSortExtractFields.getSelection());
                 config.setValue(Config.ENABLE_EXTRACT_STATUS_OUTPUT, buttonOutputExtractStatus.getSelection());

--- a/src/main/resources/labels.properties
+++ b/src/main/resources/labels.properties
@@ -90,6 +90,7 @@ AdvancedSettingsDialog.writeUTF8=Write all CSVs with UTF-8 encoding:
 AdvancedSettingsDialog.proxyPassword=Proxy password:
 AdvancedSettingsDialog.startRow=Start at row:
 AdvancedSettingsDialog.allowFieldTruncation=Allow field truncation:
+AdvancedSettingsDialog.formatPhoneFields=Format phone fields if the user locale is U.S. or Canada\n(For example, "1112223333" will be formatted as "(111) 222-3333"):
 AdvancedSettingsDialog.keepAccountTeam=Keep Account team when changing Account owner:
 AdvancedSettingsDialog.keepAccountTeamHelp=The uploaded .csv file must have the same current Account owner values in all rows. Similarly it must have the same new Account Owner values in all rows.
 AdvancedSettingsDialog.useBulkApi=Use Bulk API:


### PR DESCRIPTION
Data Loader v57 and earlier did not format phone fields for users in U.S. or Canada locale, resulting in the customer requests to do so such as https://ideas.salesforce.com/s/idea/a0B8W00000GdYUYUA3/phone-number-format-incorrect

v58 had the code change (https://github.com/forcedotcom/dataloader/commit/581ca6f626dc6d9eb83afad3b8d8b08076f709c4) for formatting phone fields. However, it can result in failure to upload if a validation rule such as "!REGEX(Phone,"^(\\d{10}?)?$")" is set for the phone field.

The fix is to introduce a property, sfdc.formatPhoneFields, set to false by default, which is used by data loader code to skip formatting if set to false.