### PR TITLE
Fix for menubar not showing up when upgrade dialog pops up

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/LoaderWindow.java
+++ b/src/main/java/com/salesforce/dataloader/ui/LoaderWindow.java
@@ -206,6 +206,7 @@ public class LoaderWindow extends ApplicationWindow {
         
         comp.pack();
         parent.pack();
+        addMenuBar();
 
         return parent;
     }
@@ -298,6 +299,7 @@ public class LoaderWindow extends ApplicationWindow {
             public void run() {
                 LoaderUpgradeDialog dlg = new LoaderUpgradeDialog(display.getActiveShell());
                 dlg.open();
+                addMenuBar();
             }
         });
     }


### PR DESCRIPTION
Menubar does not get displayed if upgrade dialog pops up. The fix is to explicitly call parent's addMenuBar() method.