### PR TITLE
"loader.query.limitOutputToQueryFields" in Settings dialog

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -96,6 +96,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
     private Button buttonShowLoaderUpgradeScreen;
     private Button buttonOutputExtractStatus;
     private Button buttonSortExtractFields;
+    private Button buttonLimitQueryResultColumnsToFieldsInQuery;
     private Button buttonReadUtf8;
     private Button buttonWriteUtf8;
     private Button buttonEuroDates;
@@ -400,6 +401,15 @@ public class AdvancedSettingsDialog extends BaseDialog {
 
         buttonSortExtractFields = new Button(restComp, SWT.CHECK);
         buttonSortExtractFields.setSelection(config.getBoolean(Config.SORT_EXTRACT_FIELDS));
+        
+        // enable/disable limiting query result columns to fields specified in the SOQL query
+        Label labelLimitQueryResultColumnsToFieldsInQuery = new Label(restComp, SWT.RIGHT | SWT.WRAP);
+        labelLimitQueryResultColumnsToFieldsInQuery.setText(Labels.getString(this.getClass().getSimpleName() + ".limitOutputToQueryFields")); //$NON-NLS-1$
+        data = new GridData(GridData.HORIZONTAL_ALIGN_END);
+        labelSortExtractFields.setLayoutData(data);
+       
+        buttonLimitQueryResultColumnsToFieldsInQuery = new Button(restComp, SWT.CHECK);
+        buttonLimitQueryResultColumnsToFieldsInQuery.setSelection(config.getBoolean(Config.LIMIT_OUTPUT_TO_QUERY_FIELDS));
 
         //enable/disable output of success file for extracts
         Label labelOutputExtractStatus = new Label(restComp, SWT.RIGHT | SWT.WRAP);
@@ -864,6 +874,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
                 config.setValue(Config.FORMAT_PHONE_FIELDS, buttonFormatPhoneFields.getSelection());
                 config.setValue(Config.TIMEOUT_SECS, textTimeout.getText());
                 config.setValue(Config.SORT_EXTRACT_FIELDS, buttonSortExtractFields.getSelection());
+                config.setValue(Config.LIMIT_OUTPUT_TO_QUERY_FIELDS, buttonLimitQueryResultColumnsToFieldsInQuery.getSelection());
                 config.setValue(Config.ENABLE_EXTRACT_STATUS_OUTPUT, buttonOutputExtractStatus.getSelection());
                 config.setValue(Config.READ_UTF8, buttonReadUtf8.getSelection());
                 config.setValue(Config.WRITE_UTF8, buttonWriteUtf8.getSelection());

--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionSOQLPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionSOQLPage.java
@@ -91,7 +91,6 @@ public class ExtractionSOQLPage extends ExtractionPage {
     private ArrayList<Field> selectedFieldsInFieldViewer = new ArrayList<Field>();
     private Button addWhereClause;
     private Button clearAllWhereClauses;
-    private Button skipLocalChecksButton;
 
     public ExtractionSOQLPage(Controller controller) {
         super("ExtractionSOQLPage", controller); //$NON-NLS-1$ //$NON-NLS-2$
@@ -501,15 +500,6 @@ public class ExtractionSOQLPage extends ExtractionPage {
             }
         });
         
-        // skip local checks
-        skipLocalChecksButton = new Button(comp, SWT.CHECK);
-        skipLocalChecksButton.setText(Labels.getString(this.getClass().getSimpleName() + ".limitOutputToQueryFields"));
-        skipLocalChecksButton.setSelection(controller.getConfig().getBoolean(Config.LIMIT_OUTPUT_TO_QUERY_FIELDS));
-        skipLocalChecksButton.addSelectionListener(new SelectionAdapter() {
-            public void widgetSelected(SelectionEvent event) {
-                controller.getConfig().setValue(Config.LIMIT_OUTPUT_TO_QUERY_FIELDS, skipLocalChecksButton.getSelection());
-            }
-        });
         labelSeparator = new Label(comp, SWT.SEPARATOR | SWT.HORIZONTAL);
         data = new GridData(GridData.FILL_HORIZONTAL);
         labelSeparator.setLayoutData(data);

--- a/src/main/resources/labels.properties
+++ b/src/main/resources/labels.properties
@@ -83,7 +83,8 @@ AdvancedSettingsDialog.proxyNtlmDomain=Proxy NTLM domain:
 AdvancedSettingsDialog.proxyUser=Proxy username:
 AdvancedSettingsDialog.lastBatch=The last batch finished at {0}. \nEnter {0} to continue from your last location.
 
-AdvancedSettingsDialog.sortQueryFieldsInExtraction=Sort Salesforce object field names \nwhen editing SoQL for Export:
+AdvancedSettingsDialog.sortQueryFieldsInExtraction=Sort Salesforce object field names \nwhen editing SOQL for Export:
+AdvancedSettingsDialog.limitOutputToQueryFields=Limit query result fields to the fields specified in the SOQL query:
 AdvancedSettingsDialog.outputExtractStatus=Generate status files for exports:
 AdvancedSettingsDialog.readUTF8=Read all CSVs with UTF-8 encoding:
 AdvancedSettingsDialog.writeUTF8=Write all CSVs with UTF-8 encoding:
@@ -249,7 +250,6 @@ ExtractionSOQLPage.initializeMsg=Initializing SOQL
 ExtractionSOQLPage.selectAllFields=Select all fields
 ExtractionSOQLPage.clearAllFields=Clear all fields
 ExtractionSOQLPage.clearAllConditions=Clear all conditions
-ExtractionSOQLPage.limitOutputToQueryFields=Limit results to the fields specified in the query
 
 FinishPage.title=Step 4: Finish
 FinishPage.description=Select the folder where your success and error files will be saved.


### PR DESCRIPTION
User sets the property "loader.query.limitOutputToQueryFields" in Settings dialog instead of extraction wizard steps.