### PR TITLE
Fix for W-14650178

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
@@ -314,17 +314,18 @@ public abstract class DAOLoadVisitor extends AbstractVisitor implements DAORowVi
         if (input == null) {
             return null;
         }
+        String unescapedInput = StringEscapeUtils.unescapeHtml4(input);
         StringBuffer htmlFormattedStr = new StringBuffer("");
-        for (int i = 0, len = input.length(); i < len; i++) {
-            char c = input.charAt(i);
+        for (int i = 0, len = unescapedInput.length(); i < len; i++) {
+            char c = unescapedInput.charAt(i);
             int cval = c;
             char nextChar = 0;
-            if (i+1 < input.length()) {
-                nextChar = input.charAt(i+1);
+            if (i+1 < unescapedInput.length()) {
+                nextChar = unescapedInput.charAt(i+1);
             }
             char prevChar = 0;
             if (i > 0) {
-                prevChar = input.charAt(i-1);
+                prevChar = unescapedInput.charAt(i-1);
             }
 
             boolean isCharWhitespace = Character.isWhitespace(c) || cval == NONBREAKING_SPACE_ASCII_VAL;


### PR DESCRIPTION
Fix for W-14650178 - Data Loader version 59 doesn't decode HTML entity in CSV file, resulting in double-encoding of HTML-escaped characters in a string uploaded into a Rich Text field. For example, if a string to be uploaded is "<p>ABCDE あいうえお &amp; &quot; &#127752;</p>"

Data Loader preserves all special characters such as <, >, &, which results in the following uploaded string: 
ABCDE あいうえお &amp; &quot; &#127752;

However, customers want to see the following in Rich Text field: 
ABCDE あいうえお & " 🌈