### PR TITLE
process unescaped newline characters as RichText field values

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
@@ -291,6 +291,9 @@ public abstract class DAOLoadVisitor extends AbstractVisitor implements DAORowVi
     }
 
     public static String convertToHTMLFormatting(String fvalue, String regex) {
+        fvalue = fvalue.replaceAll("\r\n", "<br/>");
+        fvalue = fvalue.replaceAll("\n", "<br/>");
+        fvalue = fvalue.replaceAll("\r", "<br/>");
         String[] outsideHTMLTags = fvalue.split(regex);
         Pattern htmlTagInRichTextPattern = Pattern.compile(regex);
         Matcher matcher = htmlTagInRichTextPattern.matcher(fvalue);

--- a/src/test/java/com/salesforce/dataloader/dao/RichTextHTMLEncodingTest.java
+++ b/src/test/java/com/salesforce/dataloader/dao/RichTextHTMLEncodingTest.java
@@ -171,12 +171,17 @@ public class RichTextHTMLEncodingTest extends ConfigTestBase {
     
     @Test
     public void testHTMLEncodedString() throws Exception {
-        String origText = "  &amp; & < * $ ~ % &quot;6400L -37° &#127752;  ";
+        String origText = "  &amp; & < * $ ~ % &quot;6400L -37° &#127752; \n1  \r2  \r\n3";
         String convertedText = DAOLoadVisitor.convertToHTMLFormatting(origText, regex);
-        assertEquals("Incorrect conversion of " + origText, origText.length() + 24, convertedText.length());
+        int diff = convertedText.length() - origText.length();
+        assertEquals("Incorrect conversion of " + origText, origText.length() + 45, convertedText.length());
+
+        String unescapedOrigText = StringEscapeUtils.unescapeHtml4(origText);
+        String unescapedConvertedText = StringEscapeUtils.unescapeHtml4(convertedText);
+        diff = unescapedConvertedText.length() - unescapedOrigText.length();
         assertEquals("Incorrect conversion of " + origText,
-                        StringEscapeUtils.unescapeHtml4(origText).length(),
-                        StringEscapeUtils.unescapeHtml4(convertedText).length());
+                unescapedOrigText.length()+11,
+                unescapedConvertedText.length());
     }
 
 


### PR DESCRIPTION
Convert '\n', '\r', and '\r\n' characters to <br/> tag before uploading into a RichText field. This is to preserve the newline character on the server side.