### PR TITLE
Preserve whitespace and newline chars in file content for ContentNote…

### DIFF
--- a/src/main/java/com/salesforce/dataloader/dyna/FileByteArrayConverter.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/FileByteArrayConverter.java
@@ -110,7 +110,13 @@ public final class FileByteArrayConverter implements Converter {
             Config config = Config.getCurrentConfig();
             if (mimeType.equalsIgnoreCase("text/plain")
                     && config != null
-                    && config.getBoolean(Config.LOAD_PRESERVE_WHITESPACE_IN_RICH_TEXT)) {
+                    && config.getBoolean(Config.LOAD_PRESERVE_WHITESPACE_IN_RICH_TEXT)
+                    && "ContentNote".equalsIgnoreCase(config.getString(Config.ENTITY))) {
+                // Preserve the formatting only if the content is of type plain text
+                // AND the flag to preserve whitespace characters in RichText fields is enabled
+                // AND the content is for ContentNote sobject. 
+                //     See https://help.salesforce.com/s/articleView?id=000387816&type=1 for how
+                //     data loader processes ContentNote.
                 String content = byteStream.toString();
                 String formattedContent = DAOLoadVisitor.convertToHTMLFormatting(content, DAOLoadVisitor.DEFAULT_RICHTEXT_REGEX);
                 return formattedContent.getBytes();


### PR DESCRIPTION
… only

Data loader does not preserve non-HTML encoded whitespace and newline characters in a content file for ContentNote object. This code change limits HTML encoding of whitespace and newline characters in a content file to operations performed on ContentNote object.