### PR TITLE
configurable caching of global sobject describe and sobject fields

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -212,7 +212,8 @@ public class Config {
     public static final String CSV_DELIMITER_OTHER_VALUE = "loader.csvOtherValue";
     public static final String CSV_DELIMITER_FOR_QUERY_RESULTS = "loader.query.delimiter";
     public static final String BUFFER_UNPROCESSED_BULK_QUERY_RESULTS = "loader.bufferUnprocessedBulkQueryResults";
-
+    public static final String CACHE_DESCRIBE_GLOBAL_RESULTS = "loader.cacheSObjectNamesAndFields";
+    
     //Special Internal Configs
     public static final String SFDC_INTERNAL = "sfdcInternal"; //$NON-NLS-1$
     public static final String SFDC_INTERNAL_IS_SESSION_ID_LOGIN = "sfdcInternal.isSessionIdLogin"; //$NON-NLS-1$
@@ -606,6 +607,7 @@ public class Config {
         setDefaultValue(DAO_WRITE_POSTPROCESSOR_SCRIPT, "");
         setDefaultValue(LIMIT_OUTPUT_TO_QUERY_FIELDS, true);
         setDefaultValue(WIZARD_CLOSE_ON_FINISH, true);
+        setDefaultValue(CACHE_DESCRIBE_GLOBAL_RESULTS, true);
     }
 
     /**

--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -186,11 +186,6 @@ public class Controller {
     public boolean loginIfSessionExists() {
         return loginIfSessionExists(getClient());
     }
-
-    public boolean setEntityDescribes() throws ConnectionException {
-        validateSession();
-        return getPartnerClient().setEntityDescribes();
-    }
     
     public static void setAPIVersion(String apiVersionStr) {
         API_VERSION = apiVersionStr;

--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -103,6 +103,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
     private Button buttonTruncateFields;
     private Button buttonFormatPhoneFields;
     private Button buttonKeepAccountTeam;
+    private Button buttonCacheDescribeGlobalResults;
     private Button buttonUseBulkApi;
     private Button buttonUseBulkV2Api;
     private Button buttonBulkApiSerialMode;
@@ -500,6 +501,15 @@ public class AdvancedSettingsDialog extends BaseDialog {
         data.widthHint = 5 * textSize.x;
         textQueryResultsDelimiterValue.setLayoutData(data);
         
+        Label labelCacheDescribeGlobalResults = new Label(restComp, SWT.RIGHT | SWT.WRAP);
+        labelCacheDescribeGlobalResults.setText(Labels.getString("AdvancedSettingsDialog.cacheDescribeGlobalResults"));
+        data = new GridData(GridData.HORIZONTAL_ALIGN_END);
+        labelCacheDescribeGlobalResults.setLayoutData(data);
+
+        boolean cacheDescribeGlobalResults = config.getBoolean(Config.CACHE_DESCRIBE_GLOBAL_RESULTS);
+        buttonCacheDescribeGlobalResults = new Button(restComp, SWT.CHECK);
+        buttonCacheDescribeGlobalResults.setSelection(cacheDescribeGlobalResults);
+        
         // Keep Account team setting
         Label labelKeepAccountTeam = new Label(restComp, SWT.RIGHT | SWT.WRAP);
         labelKeepAccountTeam.setText(Labels.getString("AdvancedSettingsDialog.keepAccountTeam"));
@@ -520,7 +530,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
         });
         buttonKeepAccountTeam.setToolTipText(Labels.getString("AdvancedSettingsDialog.keepAccountTeamHelp"));
         labelKeepAccountTeam.setToolTipText(Labels.getString("AdvancedSettingsDialog.keepAccountTeamHelp"));
-
+        
         // Enable Bulk API Setting
         Label labelUseBulkApi = new Label(restComp, SWT.RIGHT | SWT.WRAP);
         labelUseBulkApi.setText(Labels.getString("AdvancedSettingsDialog.useBulkApi")); //$NON-NLS-1$
@@ -886,6 +896,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
                 config.setValue(Config.PROXY_USERNAME, textProxyUsername.getText());
                 config.setValue(Config.PROXY_NTLM_DOMAIN, textProxyNtlmDomain.getText());
                 config.setValue(Config.PROCESS_KEEP_ACCOUNT_TEAM, buttonKeepAccountTeam.getSelection());
+                config.setValue(Config.CACHE_DESCRIBE_GLOBAL_RESULTS, buttonCacheDescribeGlobalResults.getSelection());
                 config.setValue(Config.BULK_API_ENABLED, buttonUseBulkApi.getSelection());
                 config.setValue(Config.BULK_API_SERIAL_MODE, buttonBulkApiSerialMode.getSelection());
                 config.setValue(Config.BULK_API_ZIP_CONTENT, buttonBulkApiZipContent.getSelection());

--- a/src/main/java/com/salesforce/dataloader/ui/AuthenticationRunner.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AuthenticationRunner.java
@@ -130,7 +130,7 @@ public class AuthenticationRunner {
 	                return;
             	}
             }
-            if (controller.login() && controller.setEntityDescribes()) {
+            if (controller.login() && controller.getEntityDescribes() != null) {
                 messenger.accept(Labels.getString("SettingsPage.loginSuccessful"));
                 controller.saveConfig();
                 controller.updateLoaderWindowTitleAndCacheUserInfoForTheSession();

--- a/src/main/java/com/salesforce/dataloader/ui/SettingsPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/SettingsPage.java
@@ -141,8 +141,7 @@ public class SettingsPage extends OperationPage {
     }
 
     public static boolean isNeeded(Controller controller) {
-        return (!controller.loginIfSessionExists() || controller.getEntityDescribes() == null || controller
-                .getEntityDescribes().isEmpty());
+        return (!controller.isLoggedIn());
     }
 
     private void authenticationCompleted(Boolean success){

--- a/src/main/resources/labels.properties
+++ b/src/main/resources/labels.properties
@@ -117,6 +117,7 @@ AdvancedSettingsDialog.latestLoggingFile=Logging output file:
 AdvancedSettingsDialog.loggingConfigFile=Logging configuration file:
 AdvancedSettingsDialog.checkUploadDelimiterCheckbox=Specify delimiter(s) for upload operations.
 AdvancedSettingsDialog.closeWizardOnFinish=Close UI Wizard dialog when an operation is completed.
+AdvancedSettingsDialog.cacheDescribeGlobalResults=Cache Salesforce object and field information across operations
 
 InsertWizard.windowTitle=Load Inserts
 InsertWizard.confFirstLine=You have chosen to insert new records.  Click Yes to begin.

--- a/src/test/java/com/salesforce/dataloader/client/PartnerClientTest.java
+++ b/src/test/java/com/salesforce/dataloader/client/PartnerClientTest.java
@@ -202,17 +202,12 @@ public class PartnerClientTest extends ProcessTestBase {
     @Test
     public void testSetEntityDescribe() throws Exception{
         PartnerClient client = new PartnerClient(getController());
-        assertTrue(client.setEntityDescribes());
         assertNotNull(client.getDescribeGlobalResults());
-        assertEquals(client.getEntityTypes().getSobjects().length, client
-                .getDescribeGlobalResults().size());
     }
 
     @Test
     public void testDescribeSObjects() throws Exception {
         PartnerClient client = new PartnerClient(getController());
-        assertTrue(client.getEntityDescribeMap().isEmpty());
-        client.setEntityDescribes();
 
         int numDescribes = 0;
         for (String objectType : client.getDescribeGlobalResults().keySet()){
@@ -221,7 +216,6 @@ public class PartnerClientTest extends ProcessTestBase {
         		numDescribes++;
                 assertNotNull(describeResult);
                 assertEquals(objectType, describeResult.getName());
-                assertEquals(numDescribes, client.getEntityDescribeMap().size());
         	} catch (Exception ex) {
         		if (ex.getMessage().contains("jsonNot")) {
         			System.out.println("PartnerClient.testDescribeSObjects: Unable to call describeSObject for " + objectType);


### PR DESCRIPTION
Make the caching of sobject and sobject field info configurable, thereby enabling refresh of sobject info as requested at https://ideas.salesforce.com/s/idea/a0B8W00000GdnjpUAB/refresh-the-data-structure-when-logged-in-data-loader