### PR TITLE
Display link to ContentNote limits info

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/DataSelectionDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/DataSelectionDialog.java
@@ -34,9 +34,15 @@ import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.*;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.swt.widgets.Shell;
 
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.controller.Controller;
@@ -49,6 +55,7 @@ public class DataSelectionDialog extends BaseDialog {
     private boolean success;
     private Button ok;
     private Label label;
+    private Link contentNoteLimitLink;
 
     /**
      * InputDialog constructor
@@ -133,6 +140,10 @@ public class DataSelectionDialog extends BaseDialog {
                 success = true;
                 ok.setEnabled(true);
                 String apiInfoStr = getController().getAPIInfo();
+                String contentNoteLimitsStr = "";
+                if ("ContentNote".equalsIgnoreCase(sObjectName)) {
+                    contentNoteLimitsStr = "\n\n<a href=\"https://help.salesforce.com/s/articleView?id=sf.content_file_size_limits.htm&type=5\">ContentNote limits</a>";
+                }
                 // Set the description
                 label.setText(Labels.getFormattedString(
                         "DataSelectionDialog.initSuccess", String.valueOf(totalRows))
@@ -145,7 +156,10 @@ public class DataSelectionDialog extends BaseDialog {
                         + " "
                         + getController().getConfig().getString(Config.LOAD_ROW_TO_START_AT)
                         + "\n"
-                        + apiInfoStr); //$NON-NLS-1$
+                        + apiInfoStr
+                    ); //$NON-NLS-1$
+                
+                contentNoteLimitLink.setText(contentNoteLimitsStr);
                 label.getParent().pack();
             }
 
@@ -178,6 +192,19 @@ public class DataSelectionDialog extends BaseDialog {
         labelData.horizontalSpan = 2;
         labelData.widthHint = 400;
         label.setLayoutData(labelData);
+        
+        contentNoteLimitLink = new Link(shell, SWT.WRAP);
+        contentNoteLimitLink.setText("");
+        GridData linkData = new GridData();
+        linkData.horizontalSpan = 2;
+        linkData.widthHint = 400;
+        contentNoteLimitLink.setLayoutData(linkData);
+        contentNoteLimitLink.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                UIUtils.openURL(e.text);
+            }
+          });
 
         //the bottom separator
         Label labelSeparatorBottom = new Label(shell, SWT.SEPARATOR | SWT.HORIZONTAL);


### PR DESCRIPTION
Help avoid issues such as the one reported at https://ideas.salesforce.com/s/idea/a0B8W00000Gdp7gUAB/upload-of-note-contentnote by displaying the link to ContentNote limits information if the upload operation is on ContentNote.