### PR TITLE
make "keep account team" and "use bulk API" mutually exclusive

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -525,6 +525,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
                 super.widgetSelected(e);
                 boolean enabled = buttonKeepAccountTeam.getSelection();
                 // make sure the appropriate check boxes are enabled or disabled
+                buttonUseBulkApi.setSelection(!enabled);
                 setBulkSettings(!enabled);
             }
         });
@@ -551,8 +552,10 @@ public class AdvancedSettingsDialog extends BaseDialog {
                 textBatch.setText(String.valueOf(newDefaultBatchSize));
                 // make sure the appropriate check boxes are enabled or disabled
                 setBulkSettings(enabled);
+                buttonKeepAccountTeam.setSelection(!enabled);
             }
         });
+        buttonKeepAccountTeam.setSelection(!buttonUseBulkApi.getSelection());
 
         // Bulk API serial concurrency mode setting
         Label labelBulkApiSerialMode = new Label(restComp, SWT.RIGHT | SWT.WRAP);

--- a/src/main/java/com/salesforce/dataloader/util/OAuthBrowserLoginRunner.java
+++ b/src/main/java/com/salesforce/dataloader/util/OAuthBrowserLoginRunner.java
@@ -99,6 +99,7 @@ public class OAuthBrowserLoginRunner {
         startBrowserLogin(config, skipUserCodePage);
     }
     
+    // Browser login uses OAuth 2.0 Device Flow - https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_device_flow.htm&type=5
     private void startBrowserLogin(Config config, boolean skipUserCodePage) throws IOException, ParameterLoadException, OAuthBrowserLoginRunnerException {
         setLoginStatus(LoginStatus.WAIT);
         this.config = config;


### PR DESCRIPTION
"keep account team" feature is not supported in Bulk API. So, make "keep account team" checkbox and "use bulk API" checkbox mutually exclusive.