### PR TITLE
fix date conversion edge cases

### DIFF
--- a/src/main/java/com/salesforce/dataloader/dyna/DateTimeConverter.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/DateTimeConverter.java
@@ -204,7 +204,11 @@ public class DateTimeConverter implements Converter {
         return NACalendarValue.getInstance();
     }
 
-    /* Helper function to produce all the patterns that DL supports */
+    /*
+     * Helper function to produce all the patterns that DL supports.
+     * These patterns are a subset of patterns supported by Java text.SimpleDateFormat
+     * https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html
+     */
     static List<String> getSupportedPatterns(boolean europeanDates) {
 
         List<String> basePatterns = new ArrayList<String>();
@@ -290,7 +294,14 @@ public class DateTimeConverter implements Converter {
         basePatterns.addAll(slashPatternsWithT);
 
         List<String> timeZones = new ArrayList<>();
+        // uppercase Z => RFC822 TimeZone
         basePatterns.forEach(p -> timeZones.add(p + "Z"));
+        basePatterns.forEach(p -> timeZones.add(p + " Z"));
+
+        // uppercase X => ISO8601 TimeZone
+        basePatterns.forEach(p -> timeZones.add(p + "XXX"));
+        basePatterns.forEach(p -> timeZones.add(p + " XXX"));
+
         basePatterns.addAll(timeZones);
 
         return basePatterns;

--- a/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
+++ b/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
@@ -643,6 +643,8 @@ public class DateConverterTest {
         assertInvalidDate("20A4-11-08", null, false);
     }
 
+    // test user-specified timezones and date formats specified at
+    // https://developer.salesforce.com/docs/atlas.en-us.dataLoader.meta/dataLoader/supported_data_types.htm
     @Test
     public void testUserSpecifiedTimeZoneIsUsed() throws Exception {
         DateTimeConverter AsianTZDateConverter = new DateTimeConverter(TimeZone.getTimeZone("Asia/Tokyo"));
@@ -774,6 +776,51 @@ public class DateConverterTest {
         assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
         assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
 
+        result = (Calendar) USTZDateConverter.convert(null, "2012-06-07 00:00:00 PST");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+
+        result = (Calendar) USTZDateConverter.convert(null, "2012-06-07 00:00:00Pacific Standard Time");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+
+        result = (Calendar) USTZDateConverter.convert(null, "2012-06-07 00:00:00 Pacific Standard Time");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+
+        result = (Calendar) USTZDateConverter.convert(null, "2012-06-07 00:00:00GMT-08:00");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+ 
+        result = (Calendar) USTZDateConverter.convert(null, "2012-06-07 00:00:00 GMT-08:00");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+        
+        result = (Calendar) USTZDateConverter.convert(null, "2012-06-07 00:00:00-08:00");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+        
+        result = (Calendar) USTZDateConverter.convert(null, "2012-06-07 00:00:00 -08:00");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+        
+        result = (Calendar) USTZDateConverter.convert(null, "2012-06-07 00:00:00-0800");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+        
+        result = (Calendar) USTZDateConverter.convert(null, "2012-06-07 00:00:00 -0800");
+        assertEquals(6, result.get(Calendar.MONTH) + 1);
+        assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), result.getTimeZone());
+        
         result = (Calendar) AsianTZDateConverter.convert(null, "2012-06-07 00:00:00JST");
         assertEquals(6, result.get(Calendar.MONTH) + 1);
         assertEquals(7, result.get(Calendar.DAY_OF_MONTH));


### PR DESCRIPTION
Added tests to check that date formats specified at https://developer.salesforce.com/docs/atlas.en-us.dataLoader.meta/dataLoader/supported_data_types.htm are supported.

Fixed issue with supporting formats "GMT-08:00" and "-0800".