### PR TITLE
Fix for an issue with a whitespace char in install path

### DIFF
--- a/src/main/java/com/salesforce/dataloader/util/AppUtil.java
+++ b/src/main/java/com/salesforce/dataloader/util/AppUtil.java
@@ -168,6 +168,11 @@ public class AppUtil {
         if (codeSource != null && codeSource.getLocation() != null) {
             try {
                 String jarFilePath = codeSource.getLocation().toURI().toString();
+                try {
+                    jarFilePath = java.net.URLDecoder.decode(jarFilePath, StandardCharsets.UTF_8.name());
+                } catch (UnsupportedEncodingException e) {
+                    // ignore
+                }
                 return jarFilePath.substring(jarFilePath.indexOf('/'));
             } catch (URISyntaxException e) {
                 return null;


### PR DESCRIPTION
Fixed the following issue:
Data Loader creates a folder with "%20%" in the folder name for configs if installation path has a whitespace character in it. For example, if the installation path is /my/dir/with a space/v60.0.0/, data loader creates a folder /my/dir/with%20a%20space/v60.0.0/ and creates configs folder within it.