### PR TITLE
Fix to include image content of RTF in query results

### DIFF
--- a/src/main/java/com/salesforce/dataloader/client/ClientBase.java
+++ b/src/main/java/com/salesforce/dataloader/client/ClientBase.java
@@ -86,6 +86,7 @@ public abstract class ClientBase<ClientType> {
         if (apiVersionStr != null && !apiVersionStr.isEmpty()) {
             apiVersionForTheSession = apiVersionStr;
         }
+        Controller.setAPIVersion(apiVersionForTheSession);
     }
 
     public final boolean connect(SessionInfo sess) {
@@ -115,6 +116,10 @@ public abstract class ClientBase<ClientType> {
         return apiVersionForTheSession;
     }
 
+    public ConnectorConfig getConnectorConfig() {
+        return getConnectorConfig(apiVersionForTheSession);
+    }
+    
     protected ConnectorConfig getConnectorConfig(String apiVersionStr) {
         ConnectorConfig cc = new ConnectorConfig();
         cc.setTransport(HttpClientTransport.class);

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -212,6 +212,7 @@ public class Config {
     public static final String CSV_DELIMITER_OTHER_VALUE = "loader.csvOtherValue";
     public static final String CSV_DELIMITER_FOR_QUERY_RESULTS = "loader.query.delimiter";
     public static final String BUFFER_UNPROCESSED_BULK_QUERY_RESULTS = "loader.bufferUnprocessedBulkQueryResults";
+    public static final String INCLUDE_RICH_TEXT_FIELD_DATA_IN_QUERY_RESULTS = "loader.query.includeBinaryData";
     public static final String CACHE_DESCRIBE_GLOBAL_RESULTS = "loader.cacheSObjectNamesAndFields";
     
     //Special Internal Configs
@@ -611,6 +612,7 @@ public class Config {
         setDefaultValue(WIZARD_CLOSE_ON_FINISH, true);
         setDefaultValue(CACHE_DESCRIBE_GLOBAL_RESULTS, true);
         setDefaultValue(PROCESS_EXIT_WITH_ERROR_ON_FAILED_ROWS_BATCH_MODE, false);
+        setDefaultValue(INCLUDE_RICH_TEXT_FIELD_DATA_IN_QUERY_RESULTS, false);
     }
 
     /**

--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -327,8 +327,15 @@ public class Controller {
         return this.partnerClient;
     }
 
-    private ClientBase<?> getClient() {
-        return this.config.useBulkAPIForCurrentOperation() ? getBulkV1Client() : getPartnerClient();
+    public ClientBase<?> getClient() {
+        if (this.config.useBulkAPIForCurrentOperation()) {
+            if (this.config.isBulkV2APIEnabled()) {
+                return getBulkV2Client();
+            } else {
+                return getBulkV1Client();
+            }
+        }
+        return getPartnerClient();
     }
 
     public BulkV1Client getBulkV1Client() {

--- a/src/main/java/com/salesforce/dataloader/exception/HttpClientTransportException.java
+++ b/src/main/java/com/salesforce/dataloader/exception/HttpClientTransportException.java
@@ -24,40 +24,48 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.salesforce.dataloader.client;
+package com.salesforce.dataloader.exception;
 
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.io.InputStream;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import com.salesforce.dataloader.exception.HttpClientTransportException;
-import com.sforce.async.AsyncApiException;
-import com.sforce.ws.transport.Transport;
+import java.net.HttpURLConnection;
 
 /**
- * This interface defines a Transport.
  *
- * @author http://cheenath.com
- * @version 1.0
- * @since 1.0  Nov 30, 2005
+ * @since 60.0
  */
-public interface HttpTransportInterface extends Transport {
-	enum SupportedHttpMethodType {
-		PUT,
-		POST,
-		PATCH
-	}
-    OutputStream connect(String endpoint, HashMap<String, String> httpHeaders, boolean enableCompression,
-    		HttpTransportInterface.SupportedHttpMethodType httpMethod) throws IOException;
+@SuppressWarnings("serial")
+public class HttpClientTransportException extends OperationException {
 
-    void connect(String endpoint, HashMap<String, String> httpHeaders, boolean enableCompression,
-    		HttpTransportInterface.SupportedHttpMethodType httpMethod, InputStream contentInputStream, String contentEncoding) throws IOException;
+    private InputStream inputStream;
+    private HttpURLConnection connection;
     
-    HttpURLConnection openHttpGetConnection(String urlStr, Map<String, String> headers) throws IOException;
-    InputStream httpGet(HttpURLConnection connection, String urlStr) throws IOException, AsyncApiException, HttpClientTransportException;
+    public HttpClientTransportException() {
+        super();
+    }
+
+    public HttpClientTransportException(String message, HttpURLConnection conn, InputStream is) {
+        super(message);
+        connection = conn;
+        inputStream = is;
+    }
+
+    public HttpClientTransportException(Throwable cause, HttpURLConnection conn, InputStream is) {
+        super(cause);
+        connection = conn;
+        inputStream = is;
+    }
+
+    public HttpClientTransportException(String message, Throwable cause, HttpURLConnection conn, InputStream is) {
+        super(message, cause);
+        connection = conn;
+        inputStream = is;
+    }
+    
+    public InputStream getInputStream() {
+        return inputStream;
+    }
+
+    public HttpURLConnection getConnection() {
+        return connection;
+    }
 }

--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -104,6 +104,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
     private Button buttonFormatPhoneFields;
     private Button buttonKeepAccountTeam;
     private Button buttonCacheDescribeGlobalResults;
+    private Button buttonIncludeRTFBinaryDataInQueryResults;
     private Button buttonUseBulkApi;
     private Button buttonUseBulkV2Api;
     private Button buttonBulkApiSerialMode;
@@ -501,6 +502,19 @@ public class AdvancedSettingsDialog extends BaseDialog {
         data.widthHint = 5 * textSize.x;
         textQueryResultsDelimiterValue.setLayoutData(data);
         
+        
+        // include image data for Rich Text Fields in query results
+        // Config.INCLUDE_RICH_TEXT_FIELD_DATA_IN_QUERY_RESULTS
+        Label labelIncludeRTFBinaryDataInQueryResults = new Label(restComp, SWT.RIGHT | SWT.WRAP);
+        labelIncludeRTFBinaryDataInQueryResults.setText(Labels.getString("AdvancedSettingsDialog.includeRTFBinaryDataInQueryResults"));
+        data = new GridData(GridData.HORIZONTAL_ALIGN_END);
+        labelIncludeRTFBinaryDataInQueryResults.setLayoutData(data);
+
+        boolean includeRTFBinaryDataInQueryResults = config.getBoolean(Config.INCLUDE_RICH_TEXT_FIELD_DATA_IN_QUERY_RESULTS);
+        buttonIncludeRTFBinaryDataInQueryResults = new Button(restComp, SWT.CHECK);
+        buttonIncludeRTFBinaryDataInQueryResults.setSelection(includeRTFBinaryDataInQueryResults);
+
+        // Cache DescribeGlobal results across operations
         Label labelCacheDescribeGlobalResults = new Label(restComp, SWT.RIGHT | SWT.WRAP);
         labelCacheDescribeGlobalResults.setText(Labels.getString("AdvancedSettingsDialog.cacheDescribeGlobalResults"));
         data = new GridData(GridData.HORIZONTAL_ALIGN_END);
@@ -931,6 +945,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
                 config.setValue(Config.PROXY_NTLM_DOMAIN, textProxyNtlmDomain.getText());
                 config.setValue(Config.PROCESS_KEEP_ACCOUNT_TEAM, buttonKeepAccountTeam.getSelection());
                 config.setValue(Config.CACHE_DESCRIBE_GLOBAL_RESULTS, buttonCacheDescribeGlobalResults.getSelection());
+                config.setValue(Config.INCLUDE_RICH_TEXT_FIELD_DATA_IN_QUERY_RESULTS, buttonIncludeRTFBinaryDataInQueryResults.getSelection());
                 config.setValue(Config.BULK_API_ENABLED, buttonUseBulkApi.getSelection());
                 config.setValue(Config.BULK_API_SERIAL_MODE, buttonBulkApiSerialMode.getSelection());
                 config.setValue(Config.BULK_API_ZIP_CONTENT, buttonBulkApiZipContent.getSelection());

--- a/src/main/resources/labels.properties
+++ b/src/main/resources/labels.properties
@@ -109,6 +109,7 @@ AdvancedSettingsDialog.useTabAsCsvDelimiter=Allow Tab as a CSV delimiter for loa
 AdvancedSettingsDialog.useOtherAsCsvDelimiter=Allow other characters as CSV delimiters for load operations:
 AdvancedSettingsDialog.csvOtherDelimiterValue=Other Delimiters for load operations\n(enter multiple values with no separator; for example, !+?):
 AdvancedSettingsDialog.queryResultsDelimiterValue=Delimiter for query results:
+AdvancedSettingsDialog.includeRTFBinaryDataInQueryResults=Include image content in query results of Rich Text Fields:
 AdvancedSettingsDialog.escapeFormulaInFieldValue=Escape formula values in exported results with a single-quote character:
 AdvancedSettingsDialog.loginFromBrowser=Enable OAuth login from browser:
 AdvancedSettingsDialog.partnerClientIdInProduction=Client ID for Partner API in Production:

--- a/src/test/java/com/salesforce/dataloader/process/CsvProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvProcessTest.java
@@ -90,7 +90,7 @@ public class CsvProcessTest extends ProcessTestBase {
     /**
      * Tests the insert operation on Account - Positive test.
      */
-    @Ignore
+    @Test
     public void testInsertAccountCsv() throws Exception {
         Map<String, String> configMap = getTestConfig(OperationInfo.insert, false);
         if (isSettingEnabled(configMap, Config.BULK_API_ZIP_CONTENT)
@@ -103,7 +103,7 @@ public class CsvProcessTest extends ProcessTestBase {
         runProcess(configMap, 100);
     }
     
-    @Ignore
+    @Test
     public void testInsertAccountWithMultipleBatchesCSV() throws ProcessInitializationException, DataAccessObjectException {
         Map<String, String> configMap = getTestConfig(OperationInfo.insert, false);
         if (isSettingEnabled(configMap, Config.BULK_API_ZIP_CONTENT)
@@ -132,7 +132,7 @@ public class CsvProcessTest extends ProcessTestBase {
     /**
      * Tests the insert operation on Account - Positive test.
      */
-    @Ignore
+    @Test
     public void testInsertTaskWithContactAsWhoCsv() throws Exception {
         Map<String, String> configMap = getTestConfig(OperationInfo.insert, false);
         if (isSettingEnabled(configMap, Config.BULK_API_ZIP_CONTENT)
@@ -165,7 +165,7 @@ public class CsvProcessTest extends ProcessTestBase {
     /**
      * Tests update operation with input coming from a CSV file. Relies on the id's in the CSV on being in the database
      */
-    @Ignore
+    @Test
     public void testUpdateAccountCsv() throws Exception {
         Map<String, String> configMap = getUpdateTestConfig(false, null, 100);
         if (isSettingEnabled(configMap, Config.BULK_API_ZIP_CONTENT)
@@ -181,7 +181,7 @@ public class CsvProcessTest extends ProcessTestBase {
     /**
      * Upsert the records from CSV file
      */
-    @Ignore
+    @Test
     public void testUpsertAccountCsv() throws Exception {
         Map<String, String> configMap = getUpdateTestConfig(true, DEFAULT_ACCOUNT_EXT_ID_FIELD, 50);
         if (isSettingEnabled(configMap, Config.BULK_API_ZIP_CONTENT)
@@ -206,7 +206,7 @@ public class CsvProcessTest extends ProcessTestBase {
      *                  when queried.
      * @throws Exception
      */
-    @Ignore
+    @Test
     public void testConstantMappingInCsv() throws Exception {
         Map<String, String> configMap = getTestConfig(OperationInfo.insert, false);
         if (isSettingEnabled(configMap, Config.BULK_API_ZIP_CONTENT)
@@ -244,7 +244,7 @@ public class CsvProcessTest extends ProcessTestBase {
      *
      * @throws Exception
      */
-    @Ignore
+    @Test
     public void testDescriptionAsConstantMappingInCsv() throws Exception {
         Map<String, String> configMap = getTestConfig(OperationInfo.insert, getTestDataDir()
                 + "/constantMappingInCsv.csv", false);
@@ -279,7 +279,7 @@ public class CsvProcessTest extends ProcessTestBase {
      *
      * @expectedResults Assert that the values retrieved for that field match those in the CSV file
      */
-    @Ignore
+    @Test
     public void testFieldAndConstantFieldClash()  throws Exception {
         Map<String, String> configMap = getTestConfig(OperationInfo.insert,
                 getTestDataDir() + "/constantMappingInCsvClashing.csv", false);
@@ -315,7 +315,7 @@ public class CsvProcessTest extends ProcessTestBase {
      *
      * @expectedResults Assert that the values retrieved for that field match those in the CSV file
      */
-    @Ignore
+    @Test
     public void testNullConstantAssignment()  throws Exception {
 
         /* Field assignments in .sdl are as follows:
@@ -378,7 +378,7 @@ public class CsvProcessTest extends ProcessTestBase {
     /**
      * Tests Upsert on foreign key for the records based on the CSV file
      */
-    @Ignore
+    @Test
     public void testUpsertFkAccountCsv() throws Exception {
         // manually inserts 100 accounts, then upserts specifying account parent for 50 accounts
         runUpsertProcess(getUpdateTestConfig(true, DEFAULT_ACCOUNT_EXT_ID_FIELD, 100), 0, 50);
@@ -387,7 +387,7 @@ public class CsvProcessTest extends ProcessTestBase {
     /**
      * Tests that Deleting the records based on a CSV file works
      */
-    @Ignore
+    @Test
     public void testDeleteAccountCsv() throws Exception {
         AccountIdTemplateListener listener = new AccountIdTemplateListener(100);
         String deleteFileName = convertTemplateToInput(baseName + "Template.csv", baseName + ".csv", listener);
@@ -456,7 +456,7 @@ public class CsvProcessTest extends ProcessTestBase {
      * @expectedResults Assert that all the records were inserted and that the constant value was mapped as well.
      *
      */
-    @Ignore
+    @Test
     public void testNonMappedFieldsPermittedInDLTransaction() throws Exception {
 
         final int numberOfRows = 4;
@@ -485,7 +485,7 @@ public class CsvProcessTest extends ProcessTestBase {
      * @expectedResults Assert that all the records were inserted and that the constant value was mapped as well.
      *
      */
-    @Ignore
+    @Test
     public void testHtmlFormattingInInsert() throws Exception {
         _doTestHtmlFormattingInInsert(true);
         _doTestHtmlFormattingInInsert(false);
@@ -581,7 +581,7 @@ public class CsvProcessTest extends ProcessTestBase {
      * @expectedResults Assert that the dates in Salesforce match up.
      *
      */
-    @Ignore
+    @Test
     public void testTimezoneNotTruncated() throws Exception {
 
         final int numberOfRows = 12;
@@ -621,7 +621,7 @@ public class CsvProcessTest extends ProcessTestBase {
      *
      * @throws Exception
      */
-    @Ignore
+    @Test
     public void testErrorsGeneratedOnInvalidDateMatching() throws Exception {
 
     	runTestErrorsGeneratedOnInvalidDateMatchWithOffset(0, 4, 2);
@@ -634,12 +634,12 @@ public class CsvProcessTest extends ProcessTestBase {
      *
      * @throws Exception
      */
-    @Ignore
+    @Test
     public void testErrorsGeneratedOnInvalidDateMatchingWithOffset() throws Exception {
     	runTestErrorsGeneratedOnInvalidDateMatchWithOffset(2, 3, 1);
     }
     
-    @Ignore
+    @Test
     public void testOneToManySforceFieldsMappingInCsv() throws Exception {
         // The use case is as follows:
         // This company in this scenario only does business in the state of CA, therefore billing and shipping
@@ -672,7 +672,7 @@ public class CsvProcessTest extends ProcessTestBase {
         }
     }
     
-    @Ignore
+    @Test
     public void testEmptyFirstRowFieldValueInCsv() throws Exception {
         Map<String, String> argumentMap = getUpdateTestConfig(false, null, 2);
         if (isSettingEnabled(argumentMap, Config.BULK_API_ZIP_CONTENT)


### PR DESCRIPTION
Query results of Rich Text Fields (RTF) include URL of images in RTF, not the content of images, which is an issue when migrating data from one org to another as reported at https://ideas.salesforce.com/s/idea/a0B8W00000GdgsjUAB/problem-with-rich-text-field-data-migration-to-another-salesforce-org

This PR contains the fix by introducing an advanced setting checkbox title "Include image content in query results of Rich Text Fields:" linked to a new property "loader.query.includeBinaryData" when set to "true" includes image content of RTF in query results.