### PR TITLE
support for the feature request in issue #1022

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -422,6 +422,7 @@ public class Config {
     public static final String WIZARD_WIDTH = "sfdc.ui.wizard.width";
     public static final String WIZARD_HEIGHT = "sfdc.ui.wizard.height";
     public static final String WIZARD_CLOSE_ON_FINISH = "sfdc.ui.wizard.closeOnFinish";
+    public static final String WIZARD_POPULATE_RESULTS_FOLDER_WITH_PREVIOUS_OP_RESULTS_FOLDER = "sfdc.ui.wizard.finishStep.prepopulateWithPreviousOpResultsFolder";
     public static final int DEFAULT_WIZARD_WIDTH = 600;
     public static final int DEFAULT_WIZARD_HEIGHT = 700;
     
@@ -618,6 +619,7 @@ public class Config {
         setDefaultValue(DAO_WRITE_POSTPROCESSOR_SCRIPT, "");
         setDefaultValue(LIMIT_OUTPUT_TO_QUERY_FIELDS, true);
         setDefaultValue(WIZARD_CLOSE_ON_FINISH, true);
+        setDefaultValue(WIZARD_POPULATE_RESULTS_FOLDER_WITH_PREVIOUS_OP_RESULTS_FOLDER, true);
         setDefaultValue(CACHE_DESCRIBE_GLOBAL_RESULTS, true);
         setDefaultValue(PROCESS_EXIT_WITH_ERROR_ON_FAILED_ROWS_BATCH_MODE, false);
         setDefaultValue(INCLUDE_RICH_TEXT_FIELD_DATA_IN_QUERY_RESULTS, false);

--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -113,6 +113,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
     private Button buttonCsvTab;
     private Button buttonLoginFromBrowser;
     private Button buttonCloseWizardOnFinish;
+    private Button buttonPopulateResultsFolderOnFinishStep;
     private static final String[] LOGGING_LEVEL = { "ALL", "DEBUG", "INFO", "WARN", "ERROR", "FATAL" };
     private Combo comboLoggingLevelDropdown;
     
@@ -408,7 +409,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
         Label labelLimitQueryResultColumnsToFieldsInQuery = new Label(restComp, SWT.RIGHT | SWT.WRAP);
         labelLimitQueryResultColumnsToFieldsInQuery.setText(Labels.getString(this.getClass().getSimpleName() + ".limitOutputToQueryFields")); //$NON-NLS-1$
         data = new GridData(GridData.HORIZONTAL_ALIGN_END);
-        labelSortExtractFields.setLayoutData(data);
+        labelLimitQueryResultColumnsToFieldsInQuery.setLayoutData(data);
        
         buttonLimitQueryResultColumnsToFieldsInQuery = new Button(restComp, SWT.CHECK);
         buttonLimitQueryResultColumnsToFieldsInQuery.setSelection(config.getBoolean(Config.LIMIT_OUTPUT_TO_QUERY_FIELDS));
@@ -462,7 +463,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
         Label labelFormatPhoneFields = new Label(restComp, SWT.RIGHT | SWT.WRAP);
         labelFormatPhoneFields.setText(Labels.getString("AdvancedSettingsDialog.formatPhoneFields"));
         data = new GridData(GridData.HORIZONTAL_ALIGN_END);
-        labelTruncateFields.setLayoutData(data);
+        labelFormatPhoneFields.setLayoutData(data);
 
         buttonFormatPhoneFields = new Button(restComp, SWT.CHECK);
         buttonFormatPhoneFields.setSelection(config.getBoolean(Config.FORMAT_PHONE_FIELDS));
@@ -811,6 +812,13 @@ public class AdvancedSettingsDialog extends BaseDialog {
         buttonCloseWizardOnFinish = new Button(restComp, SWT.CHECK);
         buttonCloseWizardOnFinish.setSelection(closeWizardOnFinish);
 
+        Label populateResultsFolderOnFinishStepText = new Label(restComp, SWT.RIGHT | SWT.WRAP);
+        populateResultsFolderOnFinishStepText.setText(Labels.getString("AdvancedSettingsDialog.populateResultsFolderOnFinishStep"));
+        populateResultsFolderOnFinishStepText.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_END));
+        boolean populateResultsFolderOnFinishStep = config.getBoolean(Config.WIZARD_POPULATE_RESULTS_FOLDER_WITH_PREVIOUS_OP_RESULTS_FOLDER);
+        buttonPopulateResultsFolderOnFinishStep = new Button(restComp, SWT.CHECK);
+        buttonPopulateResultsFolderOnFinishStep.setSelection(populateResultsFolderOnFinishStep);
+        
         blankAgain = new Label(restComp, SWT.NONE);
         data = new GridData();
         data.horizontalSpan = 2;
@@ -961,6 +969,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
                 config.setValue(Config.BULKV2_API_ENABLED, buttonUseBulkV2Api.getSelection());
                 config.setValue(Config.OAUTH_LOGIN_FROM_BROWSER, buttonLoginFromBrowser.getSelection());
                 config.setValue(Config.WIZARD_CLOSE_ON_FINISH, buttonCloseWizardOnFinish.getSelection());
+                config.setValue(Config.WIZARD_POPULATE_RESULTS_FOLDER_WITH_PREVIOUS_OP_RESULTS_FOLDER, buttonPopulateResultsFolderOnFinishStep.getSelection());
                 LoggingUtil.setLoggingLevel(LOGGING_LEVEL[comboLoggingLevelDropdown.getSelectionIndex()]);
                 String clientIdVal = textProductionPartnerClientID.getText();
                 if (clientIdVal != null && !clientIdVal.strip().isEmpty()) {

--- a/src/main/java/com/salesforce/dataloader/ui/FinishPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/FinishPage.java
@@ -116,6 +116,9 @@ public class FinishPage extends LoadPage {
     protected boolean setupPagePostLogin() {
         try {
             verifySettings();
+            if (!controller.getConfig().getBoolean(Config.WIZARD_POPULATE_RESULTS_FOLDER_WITH_PREVIOUS_OP_RESULTS_FOLDER)) {
+                dirFE.setStringValue(null); // clear previous selection
+            }
         } catch (final MappingInitializationException e) {
             final FinishPage page = this;
             Display.getDefault().syncExec(new Thread() {

--- a/src/main/resources/labels.properties
+++ b/src/main/resources/labels.properties
@@ -123,6 +123,7 @@ AdvancedSettingsDialog.loggingConfigFile=Logging configuration file:
 AdvancedSettingsDialog.checkUploadDelimiterCheckbox=Specify delimiter(s) for upload operations.
 AdvancedSettingsDialog.closeWizardOnFinish=Close UI Wizard dialog when an operation is completed.
 AdvancedSettingsDialog.cacheDescribeGlobalResults=Cache Salesforce object and field information across operations
+AdvancedSettingsDialog.populateResultsFolderOnFinishStep=Pre-populate Results Folder input field in Finish step\n (use the folder chosen in the previous operation):
 
 InsertWizard.windowTitle=Load Inserts
 InsertWizard.confFirstLine=You have chosen to insert new records.  Click Yes to begin.
@@ -261,7 +262,7 @@ FinishPage.title=Step 4: Finish
 FinishPage.description=Select the folder where your success and error files will be saved.
 FinishPage.overwritten=
 FinishPage.output=Output
-FinishPage.chooseDir=Folder:
+FinishPage.chooseDir=Results Folder:
 
 ChooseLookupFieldForRelationshipPage.title=Step 2b: (Optional) relate using lookup field
 ChooseLookupFieldForRelationshipPage.description=For each related object, select a lookup fields of related objects for relationship fields.  Otherwise, leave the selection blank.


### PR DESCRIPTION
Add a Setting "Pre-populate Results Folder input field in Finish step\n (use the folder chosen in the previous operation)" to enable/disable prepopulation of Results Folder along with the property "sfdc.ui.wizard.finishStep.prepopulateWithPreviousOpResultsFolder"