### PR TITLE
added test to check for regression in W-8551311

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.force.api</groupId>
       <artifactId>force-partner-api</artifactId>
-      <version>59.0.0</version>
+      <version>60.1.1</version>
     </dependency>
 <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-dbcp2 -->
     <dependency>

--- a/src/test/java/com/salesforce/dataloader/process/CsvExtractProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvExtractProcessTest.java
@@ -219,6 +219,27 @@ public class CsvExtractProcessTest extends ProcessExtractTestBase {
         final String[] leadidArr = new String[] { result[0].getId() };
         return leadidArr;
     }
+    
+    /**
+     * Tests the extract operation on Account. Verifies that an extract operation with a soql query is performed
+     * correctly.
+     */
+    @Test
+    public void testExtractSObjectWithJSONFieldType() throws Exception {
+        try {
+            // Test for regression in the fix for bug id: W-8551311
+            // describeSObject for ApiEvent sObject fails if JSON FieldType enum 
+            // does not exist in WSC because 'Records' field is of type JSON.
+            
+            final String soql = "SELECT Id FROM ApiEvent";
+            final Map<String, String> argmap = getExtractionTestConfig(soql, "ApiEvent", false);
+                // run the extract
+                runProcess(argmap, 0);
+        } finally {
+            // noop
+        }
+    }
+    
     /**
      * @param enableLastRunOutput
      */


### PR DESCRIPTION
added test to check for regression in W-8551311 - describeSObject for ApiEvent fails if JSON FieldType is missing in WSC.