### PR TITLE
preserve column name order specified in mapping file and soql

### DIFF
--- a/src/main/java/com/salesforce/dataloader/mapping/Mapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/Mapper.java
@@ -46,6 +46,7 @@ import com.salesforce.dataloader.config.Messages;
 import com.salesforce.dataloader.exception.MappingInitializationException;
 import com.salesforce.dataloader.model.Row;
 import com.salesforce.dataloader.util.AppUtil;
+import com.salesforce.dataloader.util.OrderedProperties;
 
 /**
  * Base class for field name mappers. Used by data loader operations to map between local field names and sfdc field
@@ -147,7 +148,7 @@ public abstract class Mapper {
     }
 
     private Properties loadProperties(String fileName) throws MappingInitializationException {
-        Properties props = new Properties();
+        OrderedProperties props = new OrderedProperties();
         if (fileName != null && fileName.length() > 0) {
             try {
                 FileInputStream in = new FileInputStream(fileName);

--- a/src/main/java/com/salesforce/dataloader/util/OrderedProperties.java
+++ b/src/main/java/com/salesforce/dataloader/util/OrderedProperties.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2015, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.dataloader.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Based on
+ * <a href="OrderedProperties.java.html"><b><i>View Source</i></b></a>
+ *
+ */
+public class OrderedProperties extends Properties {
+
+    private static final long serialVersionUID = 1L;
+    LinkedHashMap<Object, Object> props;
+    
+    public OrderedProperties() {
+        super ();
+
+        props = new LinkedHashMap<Object, Object>();
+    }
+
+    public Object put(Object key, Object value) {
+        if (props.containsKey(key)) {
+            props.remove(key);
+        }
+
+        props.put(key, value);
+
+        return super .put(key, value);
+    }
+    
+    public Set<Map.Entry<Object, Object>> entrySet() {
+        return props.entrySet();
+    }
+
+    public Object remove(Object key) {
+        props.remove(key);
+
+        return super .remove(key);
+    }
+}

--- a/src/test/java/com/salesforce/dataloader/process/ProcessExtractTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessExtractTestBase.java
@@ -401,6 +401,30 @@ public abstract class ProcessExtractTestBase extends ProcessTestBase {
         // verify IDs and phone format 
         verifyIdsInCSV(control, accountIds, true);
         
+        // Verify that column positions match positions
+        // specified in the mapping (.sdl) file.
+        String fileName = control.getConfig().getString(Config.DAO_NAME);
+        final DataReader extractionReader = new CSVFileReader(new File(fileName), getController().getConfig(), true, false);
+        try {
+            extractionReader.open();
+            List<String> daoCols = extractionReader.getColumnNames();
+            String colAt = daoCols.get(4);
+            assertEquals("Incorrect DAO column sequence", colAt.toUpperCase(), "ACCOUNT_NAME");
+            colAt = daoCols.get(5);
+            assertEquals("Incorrect DAO column sequence", colAt.toUpperCase(), "ACCOUNT_ID");
+
+            // Verify that column positions not specified in the mapping
+            // file are in the same order as specified in SOQL.
+            colAt = daoCols.get(7);
+            if (isBulkAPIEnabled(this.getTestConfig()) || isBulkV2APIEnabled(this.getTestConfig())) {
+                assertEquals("Incorrect DAO column sequence", colAt.toUpperCase(), "WEBSITE");
+            } else {
+                assertEquals("Incorrect DAO column sequence", colAt.toUpperCase(), "TYPE");
+            }
+        } finally {
+            extractionReader.close();
+        } 
+        
         testConfig = getDoNotLimitOutputToQueryFieldsTestConfig(soql, "Account", true);
         control = runProcess(testConfig, numRecords);
         // verify IDs and phone format 

--- a/src/test/resources/testfiles/data/extractAccountCsvMap.sdl
+++ b/src/test/resources/testfiles/data/extractAccountCsvMap.sdl
@@ -1,8 +1,8 @@
 # extract account mapping values for query from salesforce (left) and update to csv file (right)
 # salesforceFieldName=csvFieldName
-Id=account_id
 Oracle_Id__c=account_ext_id
-Name=account_name
 Phone=account_phone
 AnnualRevenue=account_annual_revenue
 AccountNumber__c=account_number
+Name=account_name
+Id=account_id


### PR DESCRIPTION
preserve the column name order specified in the mapping file and soql when writing query output to csv file with the order specified in the mapping file (if any) taking precedence over the  field order in soql.