### PR TITLE
add supporting classes for using REST API

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/RESTConnection.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/RESTConnection.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.dataloader.action.visitor;
+
+import com.salesforce.dataloader.controller.Controller;
+import com.sforce.async.AsyncApiException;
+import com.sforce.ws.ConnectorConfig;
+
+public class RESTConnection {
+    private ConnectorConfig config;
+    private Controller controller;
+    public RESTConnection(ConnectorConfig config, Controller controller) throws AsyncApiException {
+        this.config = config;
+        this.controller = controller;
+    }
+
+}

--- a/src/main/java/com/salesforce/dataloader/action/visitor/RESTLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/RESTLoadVisitor.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2015, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.dataloader.action.visitor;
+
+
+import java.util.List;
+
+import org.apache.commons.beanutils.DynaBean;
+
+import com.salesforce.dataloader.action.progress.ILoaderProgress;
+import com.salesforce.dataloader.client.PartnerClient;
+import com.salesforce.dataloader.controller.Controller;
+import com.salesforce.dataloader.dao.DataWriter;
+import com.salesforce.dataloader.exception.DataAccessObjectException;
+import com.salesforce.dataloader.exception.OperationException;
+import com.sforce.soap.partner.fault.ApiFault;
+import com.sforce.ws.ConnectionException;
+
+public class RESTLoadVisitor extends DAOLoadVisitor {
+
+    public RESTLoadVisitor(Controller controller, ILoaderProgress monitor, DataWriter successWriter,
+            DataWriter errorWriter) {
+        super(controller, monitor, successWriter, errorWriter);
+    }
+
+    protected void loadBatch() throws DataAccessObjectException, OperationException {
+        Object[] results = null;
+        setHeaders();
+        try {
+            results = executeClientAction(getController().getPartnerClient(), dynaArray);
+        } catch (ApiFault e) {
+            handleException(e);
+        } catch (ConnectionException e) {
+            handleException(e);
+        }
+
+        writeOutputToWriter(results);
+        setLastRunProperties(results);
+
+        // update Monitor
+        getProgressMonitor().worked(results.length);
+        getProgressMonitor().setSubTask(getRateCalculator().calculateSubTask(getNumberOfRows(), getNumberErrors()));
+
+        // now clear the arrays
+        clearArrays();
+    }
+
+    private void setLastRunProperties(Object[] results) {
+        // TODO Auto-generated method stub
+        
+    }
+
+    private void writeOutputToWriter(Object[] results) {
+        // TODO Auto-generated method stub
+        
+    }
+
+    private void setHeaders() {
+        // TODO Auto-generated method stub
+        
+    }
+
+    private Object[] executeClientAction(PartnerClient partnerClient, List<DynaBean> dynaArray) throws ConnectionException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+}

--- a/src/main/java/com/salesforce/dataloader/action/visitor/TestREST.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/TestREST.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2015, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.dataloader.action.visitor;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.TimeZone;
+
+import org.apache.commons.io.IOUtils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.salesforce.dataloader.client.HttpTransportInterface;
+import com.salesforce.dataloader.client.HttpClientTransport;
+import com.sforce.soap.partner.Connector;
+import com.sforce.soap.partner.PartnerConnection;
+import com.sforce.ws.ConnectorConfig;
+
+
+public class TestREST {
+    private static String insertFilename = "./insertAccountCsv.csv";
+    private static String deleteFilename = "./deleteAccountCsv.csv";
+    private static String successFilename = "./ingestSuccessResults.csv";
+    private static String failureFilename = "./ingestFailureResults.csv";
+    private static String unprocessedFilename = "./ingestUnprocessedRecords.csv";
+    private static String bulkQueryResultsFilename = "./queryResults.csv";
+    private static String username = "dltest@dl.com";
+    private static String password = "dataloader6";
+    private static String myDomainURLString = "https://ashit-dev-ed.my.salesforce.com";
+    private static String restEndpoint = myDomainURLString + "/services/data/v59.0/";
+
+    public static void main(String[] args) {
+
+        try {
+                URL DEFAULT_AUTH_ENDPOINT_URL = new URL(Connector.END_POINT);
+                URL serverUrl = new URL(myDomainURLString);
+
+                ConnectorConfig cc = new ConnectorConfig();
+                cc.setTransport(HttpClientTransport.class);
+                cc.setUsername(username);
+                cc.setPassword(password);
+                cc.setAuthEndpoint(serverUrl + DEFAULT_AUTH_ENDPOINT_URL.getPath());
+                cc.setServiceEndpoint(serverUrl + DEFAULT_AUTH_ENDPOINT_URL.getPath());
+                cc.setRestEndpoint(restEndpoint);
+                final PartnerConnection conn = Connector.newConnection(cc);
+                cc.setSessionId(conn.getSessionHeader().getSessionId());
+                updateAccounts(cc, conn);
+            } catch (Exception ex) {
+                ex.printStackTrace();
+                System.exit(-1);
+            }
+    }
+    
+    public static void updateAccounts(ConnectorConfig cc, PartnerConnection conn) {
+        System.out.println("\n_______________ Lead UPDATE _______________");
+ 
+        //Notice, the id for the record to update is part of the URI, not part of the JSON
+        // String uri = restEndpoint + "sobjects/Account/0014W00003QSWuSQAX";
+        String uri = restEndpoint + "composite/sobjects/";
+            //Create the JSON object containing the updated account last name
+            //and the id of the account we are updating.
+            HashMap<String, String> sobjectTypeMap = new HashMap<String, String>();
+            sobjectTypeMap.put("type", "Account");
+            HashMap<String, Object> record1 = new HashMap<String, Object>();
+            record1.put("external_id__c", "firstexid");
+            record1.put("id", "0014W00003QSWuSQAX");
+            record1.put("attributes", sobjectTypeMap);
+            HashMap<String, Object> record2 = new HashMap<String, Object>();
+            record2.put("external_id__c", "extid2");
+            record2.put("id", "0014W00003QSWuTQAX");
+            record2.put("attributes", sobjectTypeMap);
+            
+            ArrayList<Object> recordList = new ArrayList<Object>();
+            recordList.add(record1);
+            recordList.add(record2);
+
+            HashMap<String, Object> recordsMap = new HashMap<String, Object>();
+            recordsMap.put("records", recordList);
+            recordsMap.put("allOrNone", false);
+            ObjectMapper mapper = new ObjectMapper();
+            String json = "";
+            try {
+                json = mapper.writeValueAsString(recordsMap);
+                System.out.println("JSON for update of account record:\n" + json);
+            } catch (JsonProcessingException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+            
+            HashMap<String, String> headers = new HashMap<String, String>();
+            headers.put("Content-Type", "application/JSON");
+            headers.put("ACCEPT", "application/JSON");
+            headers.put("Authorization", "Bearer " + cc.getSessionId());
+            HttpClientTransport transport = new HttpClientTransport(cc);
+            try {
+                OutputStream out = transport.connect(uri, headers, true, HttpTransportInterface.SupportedHttpMethodType.PATCH);
+                out.write(json.getBytes(StandardCharsets.UTF_8.name()));
+                out.close();
+            } catch (IOException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+                System.exit(-1);
+            }
+            InputStream in = null;
+            try {
+                in = transport.getContent();
+            } catch (IOException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+                System.exit(-1);
+            }
+            boolean successfulRequest = transport.isSuccessful();
+            if (successfulRequest) {
+                try {
+                    String result = IOUtils.toString(in, StandardCharsets.UTF_8);
+                    System.out.println(result);
+                } catch (IOException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+            } else {
+                mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+                try {
+                    String result = IOUtils.toString(in, StandardCharsets.UTF_8);
+                    System.out.println(result);
+                } catch (IOException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+            }
+
+
+
+            //Set up the objects necessary to make the request.
+            //DefaultHttpClient httpClient = new DefaultHttpClient();
+/*
+            HttpClient httpClient = HttpClientBuilder.create().build();
+ 
+            HttpPatch httpPatch = new HttpPatch(uri);
+            httpPatch.addHeader(oauthHeader);
+            httpPatch.addHeader(prettyPrintHeader);
+            StringEntity body = new StringEntity(account.toString(1));
+            body.setContentType("application/json");
+            httpPatch.setEntity(body);
+ 
+            //Make the request
+            HttpResponse response = httpClient.execute(httpPatch);
+ 
+            //Process the response
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode == 204) {
+                System.out.println("Updated the lead successfully.");
+            } else {
+                System.out.println("Lead update NOT successfully. Status code is " + statusCode);
+            }
+            */
+    }
+}
+class Account implements Serializable {
+    private static final long serialVersionUID = -6580088324176619490L;
+    String external_id__c = "";
+    public Account() {
+        
+    }
+}

--- a/src/main/java/com/salesforce/dataloader/client/BulkV1Client.java
+++ b/src/main/java/com/salesforce/dataloader/client/BulkV1Client.java
@@ -80,7 +80,7 @@ public class BulkV1Client extends ClientBase<BulkV1Connection> {
     }
     
     public static String getServicePath() {
-        return ClientBase.getServicePathWithAPIVersion(BULKV1_ENDPOINT_PATH);
+        return "/services/async/" + getAPIVersionForTheSession() + "/";
     }
 
 }

--- a/src/main/java/com/salesforce/dataloader/client/ClientBase.java
+++ b/src/main/java/com/salesforce/dataloader/client/ClientBase.java
@@ -63,9 +63,7 @@ public abstract class ClientBase<ConnectionType> {
         DEFAULT_AUTH_ENDPOINT_URL = loginUrl;
     }
 
-    public static final String BULKV1_ENDPOINT_PATH = "/services/async/" + getCurrentAPIVersionInWSC();
-    public static final String BULKV2_ENDPOINT_PATH = "/services/data/v" + getCurrentAPIVersionInWSC() + "/jobs/";
-    protected static String apiVersionForTheSession = getCurrentAPIVersionInWSC();
+    private static String apiVersionForTheSession = getCurrentAPIVersionInWSC();
 
     protected final Logger logger;
     protected final Controller controller;
@@ -110,12 +108,17 @@ public abstract class ClientBase<ConnectionType> {
                 .toString(); //$NON-NLS-1$
     }
     
-    public static String getAPIVersion() {
+    public static synchronized String getAPIVersionForTheSession() {
         return apiVersionForTheSession;
     }
     
-    public static synchronized void setAPIVersion(String version) {
+    public static synchronized void setAPIVersionForTheSession(String version) {
         apiVersionForTheSession = version;
+        setEndpointPath();
+    }
+    
+    static protected void setEndpointPath() {
+        
     }
 
     public ConnectorConfig getConnectorConfig() {
@@ -228,17 +231,6 @@ public abstract class ClientBase<ConnectionType> {
         String currentMajorVerStr = versionStrArray[0];
         int currentMajorVer = Integer.parseInt(currentMajorVerStr);
         return Integer.toString(currentMajorVer-1) + ".0";
-    }
-    
-    // used for SOAP and Bulk v1 service endpoints but not for bulk v2 service
-    protected static String getServicePathWithAPIVersion(String path) {
-        String[] pathPartArray = path.split("\\/");
-        pathPartArray[pathPartArray.length-1] = apiVersionForTheSession;
-        StringBuffer buf = new StringBuffer();
-        for (int i = 0; i < pathPartArray.length; i++) {
-            buf.append(pathPartArray[i] + "/");
-        }
-        return buf.toString();
     }
 
     public SessionInfo getSession() {

--- a/src/main/java/com/salesforce/dataloader/client/HttpClientTransport.java
+++ b/src/main/java/com/salesforce/dataloader/client/HttpClientTransport.java
@@ -220,7 +220,7 @@ public class HttpClientTransport implements HttpTransportInterface {
 	    	currentConfig.setUseChunkedPost(false);
 	    	this.httpMethod.setEntity(entity);
     	}
-        InputStream input;
+        InputStream input = new ByteArrayInputStream(new byte[1]);
         try {
             HttpClientContext context = HttpClientContext.create();
             RequestConfig config = RequestConfig.custom().setExpectContinueEnabled(currentConfig.useChunkedPost()).build();
@@ -242,12 +242,14 @@ public class HttpClientTransport implements HttpTransportInterface {
                 }
                 // copy input stream data into a new input stream because releasing the connection will close the input stream
                 ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+                if (response.getEntity() != null) {
                 try (InputStream inStream = response.getEntity().getContent()) {
                     IOUtils.copy(inStream, bOut);
                     input = new ByteArrayInputStream(bOut.toByteArray());
                     if (response.containsHeader("Content-Encoding") && response.getHeaders("Content-Encoding")[0].getValue().equals("gzip")) {
                         input = new GZIPInputStream(input);
                     }
+                }
                 }
             }
         } finally {

--- a/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
+++ b/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
@@ -590,11 +590,11 @@ public class PartnerClient extends ClientBase<PartnerConnection> {
         disconnect();
         try {
             dologin();
-            logger.debug("able to successfully invoke server APIs of version " + apiVersionForTheSession);
+            logger.debug("able to successfully invoke server APIs of version " + getAPIVersionForTheSession());
         } catch (UnexpectedErrorFault fault) {
             if (fault.getExceptionCode() == ExceptionCode.UNSUPPORTED_API_VERSION) {
-                logger.error("Failed to successfully invoke server APIs of version " + apiVersionForTheSession);
-                apiVersionForTheSession = getPreviousAPIVersionInWSC();
+                logger.error("Failed to successfully invoke server APIs of version " + getAPIVersionForTheSession());
+                setAPIVersionForTheSession(getPreviousAPIVersionInWSC());
                 login();
             } else {
                 logger.error("Failed to get user info using manually configured session id", fault);
@@ -843,8 +843,7 @@ public class PartnerClient extends ClientBase<PartnerConnection> {
     }
     
     public static String getServicePath() {
-        // Auth endpoint is a SOAP service
-        return ClientBase.getServicePathWithAPIVersion(DEFAULT_AUTH_ENDPOINT_URL.getPath());
+        return "/services/Soap/u/" + getAPIVersionForTheSession() + "/";
     }
 
     private synchronized ConnectorConfig getLoginConnectorConfig() {

--- a/src/main/java/com/salesforce/dataloader/client/RESTClient.java
+++ b/src/main/java/com/salesforce/dataloader/client/RESTClient.java
@@ -28,23 +28,23 @@ package com.salesforce.dataloader.client;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.salesforce.dataloader.action.visitor.BulkV2Connection;
+import com.salesforce.dataloader.action.visitor.RESTConnection;
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.config.Messages;
 import com.salesforce.dataloader.controller.Controller;
 import com.sforce.async.AsyncApiException;
 import com.sforce.ws.ConnectorConfig;
 
-public class BulkV2Client extends ClientBase<BulkV2Connection> {
+public class RESTClient extends ClientBase<RESTConnection> {
     private static Logger LOG = LogManager.getLogger(BulkV2Client.class);
-    private BulkV2Connection client;
+    private RESTConnection client;
     private ConnectorConfig connectorConfig = null;
 
-    public BulkV2Client(Controller controller) {
+    public RESTClient(Controller controller) {
         super(controller, LOG);
     }
     
-    public BulkV2Connection getConnection() {
+    public RESTConnection getConnection() {
         return client;
     }
     
@@ -52,7 +52,7 @@ public class BulkV2Client extends ClientBase<BulkV2Connection> {
     protected boolean connectPostLogin(ConnectorConfig cc) {
         try {
             // Set up a connection object with the given config
-            this.client = new BulkV2Connection(cc, controller);
+            this.client = new RESTConnection(cc, controller);
 
         } catch (AsyncApiException e) {
             logger.error(Messages.getMessage(getClass(), "loginError", cc.getAuthEndpoint(), e.getExceptionMessage()),
@@ -76,8 +76,8 @@ public class BulkV2Client extends ClientBase<BulkV2Connection> {
         }
         return this.connectorConfig;
     }
-    
+
     protected static String getServicePath() {
-        return  "/services/data/v" + getAPIVersionForTheSession() + "/jobs/";
+        return "/services/data/v" + getAPIVersionForTheSession() + "/";
     }
 }

--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -31,7 +31,6 @@ import com.salesforce.dataloader.action.progress.ILoaderProgress;
 import com.salesforce.dataloader.client.BulkV1Client;
 import com.salesforce.dataloader.client.BulkV2Client;
 import com.salesforce.dataloader.client.ClientBase;
-import com.salesforce.dataloader.client.DescribeRefObject;
 import com.salesforce.dataloader.client.HttpClientTransport;
 import com.salesforce.dataloader.client.PartnerClient;
 import com.salesforce.dataloader.client.ReferenceEntitiesDescribeMap;
@@ -153,7 +152,7 @@ public class Controller {
         if (this.partnerClient == null) {
             return null;
         }
-        String apiInfoStr = Labels.getFormattedString("Operation.apiVersion", PartnerClient.getAPIVersion());
+        String apiInfoStr = Labels.getFormattedString("Operation.apiVersion", PartnerClient.getAPIVersionForTheSession());
         LimitInfo apiLimitInfo = this.partnerClient.getAPILimitInfo();
         if (apiLimitInfo != null) {
             apiInfoStr = Labels.getFormattedString("Operation.currentAPIUsage", apiLimitInfo.getCurrent())
@@ -185,7 +184,7 @@ public class Controller {
     }
     
     public static String getAPIVersion() {
-        return ClientBase.getAPIVersion();
+        return ClientBase.getAPIVersionForTheSession();
     }
 
     public Map<String, DescribeGlobalSObjectResult> getEntityDescribes() {

--- a/src/test/java/com/salesforce/dataloader/TestBase.java
+++ b/src/test/java/com/salesforce/dataloader/TestBase.java
@@ -266,7 +266,7 @@ abstract class TestBase {
         String configEndpoint = getController().getConfig().getString(Config.ENDPOINT);
         if (!configEndpoint.equals("")) { //$NON-NLS-1$
             try {
-                PartnerClient.setAPIVersion(apiVersionStr);
+                PartnerClient.setAPIVersionForTheSession(apiVersionStr);
                 bindingConfig.setAuthEndpoint(configEndpoint + PartnerClient.getServicePath());
                 bindingConfig.setServiceEndpoint(configEndpoint + PartnerClient.getServicePath()); // Partner SOAP service
                 bindingConfig.setRestEndpoint(configEndpoint + BulkV1Client.getServicePath());  // REST service: Bulk v1       


### PR DESCRIPTION
Data Loader uses Partner SOAP and Bulk REST APIs. This PR sets the foundation for being able to make REST API calls, specifically Composite REST calls which are similar to Partner SOAP to be able to support newer capabilities offered by Salesforce APIs.