### PR TITLE
speed up batch mode and test runs by optimizing fetch of referenced o…

### DIFF
--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -249,12 +249,16 @@ public class Controller {
             throw new MappingInitializationException(e.getMessage());
         }
         config.setValue(Config.ENTITY, sObjectName);
+        initializeMapping(); // initialize mapping before setting reference describes
         try {
             this.setFieldTypes();
             this.setReferenceDescribes();
         } catch (Exception e) {
             throw new MappingInitializationException(e);
         }
+    }
+    
+    private void initializeMapping() throws MappingInitializationException {
         String mappingFile = config.getString(Config.MAPPING_FILE);
         if (mappingFile != null 
                 && !mappingFile.isBlank() && !Files.exists(Path.of(mappingFile))) {
@@ -267,6 +271,7 @@ public class Controller {
         this.mapper = getConfig().getOperationInfo().isExtraction() ? 
                 new SOQLMapper(getPartnerClient(), dao.getColumnNames(), getFieldTypes().getFields(), mappingFile) 
               : new LoadMapper(getPartnerClient(), dao.getColumnNames(), getFieldTypes().getFields(), mappingFile);
+
     }
 
     public void createAndShowGUI() throws ControllerInitializationException {

--- a/src/main/java/com/salesforce/dataloader/dyna/ParentIdLookupFieldFormatter.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/ParentIdLookupFieldFormatter.java
@@ -46,13 +46,16 @@ public class ParentIdLookupFieldFormatter {
     // Example - "Account:Owner.username"
     public static final String NEW_FORMAT_PARENT_IDLOOKUP_FIELD_SEPARATOR_CHAR = "-";
     
-    // fieldName param can be in one of the following formats:
+    // formattedFieldName param can be in one of the following formats:
     // format 1: alphanumeric string without any ':' or '-' in it. Represents name of child's non-polymorphic relationship field
     // format 1 => it is name of a non-polymorphic relationship field in child object.
     //
     // format 2: alphanumeric string with a ':' in it
-    // format 2 has 2 (legacy format): 
-    //    <child relationship field name>:<parent idlookup field name>
+    // format 2 has 2 interpretations:
+    // 2a - (legacy format): 
+    //    <child relationship name>:<parent idlookup field name>
+    // 2b - (new format):
+    //    <parent object name>:<relationship name attribute of relationship field>
     //
     // format 3: alphanumeric string with a single ':' and a single '-' in it
     // format 3 => it is name of a field in child object with reference to an idlookup field in parent object

--- a/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
@@ -159,10 +159,6 @@ public class ProcessRunner implements InitializingBean, IProcess {
                 logger.info(Messages.getString("Process.settingFieldTypes")); //$NON-NLS-1$
                 controller.setFieldTypes();
 
-                // get the object reference info (using the describe call)
-                logger.info(Messages.getString("Process.settingReferenceTypes")); //$NON-NLS-1$
-                controller.setReferenceDescribes();
-
                 // instantiate the map
                 logger.info(Messages.getString("Process.creatingMap")); //$NON-NLS-1$
                 controller.initializeOperation(config.getString(Config.DAO_TYPE), 

--- a/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
@@ -706,6 +706,7 @@ public abstract class ProcessTestBase extends ConfigTestBase {
         if (argMap == null) argMap = getTestConfig();
         argMap.put(Config.PROCESS_THREAD_NAME, this.baseName);
         argMap.put(Config.READ_ONLY_CONFIG_PROPERTIES, Boolean.TRUE.toString());
+        argMap.put(Config.CLI_OPTION_RUN_MODE, Config.RUN_MODE_BATCH_VAL);
 
         // emulate invocation through process.bat script
         String[] args = new String[argMap.size()+1];


### PR DESCRIPTION
…bjects

speed up batch mode and test runs by optimizing fetch of referenced objects
- call sobjectDescribe only for mapped references
- avoid calling setReferenceDescribes() at the start of ProcessRunner as it is redundant