### PR TITLE
speed up tests by invoking describeSobject only for specified lookup …

### DIFF
--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -69,6 +69,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.text.SimpleDateFormat;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
 import java.util.Properties;
@@ -178,6 +179,11 @@ public class Controller {
     public void setReferenceDescribes() throws ConnectionException {
         validateSession();
         getPartnerClient().setFieldReferenceDescribes();
+    }
+    
+    public void setReferenceDescribes(Collection<String> sfFields) throws ConnectionException {
+        validateSession();
+        getPartnerClient().setFieldReferenceDescribes(sfFields);
     }
 
     private boolean connectIfSessionExists(ClientBase<?> clientToLogin) {

--- a/src/test/java/com/salesforce/dataloader/client/PartnerClientTest.java
+++ b/src/test/java/com/salesforce/dataloader/client/PartnerClientTest.java
@@ -46,6 +46,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -251,17 +252,18 @@ public class PartnerClientTest extends ProcessTestBase {
         assertTrue("Account Name not found ", hasName);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testInsertBasic() throws Exception {
         // setup our dynabeans
-        BasicDynaClass dynaClass = setupDynaClass("Account");
+        BasicDynaClass dynaClass;
 
         Map<String, Object> sforceMapping = new HashMap<String, Object>();
         sforceMapping.put("Name", "name" + System.currentTimeMillis());
         sforceMapping.put("Description", "the description");
         // Account number is set for easier test data cleanup
         sforceMapping.put("AccountNumber", ACCOUNT_NUMBER_PREFIX + System.currentTimeMillis());
-
+        dynaClass = setupDynaClass("Account", (Collection<String>)(Collection<?>)(sforceMapping.values()));
         // now convert to a dynabean array for the client
         DynaBean sforceObj = dynaClass.newInstance();
 
@@ -291,11 +293,12 @@ public class PartnerClientTest extends ProcessTestBase {
         doTestUpdateBasic(true);
     }
         
+    @SuppressWarnings("unchecked")
     private void doTestUpdateBasic(boolean noCompression) throws Exception {
         String id = getRandomAccountId();
 
         // setup our dynabeans
-        BasicDynaClass dynaClass = setupDynaClass("Account");
+        BasicDynaClass dynaClass;
 
         Map<String, Object> sforceMapping = new HashMap<String, Object>();
         sforceMapping.put("Id", id);
@@ -303,6 +306,7 @@ public class PartnerClientTest extends ProcessTestBase {
         sforceMapping.put("Description", "the new description");
         // Account number is set for easier test data cleanup
         sforceMapping.put("AccountNumber", ACCOUNT_NUMBER_PREFIX + System.currentTimeMillis());
+        dynaClass = setupDynaClass("Account", (Collection<String>)(Collection<?>)(sforceMapping.values()));
 
         // now convert to a dynabean array for the client
         DynaBean sforceObj = dynaClass.newInstance();
@@ -328,17 +332,19 @@ public class PartnerClientTest extends ProcessTestBase {
     /**
      * Basic failing - forgetting the id
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testUpdateFailBasic() throws Exception {
 
         // setup our dynabeans
-        BasicDynaClass dynaClass = setupDynaClass("Account");
+        BasicDynaClass dynaClass;
 
         Map<String, Object> sforceMapping = new HashMap<String, Object>();
         sforceMapping.put("Name", "newname" + System.currentTimeMillis());
         sforceMapping.put("Description", "the new description");
         // Account number is set for easier test data cleanup
         sforceMapping.put("AccountNumber", ACCOUNT_NUMBER_PREFIX + System.currentTimeMillis());
+        dynaClass = setupDynaClass("Account", (Collection<String>)(Collection<?>)(sforceMapping.values()));
 
         // now convert to a dynabean array for the client
         DynaBean sforceObj = dynaClass.newInstance();
@@ -483,10 +489,11 @@ public class PartnerClientTest extends ProcessTestBase {
     /**
      * Basic failing - forgetting the external id or foreign key external id
      */
+    @SuppressWarnings("unchecked")
     private void doUpsertFailBasic(boolean upsertFk) throws Exception {
 
         // setup our dynabeans
-        BasicDynaClass dynaClass = setupDynaClass("Account");
+        BasicDynaClass dynaClass;
 
         Map<String, Object> sforceMapping = new HashMap<String, Object>();
         sforceMapping.put("Name", "newname" + System.currentTimeMillis());
@@ -502,6 +509,7 @@ public class PartnerClientTest extends ProcessTestBase {
             // forget to set the foreign key external id value
             sforceMapping.put(new ParentIdLookupFieldFormatter(null, "Parent", extIdField).toString(), "bogus");
         }
+        dynaClass = setupDynaClass("Account", (Collection<String>)(Collection<?>)(sforceMapping.values()));
 
         // now convert to a dynabean array for the client
         DynaBean sforceObj = dynaClass.newInstance();
@@ -521,12 +529,13 @@ public class PartnerClientTest extends ProcessTestBase {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testDeleteBasic() throws Exception {
         String id = getRandomAccountId();
 
         // setup our dynabeans
-        BasicDynaClass dynaClass = setupDynaClass("Account");
+        BasicDynaClass dynaClass;
 
         Map<String, Object> sforceMapping = new HashMap<String, Object>();
         sforceMapping.put("Id", id);
@@ -534,6 +543,7 @@ public class PartnerClientTest extends ProcessTestBase {
         sforceMapping.put("Description", "the description");
         // Account number is set for easier test data cleanup
         sforceMapping.put("AccountNumber", ACCOUNT_NUMBER_PREFIX + System.currentTimeMillis());
+        dynaClass = setupDynaClass("Account", (Collection<String>)(Collection<?>)(sforceMapping.values()));
 
         // now convert to a dynabean array for the client
         DynaBean sforceObj = dynaClass.newInstance();
@@ -561,13 +571,14 @@ public class PartnerClientTest extends ProcessTestBase {
     public void testDeleteFailBasic() throws Exception {
 
         // setup our dynabeans
-        BasicDynaClass dynaClass = setupDynaClass("Account");
+        BasicDynaClass dynaClass;
 
         Map<String, Object> sforceMapping = new HashMap<String, Object>();
         sforceMapping.put("name", "name" + System.currentTimeMillis());
         sforceMapping.put("description", "the description");
         // Account number is set for easier test data cleanup
         sforceMapping.put("AccountNumber", ACCOUNT_NUMBER_PREFIX + System.currentTimeMillis());
+        dynaClass = setupDynaClass("Account", (Collection<String>)(Collection<?>)(sforceMapping.values()));
 
         // now convert to a dynabean array for the client
         DynaBean sforceObj = dynaClass.newInstance();

--- a/src/test/java/com/salesforce/dataloader/dyna/SObjectReferenceConverterTest.java
+++ b/src/test/java/com/salesforce/dataloader/dyna/SObjectReferenceConverterTest.java
@@ -31,6 +31,7 @@ import com.sforce.ws.ConnectionException;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 
 import static org.junit.Assert.assertEquals;
@@ -44,7 +45,6 @@ public class SObjectReferenceConverterTest extends ConfigTestBase {
         SObjectReference ref;
 
         getController().login();
-        getController().setReferenceDescribes();
 
         // null test
         ref = (SObjectReference)refConverter.convert(null, null);
@@ -74,10 +74,13 @@ public class SObjectReferenceConverterTest extends ConfigTestBase {
         testValidSObjectReference("12345", "Bogus", false);
     }
 
-    private void testValidSObjectReference(String refValue, String relationshipName, boolean expectSuccess) {
+    private void testValidSObjectReference(String refValue, String relationshipName, boolean expectSuccess) throws ConnectionException {
         SObjectReference ref = new SObjectReference(refValue);
         SObject sObj = new SObject();
         String fkFieldName = ConfigTestBase.DEFAULT_ACCOUNT_EXT_ID_FIELD;
+        ArrayList<String> lookupFields = new ArrayList<String>();
+        lookupFields.add(relationshipName + ":" + fkFieldName);
+        getController().setReferenceDescribes(lookupFields);
 
         try {
             // legacy formatting

--- a/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
@@ -963,10 +963,11 @@ public abstract class ProcessTestBase extends ConfigTestBase {
     }
     
 
+    @SuppressWarnings("unchecked")
     protected UpsertResult[] doUpsert(String entity, Map<String, Object> sforceMapping) throws Exception {
         // now convert to a dynabean array for the client
         // setup our dynabeans
-        BasicDynaClass dynaClass = setupDynaClass(entity);
+        BasicDynaClass dynaClass = setupDynaClass(entity, (Collection<String>)(Collection<?>)(sforceMapping.values()));
 
         DynaBean sforceObj = dynaClass.newInstance();
 
@@ -1035,7 +1036,7 @@ public abstract class ProcessTestBase extends ConfigTestBase {
         return records[0].getField(extIdField);
     }
     
-    protected BasicDynaClass setupDynaClass(String entity) throws ConnectionException {
+    protected BasicDynaClass setupDynaClass(String entity, Collection<String> sfFields) throws ConnectionException {
         getController().getConfig().setValue(Config.ENTITY, entity);
         PartnerClient client = getController().getPartnerClient();
         if (!client.isLoggedIn()) {
@@ -1043,7 +1044,7 @@ public abstract class ProcessTestBase extends ConfigTestBase {
         }
 
         getController().setFieldTypes();
-        getController().setReferenceDescribes();
+        getController().setReferenceDescribes(sfFields);
         DynaProperty[] dynaProps = SforceDynaBean.createDynaProps(getController().getPartnerClient().getFieldTypes(), getController());
         BasicDynaClass dynaClass = SforceDynaBean.getDynaBeanInstance(dynaProps);
         SforceDynaBean.registerConverters(getController().getConfig());


### PR DESCRIPTION
…relationships

Added method PartnerClient.setFieldReferenceDescribes(Collection<String>sfFields) that can be used by tests to provide the list of relationships of the sObject for which describeSObject on parent sobject is performed instead of all parent sobjects for all lookup relationships.