### PR TITLE
decouple bulk v1 and bulk v2 config properties

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/BulkLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/BulkLoadVisitor.java
@@ -392,7 +392,7 @@ public class BulkLoadVisitor extends DAOLoadVisitor {
                 logger.warn("Failed to close job", e);
             }
             try {
-            	if (this.getConfig().isBulkAPIEnabled())
+            	if (this.getConfig().isBulkAPIEnabled() || this.getConfig().isBulkV2APIEnabled())
                 getResults();
             } catch (AsyncApiException e) {
                 throw new LoadException("Failed to get batch results", e);

--- a/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
@@ -138,9 +138,10 @@ public abstract class DAOLoadVisitor extends AbstractVisitor implements DAORowVi
     @Override
     public boolean visit(Row row) throws OperationException, DataAccessObjectException,
     ConnectionException {
-        if (controller.getConfig().getBoolean(Config.PROCESS_BULK_CACHE_DATA_FROM_DAO)
-            || !controller.getConfig().getBoolean(Config.BULK_API_ENABLED)) {
-            // either batch mode or cache bulk data uploaded from DAO
+        Config config = controller.getConfig();
+        if (config.getBoolean(Config.PROCESS_BULK_CACHE_DATA_FROM_DAO)
+            || (!config.isBulkAPIEnabled() && !config.isBulkV2APIEnabled())) {
+            // either bulk mode or cache bulk data uploaded from DAO
             this.daoRowList.add(row);
         }
         // the result are sforce fields mapped to data

--- a/src/main/java/com/salesforce/dataloader/client/ClientBase.java
+++ b/src/main/java/com/salesforce/dataloader/client/ClientBase.java
@@ -92,15 +92,18 @@ public abstract class ClientBase<ConnectionType> {
 
     private static final String BASE_CLIENT_NAME = "DataLoader";
     private static final String BULK_API_CLIENT_TYPE = "Bulk";
+    private static final String BULK_V2_API_CLIENT_TYPE = "Bulkv2";
     private static final String PARTNER_API_CLIENT_TYPE = "Partner";
     private static final String BATCH_CLIENT_STRING = "Batch";
     private static final String UI_CLIENT_STRING = "UI";
 
     public static String getClientName(Config cfg) {
-        String apiType = cfg.isBulkAPIEnabled() ? BULK_API_CLIENT_TYPE : PARTNER_API_CLIENT_TYPE;
+        String apiType = PARTNER_API_CLIENT_TYPE;
         final String interfaceType = cfg.isBatchMode() ? BATCH_CLIENT_STRING : UI_CLIENT_STRING;
-        if (cfg.isBulkAPIEnabled() && cfg.isBulkV2APIEnabled()) {
-            apiType = apiType + "v2";
+        if (cfg.isBulkAPIEnabled()) {
+            apiType = BULK_API_CLIENT_TYPE;
+        }else if (cfg.isBulkV2APIEnabled()) {
+            apiType = BULK_V2_API_CLIENT_TYPE;
         }
         return new StringBuilder(32).append(BASE_CLIENT_NAME).append(apiType).append(interfaceType)
                 .append("/")

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -1352,7 +1352,7 @@ public class Config {
         boolean bulkApi = isBulkAPIEnabled();
         boolean bulkV2Api = this.isBulkV2APIEnabled();
         
-        if (bulkApi && bulkV2Api) {
+        if (bulkV2Api) {
             return MAX_BULKV2_API_IMPORT_JOB_SIZE;
         }
         
@@ -1366,29 +1366,29 @@ public class Config {
     }
 
     public int getDefaultImportBatchSize(boolean bulkApi, boolean bulkV2Api) {
-        if (bulkApi && bulkV2Api) {
+        if (bulkV2Api) {
             return MAX_BULKV2_API_IMPORT_JOB_SIZE;
         }
         return bulkApi ? DEFAULT_BULK_API_IMPORT_BATCH_SIZE : DEFAULT_LOAD_BATCH_SIZE;
     }
     
     public int getMaxImportBatchSize(boolean bulkApi, boolean bulkV2Api) {
-        if (bulkApi && bulkV2Api) {
+        if (bulkV2Api) {
             return MAX_BULKV2_API_IMPORT_JOB_SIZE;
         }
         return bulkApi ? MAX_BULK_API_IMPORT_BATCH_SIZE : MAX_SOAP_API_IMPORT_BATCH_SIZE;
     }
     
     public boolean useBulkAPIForCurrentOperation() {
-        return isBulkAPIEnabled() && isBulkApiOperation();
+        return (isBulkAPIEnabled() || isBulkV2APIEnabled()) && isBulkApiOperation();
     }
 
     public boolean isBulkAPIEnabled() {
-        return getBoolean(BULK_API_ENABLED);
+        return getBoolean(BULK_API_ENABLED) && !isBulkV2APIEnabled();
     }
     
     public boolean isBulkV2APIEnabled() {
-        return isBulkAPIEnabled() && getBoolean(BULKV2_API_ENABLED);
+        return getBoolean(BULKV2_API_ENABLED);
     }
     
     public boolean isRESTAPIEnabled() {
@@ -1488,7 +1488,7 @@ public class Config {
         if (!isEnvMatch) {
             environment = OAUTH_PROD_ENVIRONMENT_VAL;
         }
-        if (getBoolean(BULK_API_ENABLED)) {
+        if (getBoolean(BULK_API_ENABLED) || getBoolean(BULKV2_API_ENABLED)) {
             clientId = getOAuthEnvironmentString(environment, OAUTH_PARTIAL_BULK_CLIENTID);
         } else {
             clientId = getOAuthEnvironmentString(environment, OAUTH_PARTIAL_PARTNER_CLIENTID);

--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -315,7 +315,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
 
         // Enable Bulk API Setting
         useBulkAPI = config.getBoolean(Config.BULK_API_ENABLED) && !config.getBoolean(Config.BULKV2_API_ENABLED);
-        useBulkV2API = config.getBoolean(Config.BULK_API_ENABLED) && config.getBoolean(Config.BULKV2_API_ENABLED);
+        useBulkV2API = config.getBoolean(Config.BULKV2_API_ENABLED);
         useSoapAPI = !useBulkAPI && !useBulkV2API;
 
         buttonUseSOAPApi = new Button(apiChoiceComposite, SWT.RADIO);
@@ -987,10 +987,10 @@ public class AdvancedSettingsDialog extends BaseDialog {
 
                 // Config requires Bulk API AND Bulk V2 API settings enabled to use Bulk V2 features
                 // This is different from UI. UI shows them as mutually exclusive.
-                config.setValue(Config.BULK_API_ENABLED, useBulkAPI || useBulkV2API);
+                config.setValue(Config.BULK_API_ENABLED, buttonUseBulkV1Api.getSelection());
                 config.setValue(Config.BULK_API_SERIAL_MODE, buttonBulkApiSerialMode.getSelection());
                 config.setValue(Config.BULK_API_ZIP_CONTENT, buttonBulkApiZipContent.getSelection());
-                config.setValue(Config.BULKV2_API_ENABLED, useBulkV2API);
+                config.setValue(Config.BULKV2_API_ENABLED, buttonUseBulkV2Api.getSelection());
                 config.setValue(Config.OAUTH_LOGIN_FROM_BROWSER, buttonLoginFromBrowser.getSelection());
                 config.setValue(Config.WIZARD_CLOSE_ON_FINISH, buttonCloseWizardOnFinish.getSelection());
                 config.setValue(Config.WIZARD_WIDTH, textWizardWidth.getText());

--- a/src/test/java/com/salesforce/dataloader/process/CsvExtractProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvExtractProcessTest.java
@@ -75,7 +75,7 @@ public class CsvExtractProcessTest extends ProcessExtractTestBase {
                 // Bulk API
                 TestVariant.forSettings(TestSetting.BULK_API_ENABLED, TestSetting.BULK_V2_API_DISABLED),
                 // Bulk V2 Query API
-                TestVariant.forSettings(TestSetting.BULK_API_ENABLED, TestSetting.BULK_V2_API_ENABLED));
+                TestVariant.forSettings(TestSetting.BULK_V2_API_ENABLED));
     }
     
     public CsvExtractProcessTest(Map<String, String> config) {

--- a/src/test/java/com/salesforce/dataloader/process/CsvHardDeleteTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvHardDeleteTest.java
@@ -69,7 +69,7 @@ public class CsvHardDeleteTest extends ProcessTestBase {
                 TestVariant.forSettings(TestSetting.BULK_API_ENABLED, TestSetting.BULK_API_CACHE_DAO_UPLOAD_ENABLED),
                 TestVariant.forSettings(TestSetting.BULK_API_ENABLED, TestSetting.BULK_API_ZIP_CONTENT_ENABLED),
                 TestVariant.forSettings(TestSetting.BULK_API_ENABLED, TestSetting.BULK_API_SERIAL_MODE_ENABLED),
-                TestVariant.forSettings(TestSetting.BULK_API_ENABLED, TestSetting.BULK_V2_API_ENABLED)
+                TestVariant.forSettings(TestSetting.BULK_V2_API_ENABLED)
             );
     }
 
@@ -142,7 +142,7 @@ public class CsvHardDeleteTest extends ProcessTestBase {
     }
 
     /**
-     * Hard Delete - Negative test. Uncheck Bull Api setting in data loader to verify that Hard Delete operation cannot
+     * Hard Delete - Negative test. Uncheck Bulk Api setting in data loader to verify that Hard Delete operation cannot
      * be done.
      */
     @Test
@@ -153,6 +153,7 @@ public class CsvHardDeleteTest extends ProcessTestBase {
         // set batch process parameters
         Map<String, String> argMap = getHardDeleteTestConfig(new AccountIdTemplateListener(1));
         argMap.remove(Config.BULK_API_ENABLED);
+        argMap.remove(Config.BULKV2_API_ENABLED);
         try {
             runProcess(argMap, 889);
             Assert.fail("hard delete should not succeed if bulk api is turned off");

--- a/src/test/java/com/salesforce/dataloader/process/NAProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/NAProcessTest.java
@@ -150,7 +150,8 @@ public class NAProcessTest extends ProcessTestBase {
         generateCsvWithNAField(nullFieldName, taskId);
         Map<String, String> argMap = getArgMap(operation);
         Controller controller;
-        if (!getController().getConfig().getBoolean(Config.BULK_API_ENABLED) && isDateField) {
+        Config config = getController().getConfig();
+        if (!config.isBulkAPIEnabled() && !config.isBulkV2APIEnabled() && isDateField) {
             controller = runProcess(argMap, true, null, 0, 0, 1, false);
             String errorFile = controller.getConfig().getStringRequired(Config.OUTPUT_ERROR);
             String errorMessage = getCsvFieldValue(errorFile, "ERROR");

--- a/src/test/java/com/salesforce/dataloader/process/ProcessExtractTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessExtractTestBase.java
@@ -68,7 +68,7 @@ public abstract class ProcessExtractTestBase extends ProcessTestBase {
                 // Bulk API
                 , TestVariant.forSettings(TestSetting.BULK_API_ENABLED, TestSetting.BULK_V2_API_DISABLED)
                 // Bulk V2 Query API
-                , TestVariant.forSettings(TestSetting.BULK_API_ENABLED, TestSetting.BULK_V2_API_ENABLED)
+                , TestVariant.forSettings(TestSetting.BULK_V2_API_ENABLED)
                 );
     }
 

--- a/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
@@ -637,7 +637,12 @@ public abstract class ProcessTestBase extends ConfigTestBase {
         res.put(Config.DAO_TYPE, isExtraction ? DataAccessObjectFactory.CSV_WRITE_TYPE
                 : DataAccessObjectFactory.CSV_READ_TYPE);
         res.put(Config.OUTPUT_STATUS_DIR, getTestStatusDir());
-        String apiType = isBulkAPIEnabled(res) || isBulkV2APIEnabled(res) ? "Bulk" : "Soap";
+        String apiType = "Soap";
+        if (isBulkAPIEnabled(res)) {
+            apiType = "Bulk";
+        } else if (isBulkV2APIEnabled(res)) {
+            apiType = "BulkV2";
+        }
         res.put(Config.OUTPUT_SUCCESS, getSuccessFilePath(apiType));
         res.put(Config.OUTPUT_ERROR, getErrorFilePath(apiType));
 
@@ -914,8 +919,7 @@ public abstract class ProcessTestBase extends ConfigTestBase {
     }
     
     protected boolean isBulkV2APIEnabled(Map<String, String> argMap) {
-        return isSettingEnabled(argMap, Config.BULK_API_ENABLED)
-                && isSettingEnabled(argMap, Config.BULKV2_API_ENABLED);
+        return isSettingEnabled(argMap, Config.BULKV2_API_ENABLED);
     }
     protected boolean isSettingEnabled(Map<String, String> argMap, String configKey) {
         return Config.TRUE.equalsIgnoreCase(argMap.get(configKey));


### PR DESCRIPTION
decouple bulk v1 and bulk v2 config properties so that bulk v1 config property does not have to be set to true in order to enable bulk v2.