### PR TITLE
FIx for issue #1193

### DIFF
--- a/src/main/resources/mac/dataloader_console
+++ b/src/main/resources/mac/dataloader_console
@@ -1,5 +1,5 @@
 #!/bin/bash
 DL_INSTALL_ROOT="$(dirname "$(readlink -f "$0")")"
-source ${DL_INSTALL_ROOT}/util/util.sh
+source "${DL_INSTALL_ROOT}/util/util.sh"
 
 runDataLoader $@


### PR DESCRIPTION
fix for the bug in the launch script that prevents it from starting Data Loader if the installation folder path has a space character.