### PR TITLE
Fix for issue #1203 - extraction column values are empty for functions

### DIFF
--- a/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileWriter.java
+++ b/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileWriter.java
@@ -231,6 +231,12 @@ public class CSVFileWriter implements DataWriter {
     static private void visitColumns(List<String> columnNames, Row row, CSVColumnVisitor visitor) throws IOException {
         for (String colName : columnNames) {
             Object colVal = row.get(colName);
+            if (colVal == null && colName.contains("(")) {
+                int lparenIdx = colName.indexOf('(');
+                int rparenIdx = colName.indexOf(')');
+                colName = colName.substring(lparenIdx + 1, rparenIdx);
+                colVal = row.get(colName);
+            }
             visitor.visit(colVal != null ? colVal.toString() : "");
         }
     }


### PR DESCRIPTION
Fix for issue #1023 - extraction column values are empty for non-aggregation functions such as format().