### PR TITLE
fix syntax error in CsvExtractAllProcessTest

### DIFF
--- a/src/test/java/com/salesforce/dataloader/process/CsvExtractAllProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvExtractAllProcessTest.java
@@ -54,7 +54,7 @@ public class CsvExtractAllProcessTest extends ProcessExtractTestBase {
                 // partner API
                 TestVariant.forSettings(TestSetting.BULK_API_DISABLED, TestSetting.BULK_V2_API_DISABLED),
                 // Bulk API
-                TestVariant.forSettings(TestSetting.BULK_API_ENABLED, TestSetting.BULK_V2_API_DISABLED)
+                TestVariant.forSettings(TestSetting.BULK_API_ENABLED, TestSetting.BULK_V2_API_DISABLED),
                 // Bulk V2 Query API does not support query_all
                 TestVariant.forSettings(TestSetting.BULK_API_ENABLED, TestSetting.BULK_V2_API_ENABLED)
             );


### PR DESCRIPTION
fix syntax error in CsvExtractAllProcessTest introduced during commenting/uncommenting to troubleshoot an issue.