### PR TITLE
perf improvement in bulk v2 upload

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/AbstractVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/AbstractVisitor.java
@@ -76,6 +76,10 @@ public abstract class AbstractVisitor implements IVisitor {
         this.successes++;
     }
     
+    protected void addErrors() {
+        this.errors++;
+    }
+    
     protected void setSuccesses(long num) {
     	this.successes = num;
     }
@@ -149,7 +153,7 @@ public abstract class AbstractVisitor implements IVisitor {
             }
             this.errorWriter.writeRow(row);
         }
-        this.errors++;
+        addErrors();
     }
 
     protected LoadRateCalculator getRateCalculator() {


### PR DESCRIPTION
avoid saving server-side error rows in a temporary file, thereby speeding up end-to-end processing time. Also, use Files utility to determine number of lines in error and success files, thereby avoiding row by row traversal and count of each.