### PR TITLE
fix soql query reset when selecting/unselecting a field

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionSOQLPage.java
+++ b/src/main/java/com/salesforce/dataloader/ui/extraction/ExtractionSOQLPage.java
@@ -498,6 +498,7 @@ public class ExtractionSOQLPage extends ExtractionPage {
         soqlText.addModifyListener(new ModifyListener() {
             @Override
             public void modifyText(ModifyEvent arg0) {
+                updateWherePart();
                 setPageComplete();
             }
         });
@@ -681,6 +682,19 @@ public class ExtractionSOQLPage extends ExtractionPage {
         }
         setAddWhereButtonState();
         setClearWhereButtonState();
+    }
+    
+    private void updateWherePart() {
+        String soqlStr = soqlText.getText();
+        String whereClause = "";
+        if (soqlStr != null && !soqlStr.isBlank()) {
+            soqlStr = soqlStr.toLowerCase();
+            int idx = soqlStr.indexOf("where");
+            if (idx >= 0) {
+                whereClause = soqlText.getText().substring(idx);
+            }
+        }
+        wherePart = new StringBuffer(whereClause);
     }
 
     public String getSOQL() {


### PR DESCRIPTION
Address the issue reported at https://ideas.salesforce.com/s/idea/a0B8W00000PGMNfUAP/data-loader-soql-query-reset-after-manually-editing-then-clicking-add-condition