### PR TITLE
Fix an issue during cancellation of drag-n-drop action for mapping

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/MappingDialog.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.ArrayList;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -106,6 +105,7 @@ public class MappingDialog extends WizardDialog {
     private Shell parentShell;
     private Shell dialogShell;
     private Text sforceFieldsSearch;
+    private boolean dragNDropCancelled = false;
 
     public void setSforceFieldInfo(Field[] sforceFieldInfo) {
         this.sforceFieldInfo = sforceFieldInfo;
@@ -311,6 +311,14 @@ public class MappingDialog extends WizardDialog {
         // user can type input and press Enter
         // to dismiss
         shell.setDefaultButton(ok);
+    }
+    
+    public void setIsDragNDropCancelled(boolean cancelled) {
+        this.dragNDropCancelled = cancelled;
+    }
+    
+    public boolean isDragActionCancelled() {
+        return this.dragNDropCancelled;
     }
 
     private void initializeMappingViewer(Shell shell) {

--- a/src/main/java/com/salesforce/dataloader/ui/mapping/MappingDropAdapter.java
+++ b/src/main/java/com/salesforce/dataloader/ui/mapping/MappingDropAdapter.java
@@ -68,7 +68,8 @@ public class MappingDropAdapter extends ViewerDropAdapter {
         this.dropEntry = (Entry<String, String>)getCurrentTarget();
         this.currentSforceMappings = this.dropEntry.getValue();
         this.sforceFieldToAddOrReplace = (String)arg0;
-        
+        mappingDialog.setIsDragNDropCancelled(false);
+
         if (this.currentSforceMappings == null || this.currentSforceMappings.isBlank()) {
             // if no existing mapping, perform add action
             performDropAction(MAPPING_CHOICE.ADD);
@@ -87,6 +88,7 @@ public class MappingDropAdapter extends ViewerDropAdapter {
     public void performDropAction(MAPPING_CHOICE choice) {
         String newSforceMappings = this.sforceFieldToAddOrReplace;
         if (choice == MAPPING_CHOICE.CANCEL) {
+            mappingDialog.setIsDragNDropCancelled(true);
             return;
         }
         if (this.currentSforceMappings != null && !this.currentSforceMappings.isBlank()) {

--- a/src/main/java/com/salesforce/dataloader/ui/mapping/SforceDragListener.java
+++ b/src/main/java/com/salesforce/dataloader/ui/mapping/SforceDragListener.java
@@ -43,11 +43,11 @@ import com.salesforce.dataloader.ui.MappingDialog;
  */
 public class SforceDragListener extends DragSourceAdapter {
     private final StructuredViewer viewer;
-    private final MappingDialog dlg;
+    private final MappingDialog mappingDialog;
 
     public SforceDragListener(StructuredViewer viewer, MappingDialog dialog) {
         this.viewer = viewer;
-        this.dlg = dialog;
+        this.mappingDialog = dialog;
     }
 
     /**
@@ -59,16 +59,15 @@ public class SforceDragListener extends DragSourceAdapter {
         //if the gadget was moved, remove it from the source viewer
 
         try {
-            if (event.detail == DND.DROP_MOVE) {
+            if (event.detail == DND.DROP_MOVE && !mappingDialog.isDragActionCancelled()) {
                 IStructuredSelection selection = (IStructuredSelection)viewer.getSelection();
                 for (Iterator<?> it = selection.iterator(); it.hasNext();) {
                     @SuppressWarnings("unchecked")
                     Map.Entry<String, String> eventElem = (Entry<String, String>)it.next();
                     eventElem.setValue("");
-                    dlg.getMapper().removeMapping(eventElem.getKey());
+                    mappingDialog.getMapper().removeMapping(eventElem.getKey());
                 }
-
-                dlg.packMappingColumns();
+                mappingDialog.packMappingColumns();
                 viewer.refresh();
             }
         } catch (Exception e) {


### PR DESCRIPTION
Fix the issue where cancelling drag-n-drop of a field mapping results in removal of the field from the source row.