### PR TITLE
logs to help debugging mapping issues

### DIFF
--- a/src/main/java/com/salesforce/dataloader/mapping/Mapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/Mapper.java
@@ -152,6 +152,7 @@ public abstract class Mapper {
             Boolean destFieldTypeIsString = this.fieldTypeIsStringMap.get(destFieldName.toLowerCase());
             if (destFieldTypeIsString == null || !destFieldTypeIsString) {
                 isDestinationListStringOnly = false;
+                logger.debug(destFieldName + " is not string or text area.");
                 break;
             }
         }
@@ -173,6 +174,7 @@ public abstract class Mapper {
             if (!isDestinationListStringOnly) {
                 // set up only the first daoCol for mapping if the destination
                 // field list contains a field whose type is not string
+                logger.debug("Mapping first CSV column '" + daoCol + "' because one of the sobject fields it is mapped to is not a string or a text area");
                 break; 
             }
         }


### PR DESCRIPTION
log when multiple csv columns mapping to a sobject field is ignored because sobject field is not a string or a text area field.