### PR TITLE
Auth code cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- test properties -->
-    <test.endpoint>http://testendpoint</test.endpoint>
+    <test.endpoint>https://testendpoint</test.endpoint>
     <test.user.default>admin@org.com</test.user.default>
     <test.user.restricted>standard@org.com</test.user.restricted>
     <test.password></test.password><!-- use the encrypted password -->

--- a/src/main/java/com/salesforce/dataloader/client/ClientBase.java
+++ b/src/main/java/com/salesforce/dataloader/client/ClientBase.java
@@ -26,11 +26,8 @@
 package com.salesforce.dataloader.client;
 
 import java.io.FileNotFoundException;
-import java.net.MalformedURLException;
-import java.net.URL;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import com.salesforce.dataloader.client.SessionInfo.NotLoggedInException;
 import com.salesforce.dataloader.config.Config;
@@ -48,20 +45,6 @@ import com.sforce.ws.ConnectorConfig;
  * @since 17.0
  */
 public abstract class ClientBase<ConnectionType> {
-
-    private static Logger LOG = LogManager.getLogger(PartnerClient.class);
-
-    protected static final URL DEFAULT_AUTH_ENDPOINT_URL;
-    static {
-        URL loginUrl;
-        try {
-            loginUrl = new URL(Connector.END_POINT);
-        } catch (MalformedURLException ex) {
-            LOG.error(ex);
-            throw new RuntimeException(ex);
-        }
-        DEFAULT_AUTH_ENDPOINT_URL = loginUrl;
-    }
 
     private static String apiVersionForTheSession = getCurrentAPIVersionInWSC();
 

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -1201,6 +1201,7 @@ public class Config {
     }
     
     public void setAuthEndpointForEnv(String authEndpoint, String env) {
+        AppUtil.validateAuthenticationHostDomainUrlAndThrow(authEndpoint);
         if (env != null && env.equalsIgnoreCase(getString(Config.SB_ENVIRONMENT_VAL))) {
             this.setValue(Config.AUTH_ENDPOINT_SANDBOX, authEndpoint);
         } else {
@@ -1209,7 +1210,7 @@ public class Config {
     }
     
     public String getAuthEndpoint() {
-        String endpoint = getString(Config.AUTH_ENDPOINT);
+        String endpoint = null;
         if (Config.SB_ENVIRONMENT_VAL.equals(this.getString(Config.SELECTED_AUTH_ENVIRONMENT))) {
             endpoint = getString(Config.AUTH_ENDPOINT_SANDBOX);
             if (endpoint == null || endpoint.isBlank()) {
@@ -1221,6 +1222,7 @@ public class Config {
                 endpoint = getDefaultAuthEndpoint();
             }
         }
+        AppUtil.validateAuthenticationHostDomainUrlAndThrow(endpoint);
         return endpoint;
     }
     

--- a/src/main/java/com/salesforce/dataloader/util/AppUtil.java
+++ b/src/main/java/com/salesforce/dataloader/util/AppUtil.java
@@ -505,9 +505,9 @@ public class AppUtil {
             return false;
         }
     }
-    public static void validateHttpsUrlAndThrow(String url) {
+    public static void validateAuthenticationHostDomainUrlAndThrow(String url) {
         if (!isValidHttpsUrl(url)) {
-            throw new RuntimeException("Dataloader only supports server URL that uses https protocol:" + url);
+            throw new RuntimeException("Dataloader only supports Authentication host domain URL that uses https protocol:" + url);
         }
     }
     

--- a/src/test/java/com/salesforce/dataloader/oauth/OAuthFlowUtilTests.java
+++ b/src/test/java/com/salesforce/dataloader/oauth/OAuthFlowUtilTests.java
@@ -54,7 +54,7 @@ public class OAuthFlowUtilTests extends ConfigTestBase {
         config = getController().getConfig();
         existingOAuthEnvironments = config.getStrings(Config.AUTH_ENVIRONMENTS);
         existingEndPoint = config.getAuthEndpoint();
-        oauthServer = "http://OAUTH_PARTIAL_SERVER";
+        oauthServer = "https://OAUTH_PARTIAL_SERVER";
         oauthClientId = "CLIENTID";
         oauthRedirectUri = "REDIRECTURI";
 
@@ -74,7 +74,7 @@ public class OAuthFlowUtilTests extends ConfigTestBase {
     @Test
     public void testGetStartUrl(){
         try {
-            String expected = "http://OAUTH_PARTIAL_SERVER/services/oauth2/authorize?response_type=token&display=popup&client_id=CLIENTID&redirect_uri=REDIRECTURI";
+            String expected = "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize?response_type=token&display=popup&client_id=CLIENTID&redirect_uri=REDIRECTURI";
             String actual = OAuthFlowUtil.getStartUrlImpl(config);
 
             Assert.assertEquals( "OAuth Token Flow returned the wrong url", expected, actual);
@@ -86,7 +86,7 @@ public class OAuthFlowUtilTests extends ConfigTestBase {
     @Test
     public void testInvalidReponseUrl(){
         try {
-            Boolean condition = OAuthFlowUtil.handleCompletedUrl( "http://OAUTH_PARTIAL_SERVER/services/oauth2/authorize?doit=1", config);
+            Boolean condition = OAuthFlowUtil.handleCompletedUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize?doit=1", config);
             Assert.assertFalse("OAuthToken should not have handled this", condition);
 
         } catch (URISyntaxException e) {
@@ -97,7 +97,7 @@ public class OAuthFlowUtilTests extends ConfigTestBase {
     @Test
     public void testValidResponseUrl(){
         try {
-            Boolean condition = OAuthFlowUtil.handleCompletedUrl( "http://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN", config);
+            Boolean condition = OAuthFlowUtil.handleCompletedUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN", config);
             Assert.assertTrue("OAuthToken should have handled this", condition);
 
         } catch (URISyntaxException e) {
@@ -108,7 +108,7 @@ public class OAuthFlowUtilTests extends ConfigTestBase {
     @Test
     public void testValidResponseUrlSetsAccessToken(){
         try {
-            OAuthFlowUtil.handleCompletedUrl( "http://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN", config);
+            OAuthFlowUtil.handleCompletedUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN", config);
             String expected = "TOKEN";
             String actual = config.getString(Config.OAUTH_ACCESSTOKEN);
 
@@ -121,7 +121,7 @@ public class OAuthFlowUtilTests extends ConfigTestBase {
     @Test
     public void testValidResponseUrlSetsRefreshToken(){
         try {
-            OAuthFlowUtil.handleCompletedUrl( "http://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN&refresh_token=REFRESHTOKEN", config);
+            OAuthFlowUtil.handleCompletedUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN&refresh_token=REFRESHTOKEN", config);
             String expected = "REFRESHTOKEN";
             String actual = config.getString(Config.OAUTH_REFRESHTOKEN);
 
@@ -134,7 +134,7 @@ public class OAuthFlowUtilTests extends ConfigTestBase {
     @Test
     public void testValidResponseUrlSetsEndPoint(){
         try {
-            OAuthFlowUtil.handleCompletedUrl( "http://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN&instance_url=INSTANCEURL", config);
+            OAuthFlowUtil.handleCompletedUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN&instance_url=INSTANCEURL", config);
             String expected = "INSTANCEURL";
             String actual = config.getString(Config.OAUTH_INSTANCE_URL);
 

--- a/src/test/java/com/salesforce/dataloader/oauth/OAuthSecretFlowUtilTests.java
+++ b/src/test/java/com/salesforce/dataloader/oauth/OAuthSecretFlowUtilTests.java
@@ -67,7 +67,7 @@ public class OAuthSecretFlowUtilTests extends ConfigTestBase {
         config = getController().getConfig();
         existingOAuthEnvironments = config.getStrings(Config.AUTH_ENVIRONMENTS);
         existingEndPoint = config.getAuthEndpoint();
-        oauthServer = "http://OAUTH_PARTIAL_SERVER";
+        oauthServer = "https://OAUTH_PARTIAL_SERVER";
         oauthClientId = "CLIENTID";
         oauthRedirectUri = "REDIRECTURI";
         mockSimplePost = mock(SimplePost.class);
@@ -92,7 +92,7 @@ public class OAuthSecretFlowUtilTests extends ConfigTestBase {
     @Test
     public void testGetStartUrl(){
         try {
-            String expected = "http://OAUTH_PARTIAL_SERVER/services/oauth2/authorize?response_type=code&display=popup&client_id=CLIENTID&redirect_uri=REDIRECTURI";
+            String expected = "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize?response_type=code&display=popup&client_id=CLIENTID&redirect_uri=REDIRECTURI";
             String actual = OAuthSecretFlowUtil.getStartUrlImpl(config);
 
             Assert.assertEquals( "OAuth Token Flow returned the wrong url", expected, actual);
@@ -105,7 +105,7 @@ public class OAuthSecretFlowUtilTests extends ConfigTestBase {
     public void testInvalidInitialReponseUrl(){
         try {
             String expected = null;
-            String actual = OAuthSecretFlowUtil.handleInitialUrl( "http://OAUTH_PARTIAL_SERVER/services/oauth2/authorize?doit=1");
+            String actual = OAuthSecretFlowUtil.handleInitialUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize?doit=1");
             Assert.assertEquals("OAuthToken should not have handled this", expected, actual);
 
         } catch (URISyntaxException e) {
@@ -117,7 +117,7 @@ public class OAuthSecretFlowUtilTests extends ConfigTestBase {
     public void testValidInitialResponseUrl(){
         try {
             String expected = "TOKEN";
-            String actual = OAuthSecretFlowUtil.handleInitialUrl( "http://OAUTH_PARTIAL_SERVER/services/oauth2/authorize?code=TOKEN");
+            String actual = OAuthSecretFlowUtil.handleInitialUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize?code=TOKEN");
             Assert.assertEquals("OAuthToken should not have handled this", expected, actual);
 
         } catch (URISyntaxException e) {
@@ -188,7 +188,7 @@ public class OAuthSecretFlowUtilTests extends ConfigTestBase {
                     .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                     .create();
             OAuthToken token = new OAuthToken();
-            token.setInstanceUrl("http://INSTANCEURL");
+            token.setInstanceUrl("https://INSTANCEURL");
             String jsonToken = gson.toJson(token);
             InputStream input = new ByteArrayInputStream(jsonToken.getBytes(StandardCharsets.UTF_8));
             when(mockSimplePost.getInput()).thenAnswer(i -> input);
@@ -197,7 +197,7 @@ public class OAuthSecretFlowUtilTests extends ConfigTestBase {
             @SuppressWarnings("unused")
             SimplePost simplePost = OAuthSecretFlowUtil.handleSecondPost("simplePost", config);
 
-            String expected = "http://INSTANCEURL";
+            String expected = "https://INSTANCEURL";
             String actual = config.getString(Config.OAUTH_INSTANCE_URL);;
 
             Assert.assertEquals("Access token was not set", expected, actual);


### PR DESCRIPTION
- make sure that Auth endpoint uses https protocol in getters and setters.
- rename method to validate Auth endpoint to reflect its purpose.
- remove use of auth endpoint URL obtained from WSC's endpoint setting.