### PR TITLE
fix broken test for REST API update

### DIFF
--- a/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
@@ -557,6 +557,13 @@ public abstract class ProcessTestBase extends ConfigTestBase {
         @Override
         public void updateRow(int idx, Row row) {
             row.put("ID", idx < this.accountIds.length ? this.accountIds[idx] : "");
+            if (row.containsValue("standard@org.com")) {
+                for (String key : row.keySet()) {
+                    if ("standard@org.com".equals(row.get(key))) {
+                        row.put(key, getProperty("test.user.restricted"));
+                    }
+                }
+            }
         }
 
         public String[] getAccountIds() {

--- a/src/test/resources/testfiles/data/updateAccountWithExternalIdCsvMap.sdl
+++ b/src/test/resources/testfiles/data/updateAccountWithExternalIdCsvMap.sdl
@@ -7,4 +7,4 @@ TYPE=Type
 ANNUALREVENUE=AnnualRevenue
 PHONE=Phone
 ORACLE_ID__C=Oracle_Id__c
-OWNER\:User-username=owner\:user-username
+OWNER\:User-username=Owner\:User-Username


### PR DESCRIPTION
fix broken test for REST API update with lookup relationship using an idlookup field in the parent object.