### PR TITLE
support case-insensitive mappings in mapping file

### DIFF
--- a/src/main/java/com/salesforce/dataloader/client/ReferenceEntitiesDescribeMap.java
+++ b/src/main/java/com/salesforce/dataloader/client/ReferenceEntitiesDescribeMap.java
@@ -45,12 +45,12 @@ public class ReferenceEntitiesDescribeMap {
 
     private Map<String, DescribeRefObject> referenceEntitiesDescribeMap = new HashMap<String, DescribeRefObject>();
     private static final Logger logger = LogManager.getLogger(ReferenceEntitiesDescribeMap.class);
-
+    private PartnerClient client = null;
     /**
      * 
      */
-    public ReferenceEntitiesDescribeMap() {
-        
+    public ReferenceEntitiesDescribeMap(PartnerClient client) {
+        this.client = client;
     }
     
     public void put(String relationshipFieldName, DescribeRefObject parent) {
@@ -122,12 +122,21 @@ public class ReferenceEntitiesDescribeMap {
         return null;
     }
  
-    private DescribeRefObject getParentSObject(ParentSObjectFormatter parentStr) {
-        if (parentStr == null || parentStr.getRelationshipName() == null) {
+    private DescribeRefObject getParentSObject(ParentSObjectFormatter parentFormatter) {
+        if (parentFormatter == null || parentFormatter.getRelationshipName() == null) {
             return null;
         }
+        String parentObjName = parentFormatter.getParentObjectName();
+        if (parentObjName == null) {
+            Field relationshipField = client.getFieldFromRelationshipName(parentFormatter.getRelationshipName());
+            if (relationshipField == null) {
+                return null;
+            }
+            parentObjName = relationshipField.getReferenceTo()[0];
+            parentFormatter.setParentObjectName(parentObjName);
+        }
         for (Map.Entry<String, DescribeRefObject> ent : referenceEntitiesDescribeMap.entrySet()) {
-            if (parentStr.matches(ent.getKey())) {
+            if (parentFormatter.matches(ent.getKey())) {
                 return ent.getValue();
             }
         }

--- a/src/main/java/com/salesforce/dataloader/dyna/ParentSObjectFormatter.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/ParentSObjectFormatter.java
@@ -76,6 +76,10 @@ public class ParentSObjectFormatter {
         }
         initialize(parentObjectName, relationshipName);
     }
+    
+    public void setParentObjectName(String name) {
+        this.parentObjectName = name;
+    }
 
     private void initialize(String parentObjectName, String relationshipName) throws RelationshipFormatException{
         if ((relationshipName == null || relationshipName.isBlank())) {

--- a/src/main/java/com/salesforce/dataloader/dyna/SforceDynaBean.java
+++ b/src/main/java/com/salesforce/dataloader/dyna/SforceDynaBean.java
@@ -233,8 +233,12 @@ public class SforceDynaBean {
             //This does an automatic conversion of types.
             BeanUtils.copyProperties(sforceObj, sforceDataRow);
             for (String sforceField : sforceDataRow.keySet()) {
-                if (sforceObj.get(sforceField) == null) {
-                    String errStr = "unable to convert " + sforceField + " to a field on entity " + Config.getCurrentConfig().getString(Config.ENTITY);
+                Object val = sforceDataRow.get(sforceField);
+                if (val != null
+                        && val instanceof String
+                        && !((String)val).isBlank()
+                        && sforceObj.get(sforceField) == null) {
+                    String errStr = "unable to convert a non-null " + sforceField + "value " + (String)val + " to a field on entity " + Config.getCurrentConfig().getString(Config.ENTITY);
                     logger.error(errStr); //$NON-NLS-1$
                     throw new LoadException(errStr);
                 }

--- a/src/main/java/com/salesforce/dataloader/mapping/CaseInsensitiveSet.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/CaseInsensitiveSet.java
@@ -29,7 +29,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class CaseInsensitiveSet {
-    private final CaseInsensitiveMap originalMap = new CaseInsensitiveMap();
+    private final CaseInsensitiveStringMap originalMap = new CaseInsensitiveStringMap();
 
     public CaseInsensitiveSet(){
     }

--- a/src/main/java/com/salesforce/dataloader/mapping/CaseInsensitiveStringMap.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/CaseInsensitiveStringMap.java
@@ -28,7 +28,7 @@ package com.salesforce.dataloader.mapping;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 
-public class CaseInsensitiveMap extends LinkedHashMap<String, String> {
+public class CaseInsensitiveStringMap extends LinkedHashMap<String, String> {
     /**
      * 
      */

--- a/src/main/java/com/salesforce/dataloader/mapping/LoadMapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/LoadMapper.java
@@ -70,7 +70,7 @@ public class LoadMapper extends Mapper {
     }
 
     public Map<String, String> getMappingWithUnmappedColumns(boolean includeUnmapped) {
-        final CaseInsensitiveMap result = new CaseInsensitiveMap();
+        final CaseInsensitiveStringMap result = new CaseInsensitiveStringMap();
         Set<String> candidateCols = null;
         if (getCompositeDAOColumns() == null || getCompositeDAOColumns().isEmpty()) {
             // no compositions yet

--- a/src/main/java/com/salesforce/dataloader/mapping/SOQLMapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/SOQLMapper.java
@@ -87,7 +87,7 @@ public class SOQLMapper extends Mapper {
     private static final Logger logger = LogManager.getLogger(SOQLMapper.class);
 
     private SOQLInfo soqlInfo;
-    private CaseInsensitiveMap extractionMap = new CaseInsensitiveMap();
+    private CaseInsensitiveStringMap extractionMap = new CaseInsensitiveStringMap();
     private boolean isInitialized = false;
 
     public SOQLMapper(PartnerClient client, Collection<String> columnNames, Field[] fields, String mappingFileName)

--- a/src/main/java/com/salesforce/dataloader/model/Row.java
+++ b/src/main/java/com/salesforce/dataloader/model/Row.java
@@ -27,6 +27,7 @@ package com.salesforce.dataloader.model;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -44,6 +45,7 @@ public class Row implements Map<String, Object> {
 
     private static final int DEFAULT_COLUMN_COUNT = 16; // same as HashMap
     private final Map<String, Object> internalMap;
+    private final Map<String, String> keyMap = new HashMap<String, String>();
 
     public Row() {
         this(DEFAULT_COLUMN_COUNT);
@@ -56,6 +58,9 @@ public class Row implements Map<String, Object> {
     public Row(Map<String, Object> internalMap) {
         this(internalMap.size());
         this.internalMap.putAll(internalMap);
+        for (String key : internalMap.keySet()) {
+            this.keyMap.put(key.toLowerCase(), key);
+        }
     }
 
     public static Row emptyRow() {
@@ -78,7 +83,11 @@ public class Row implements Map<String, Object> {
 
     @Override
     public boolean containsKey(Object key) {
-        return internalMap.containsKey(key);
+        String realKey = this.keyMap.get(((String)key).toLowerCase());
+        if (realKey == null) {
+            return false;
+        }
+        return internalMap.containsKey(realKey);
     }
 
     @Override
@@ -88,26 +97,36 @@ public class Row implements Map<String, Object> {
 
     @Override
     public Object get(Object key) {
-        return internalMap.get(key);
+        String realKey = this.keyMap.get(((String)key).toLowerCase());
+        if (realKey == null) {
+            return null;
+        }
+        return internalMap.get(realKey);
     }
 
     @Override
     public Object put(String key, Object value) {
+        this.keyMap.put(key.toLowerCase(), key);
         return internalMap.put(key, value);
     }
 
     @Override
     public Object remove(Object key) {
+        this.keyMap.remove(((String)key).toLowerCase());
         return internalMap.remove(key);
     }
 
     @Override
     public void putAll(Map<? extends String, ?> m) {
+        for (String key : m.keySet()) {
+            this.keyMap.put(key.toLowerCase(), key);
+        }
         internalMap.putAll(m);
     }
 
     @Override
     public void clear() {
+        this.keyMap.clear();
         internalMap.clear();
     }
 

--- a/src/test/resources/testfiles/data/updateAccountWithExternalIdCsvMap.sdl
+++ b/src/test/resources/testfiles/data/updateAccountWithExternalIdCsvMap.sdl
@@ -7,4 +7,4 @@ TYPE=Type
 ANNUALREVENUE=AnnualRevenue
 PHONE=Phone
 ORACLE_ID__C=Oracle_Id__c
-OWNER\:User-username=Owner\:User-Username
+OWNER\:User-username=owner\:user-username


### PR DESCRIPTION
Field names, relationship names, parent sobject names, and parent sobject idlookup field names in mappings file are case sensitive. The change is to make them case insensitive for ease-of-use in setting up mappings.