### PR TITLE
support territory assignment rules in bulk v2 upload ops

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/bulk/BulkV2Connection.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/bulk/BulkV2Connection.java
@@ -379,6 +379,13 @@ public class BulkV2Connection extends BulkConnection {
         	if (operation.equals(OperationEnum.upsert)) {
         	    requestBodyMap.put("externalIdFieldName", job.getExternalIdFieldName());
         	}
+        	if (operation.equals(OperationEnum.upsert)
+        	   || operation.equals(OperationEnum.insert)
+        	   || operation.equals(OperationEnum.update)) {
+        	    if (job.getAssignmentRuleId() != null && !job.getAssignmentRuleId().isBlank()) {
+        	        requestBodyMap.put("assignmentRuleId", job.getAssignmentRuleId());
+        	    }
+        	}
         }
         return doSendJobRequestToServer(urlString, 
 										headers,


### PR DESCRIPTION
support territory assignment rules in bulk v2 upload ops (insert, update, upsert).