### PR TITLE
Fix for OAuth regression introduced in PR #1247

### DIFF
--- a/src/main/java/com/salesforce/dataloader/oauth/OAuthFlowUtil.java
+++ b/src/main/java/com/salesforce/dataloader/oauth/OAuthFlowUtil.java
@@ -90,7 +90,7 @@ public class OAuthFlowUtil {
                 }
             }
 
-
+            config.setAuthEndpoint(token.getInstanceUrl());
             config.setValue(Config.OAUTH_ACCESSTOKEN, token.getAccessToken());
             config.setValue(Config.OAUTH_REFRESHTOKEN, token.getRefreshToken());
             config.setValue(Config.OAUTH_INSTANCE_URL, token.getInstanceUrl());

--- a/src/main/java/com/salesforce/dataloader/util/OAuthBrowserLoginRunner.java
+++ b/src/main/java/com/salesforce/dataloader/util/OAuthBrowserLoginRunner.java
@@ -333,6 +333,7 @@ public class OAuthBrowserLoginRunner {
                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                .create();
        OAuthToken token = gson.fromJson(jsonTokenResult, OAuthToken.class);
+       config.setAuthEndpoint(token.getInstanceUrl());
        config.setValue(Config.OAUTH_ACCESSTOKEN, token.getAccessToken());
        config.setValue(Config.OAUTH_REFRESHTOKEN, token.getRefreshToken());
        config.setValue(Config.OAUTH_INSTANCE_URL, token.getInstanceUrl());

--- a/src/test/java/com/salesforce/dataloader/oauth/OAuthFlowUtilTests.java
+++ b/src/test/java/com/salesforce/dataloader/oauth/OAuthFlowUtilTests.java
@@ -97,7 +97,7 @@ public class OAuthFlowUtilTests extends ConfigTestBase {
     @Test
     public void testValidResponseUrl(){
         try {
-            Boolean condition = OAuthFlowUtil.handleCompletedUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN", config);
+            Boolean condition = OAuthFlowUtil.handleCompletedUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN&instance_url=https://INSTANCEURL", config);
             Assert.assertTrue("OAuthToken should have handled this", condition);
 
         } catch (URISyntaxException e) {
@@ -108,7 +108,7 @@ public class OAuthFlowUtilTests extends ConfigTestBase {
     @Test
     public void testValidResponseUrlSetsAccessToken(){
         try {
-            OAuthFlowUtil.handleCompletedUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN", config);
+            OAuthFlowUtil.handleCompletedUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN&instance_url=https://INSTANCEURL", config);
             String expected = "TOKEN";
             String actual = config.getString(Config.OAUTH_ACCESSTOKEN);
 
@@ -121,7 +121,7 @@ public class OAuthFlowUtilTests extends ConfigTestBase {
     @Test
     public void testValidResponseUrlSetsRefreshToken(){
         try {
-            OAuthFlowUtil.handleCompletedUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN&refresh_token=REFRESHTOKEN", config);
+            OAuthFlowUtil.handleCompletedUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN&refresh_token=REFRESHTOKEN&instance_url=https://INSTANCEURL", config);
             String expected = "REFRESHTOKEN";
             String actual = config.getString(Config.OAUTH_REFRESHTOKEN);
 
@@ -134,8 +134,8 @@ public class OAuthFlowUtilTests extends ConfigTestBase {
     @Test
     public void testValidResponseUrlSetsEndPoint(){
         try {
-            OAuthFlowUtil.handleCompletedUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN&instance_url=INSTANCEURL", config);
-            String expected = "INSTANCEURL";
+            OAuthFlowUtil.handleCompletedUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize#access_token=TOKEN&instance_url=https://INSTANCEURL", config);
+            String expected = "https://INSTANCEURL";
             String actual = config.getString(Config.OAUTH_INSTANCE_URL);
 
             Assert.assertEquals("Incorrect refresh token found in config", expected, actual);

--- a/src/test/java/com/salesforce/dataloader/oauth/OAuthSecretFlowUtilTests.java
+++ b/src/test/java/com/salesforce/dataloader/oauth/OAuthSecretFlowUtilTests.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.*;
 
 import java.io.*;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.function.Function;
@@ -69,7 +70,7 @@ public class OAuthSecretFlowUtilTests extends ConfigTestBase {
         existingEndPoint = config.getAuthEndpoint();
         oauthServer = "https://OAUTH_PARTIAL_SERVER";
         oauthClientId = "CLIENTID";
-        oauthRedirectUri = "REDIRECTURI";
+        oauthRedirectUri = "https://REDIRECTURI";
         mockSimplePost = mock(SimplePost.class);
 
         config.setValue(Config.AUTH_ENVIRONMENTS, "Testing");
@@ -92,7 +93,8 @@ public class OAuthSecretFlowUtilTests extends ConfigTestBase {
     @Test
     public void testGetStartUrl(){
         try {
-            String expected = "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize?response_type=code&display=popup&client_id=CLIENTID&redirect_uri=REDIRECTURI";
+            String expected = "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize?response_type=code&display=popup&client_id=CLIENTID"
+                    + "&" + "redirect_uri=" + URLEncoder.encode("https://REDIRECTURI",  StandardCharsets.UTF_8.name());
             String actual = OAuthSecretFlowUtil.getStartUrlImpl(config);
 
             Assert.assertEquals( "OAuth Token Flow returned the wrong url", expected, actual);
@@ -117,7 +119,7 @@ public class OAuthSecretFlowUtilTests extends ConfigTestBase {
     public void testValidInitialResponseUrl(){
         try {
             String expected = "TOKEN";
-            String actual = OAuthSecretFlowUtil.handleInitialUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize?code=TOKEN");
+            String actual = OAuthSecretFlowUtil.handleInitialUrl( "https://OAUTH_PARTIAL_SERVER/services/oauth2/authorize?code=TOKEN&instance_url=https://INSTANCEURL");
             Assert.assertEquals("OAuthToken should not have handled this", expected, actual);
 
         } catch (URISyntaxException e) {
@@ -134,6 +136,7 @@ public class OAuthSecretFlowUtilTests extends ConfigTestBase {
                     .create();
             OAuthToken token = new OAuthToken();
             token.setAccessToken("ACCESS");
+            token.setInstanceUrl("https://INSTANCEURL");
             String jsonToken = gson.toJson(token);
             InputStream input = new ByteArrayInputStream(jsonToken.getBytes(StandardCharsets.UTF_8));
             when(mockSimplePost.getInput()).thenAnswer(i -> input);
@@ -162,6 +165,7 @@ public class OAuthSecretFlowUtilTests extends ConfigTestBase {
                     .create();
             OAuthToken token = new OAuthToken();
             token.setRefreshToken("REFRESHTOKEN");
+            token.setInstanceUrl("https://INSTANCEURL");
             String jsonToken = gson.toJson(token);
             InputStream input = new ByteArrayInputStream(jsonToken.getBytes(StandardCharsets.UTF_8));
             when(mockSimplePost.getInput()).thenAnswer(i -> input);


### PR DESCRIPTION
Bulk v1 operations return error: "Destination URL not reset. The URL returned from login must be set" due to a bug introduced in PR #1247.

Fixed it by calling config.setAuthEndpoint(token.getInstanceUrl()) that was removed in PR #1247.