### PR TITLE
refactor of DefaultSimplePost

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/bulk/BulkV2Connection.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/bulk/BulkV2Connection.java
@@ -284,7 +284,7 @@ public class BulkV2Connection extends BulkConnection {
         HashMap<String, String> headers = getHeaders(CSV_CONTENT_TYPE, JSON_CONTENT_TYPE);
         try {
         	HttpTransportInterface transport = (HttpTransportInterface)getConfig().createTransport();
-            transport.connect(urlString, headers, true, HttpTransportInterface.SupportedHttpMethodType.PUT, bulkUploadStream, CSV_CONTENT_TYPE);
+            transport.connect(urlString, headers, false, HttpTransportInterface.SupportedHttpMethodType.PUT, bulkUploadStream, CSV_CONTENT_TYPE);
 
             // Following is needed to actually send the request to the server
             InputStream serverResponseStream = transport.getContent();

--- a/src/main/java/com/salesforce/dataloader/client/DefaultSimplePost.java
+++ b/src/main/java/com/salesforce/dataloader/client/DefaultSimplePost.java
@@ -28,29 +28,13 @@ package com.salesforce.dataloader.client;
 
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.exception.ParameterLoadException;
-import com.sforce.ws.tools.VersionInfo;
-
-import org.apache.commons.io.IOUtils;
+import com.salesforce.dataloader.util.AppUtil;
+import com.sforce.ws.ConnectorConfig;
 import org.apache.http.Header;
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.Credentials;
-import org.apache.http.auth.NTCredentials;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.*;
 import org.apache.http.message.BasicNameValuePair;
 
 import java.io.*;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.util.Arrays;
-import java.util.zip.GZIPInputStream;
 
 /**
  * simplied http client transport for posts (used for oauth)
@@ -85,70 +69,11 @@ public class DefaultSimplePost implements SimplePost {
 
     @Override
     public void post() throws IOException, ParameterLoadException {
-        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-        HttpPost post = new HttpPost(endpoint);
-        UrlEncodedFormEntity entity = new UrlEncodedFormEntity(Arrays.asList(pairs));
-
-        int proxyPort = config.getInt(Config.PROXY_PORT);
-        String proxyHostName = config.getString(Config.PROXY_HOST);
-        String proxyUser = config.getString(Config.PROXY_USERNAME);
-        String proxyPassword = config.getString(Config.PROXY_PASSWORD);
-        String ntlmDomain = config.getString(Config.PROXY_NTLM_DOMAIN);
-        proxyHostName = proxyHostName != null ? proxyHostName.trim() : "";
-        proxyUser = proxyUser != null ? proxyUser.trim() : "";
-        proxyPassword = proxyPassword != null ? proxyPassword.trim() : "";
-        ntlmDomain = ntlmDomain != null ? ntlmDomain.trim() : "";
-
-        post.addHeader("User-Agent", VersionInfo.info());
-        post.setEntity(entity);
-
-        //proxy
-        if (proxyHostName.length() > 0) {
-            InetSocketAddress proxyAddress = new InetSocketAddress(proxyHostName, proxyPort);
-            HttpHost proxyHost = new HttpHost(proxyAddress.getHostName(), proxyAddress.getPort(), "http");
-            AuthScope scope = new AuthScope(proxyAddress.getHostName(), proxyAddress.getPort(), null, null);
-            Credentials credentials = new UsernamePasswordCredentials(proxyUser, proxyPassword);
-
-            if (ntlmDomain.length() > 0) {
-                credentials = new NTCredentials(proxyUser, proxyPassword, InetAddress.getLocalHost().getCanonicalHostName(), ntlmDomain);
-            }
-
-            RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
-            requestConfigBuilder.setProxy(proxyHost);
-            post.setConfig(requestConfigBuilder.build());
-
-            CredentialsProvider credentialsprovider = new BasicCredentialsProvider();
-            credentialsprovider.setCredentials(scope, credentials);
-            httpClientBuilder.setDefaultCredentialsProvider(credentialsprovider).build();
-        }
-
-        try (CloseableHttpClient httpClient = httpClientBuilder.build()) {
-
-            if (ntlmDomain.length() > 0) {
-                // need to send a HEAD request to trigger NTLM authentication
-                HttpHead head = new HttpHead("http://salesforce.com");
-                try (CloseableHttpResponse ignored = httpClient.execute(head)) {
-                }
-            }
-            try (CloseableHttpResponse postResponse = httpClient.execute(post)) {
-
-                successful = postResponse.getStatusLine().getStatusCode() < 400;
-                statusCode = postResponse.getStatusLine().getStatusCode();
-                reasonPhrase = postResponse.getStatusLine().getReasonPhrase();
-                response = postResponse;
-
-                // copy input stream data into a new input stream because releasing the connection will close the input stream
-                ByteArrayOutputStream bOut = new ByteArrayOutputStream();
-                try (InputStream inStream = response.getEntity().getContent()) {
-                    IOUtils.copy(inStream, bOut);
-                    input = new ByteArrayInputStream(bOut.toByteArray());
-                    if (response.containsHeader("Content-Encoding") && response.getHeaders("Content-Encoding")[0].getValue().equals("gzip")) {
-                        input = new GZIPInputStream(input);
-                    }
-                }
-
-            }
-        }
+        ConnectorConfig connConfig = new ConnectorConfig();
+        AppUtil.setConnectorConfigProxySettings(config, connConfig);
+        HttpClientTransport clientTransport = new HttpClientTransport(connConfig);
+        this.input = clientTransport.simplePost(endpoint, null, pairs);
+        successful = clientTransport.isSuccessful();
     }
 
     @Override


### PR DESCRIPTION
DefaultSimplePost duplicates the functionality provided by HttpClientTransport. Refactor the code so that DefaultSimplePost leverages HttpClientTransport methods instead of duplicating.