### PR TITLE
HttpClientTransport optimizations

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/visitor/AbstractQueryVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/AbstractQueryVisitor.java
@@ -28,6 +28,7 @@ package com.salesforce.dataloader.action.visitor;
 
 import com.salesforce.dataloader.action.AbstractExtractAction;
 import com.salesforce.dataloader.action.progress.ILoaderProgress;
+import com.salesforce.dataloader.client.HttpClientTransport;
 import com.salesforce.dataloader.client.HttpTransportInterface;
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.config.Messages;
@@ -206,7 +207,8 @@ public abstract class AbstractQueryVisitor extends AbstractVisitor implements IQ
                     + "/"
                     + refId;
             
-            HttpTransportInterface transport = (HttpTransportInterface) controller.getClient().getConnectorConfig().createTransport();
+            HttpClientTransport transport = HttpClientTransport.getInstance();
+            transport.setConfig(controller.getClient().getConnectorConfig());
             InputStream is = transport.httpGet(urlStr);
             byte[] binaryResponse = is.readAllBytes();
             return Base64.getEncoder().encodeToString(binaryResponse);

--- a/src/main/java/com/salesforce/dataloader/action/visitor/bulk/BulkV1Connection.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/bulk/BulkV1Connection.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.salesforce.dataloader.client.ClientBase;
+import com.salesforce.dataloader.client.HttpClientTransport;
 import com.salesforce.dataloader.client.HttpTransportInterface;
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.exception.HttpClientTransportException;
@@ -136,10 +137,10 @@ public class BulkV1Connection extends BulkConnection {
             }
         }
         try {
-            HttpTransportInterface transport = (HttpTransportInterface) getConfig().createTransport();
+            HttpTransportInterface transport = HttpClientTransport.getInstance();
+            transport.setConfig(getConfig());
             return transport.httpGet(endpoint);
-
-        } catch (IOException | HttpClientTransportException | ConnectionException e) {
+        } catch (IOException | HttpClientTransportException e) {
             logger.error(e.getMessage());
             throw new AsyncApiException("Failed to get result ", AsyncExceptionCode.ClientInputError, e);
         }

--- a/src/main/java/com/salesforce/dataloader/action/visitor/rest/RESTConnection.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/rest/RESTConnection.java
@@ -110,8 +110,9 @@ public class RESTConnection {
                 logger.error(message);
                 throw new ConnectionException(message);
             }
-            HttpClientTransport transport = new HttpClientTransport(this.connectorConfig);
-    
+            HttpClientTransport transport = HttpClientTransport.getInstance();
+            transport.setConfig(connectorConfig);
+            
             // assume update operation by default and set http method value to PATCH
             HttpTransportInterface.SupportedHttpMethodType httpMethod = HttpTransportInterface.SupportedHttpMethodType.PATCH;
             if (action == ACTION_ENUM.DELETE) {

--- a/src/main/java/com/salesforce/dataloader/client/ClientBase.java
+++ b/src/main/java/com/salesforce/dataloader/client/ClientBase.java
@@ -113,7 +113,7 @@ public abstract class ClientBase<ConnectionType> {
 
     public ConnectorConfig getConnectorConfig() {
         ConnectorConfig cc = new ConnectorConfig();
-        cc.setTransport(HttpClientTransport.class);
+        cc.setTransportFactory(new TransportFactoryImpl());
         cc.setSessionId(getSessionId());
         cc.setRequestHeader(SFORCE_CALL_OPTIONS_HEADER,
                 "client=" + ClientBase.getClientName(this.config));      

--- a/src/main/java/com/salesforce/dataloader/client/DefaultSimplePost.java
+++ b/src/main/java/com/salesforce/dataloader/client/DefaultSimplePost.java
@@ -71,7 +71,8 @@ public class DefaultSimplePost implements SimplePost {
     public void post() throws IOException, ParameterLoadException {
         ConnectorConfig connConfig = new ConnectorConfig();
         AppUtil.setConnectorConfigProxySettings(config, connConfig);
-        HttpClientTransport clientTransport = new HttpClientTransport(connConfig);
+        HttpClientTransport clientTransport = HttpClientTransport.getInstance();
+        clientTransport.setConfig(connConfig);
         this.input = clientTransport.simplePost(endpoint, null, pairs);
         successful = clientTransport.isSuccessful();
     }

--- a/src/main/java/com/salesforce/dataloader/client/TransportFactoryImpl.java
+++ b/src/main/java/com/salesforce/dataloader/client/TransportFactoryImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *    Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ *    the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ *    Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ *    promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.dataloader.client;
+
+import com.sforce.ws.transport.Transport;
+import com.sforce.ws.transport.TransportFactory;
+
+public class TransportFactoryImpl implements TransportFactory {
+
+    public TransportFactoryImpl() {
+    }
+
+    @Override
+    public Transport createTransport() {
+        return HttpClientTransport.getInstance();
+    }
+
+}

--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -35,6 +35,7 @@ import com.salesforce.dataloader.client.HttpClientTransport;
 import com.salesforce.dataloader.client.PartnerClient;
 import com.salesforce.dataloader.client.CompositeRESTClient;
 import com.salesforce.dataloader.client.ReferenceEntitiesDescribeMap;
+import com.salesforce.dataloader.client.TransportFactoryImpl;
 import com.salesforce.dataloader.config.Config;
 import com.salesforce.dataloader.config.Messages;
 import com.salesforce.dataloader.dao.DataAccessObject;
@@ -150,7 +151,8 @@ public class Controller {
         try {
             ConnectorConfig connConfig = new ConnectorConfig();
             AppUtil.setConnectorConfigProxySettings(config, connConfig);
-            HttpClientTransport clientTransport = new HttpClientTransport(connConfig);
+            HttpClientTransport clientTransport = HttpClientTransport.getInstance();
+            clientTransport.setConfig(connConfig);
             InputStream inputStream = clientTransport.httpGet(AppUtil.DATALOADER_DOWNLOAD_URL);
 
             String responseContent = new String(inputStream.readAllBytes());            


### PR DESCRIPTION
- Use a singleton HttpClientTransport object
- Make sure that all server calls go through HttpClientTransport
- Make sure that HttpClientTransport does not close HttpClient connection if caching is enabled
- Do more extensive equality check for ConnectorConfig instances in HttpClientTransport before deciding whether to close existing HttpClient and open a new one