### PR TITLE
read-only property sfdc.useSysPropsForHttpClient

### DIFF
--- a/src/main/java/com/salesforce/dataloader/client/HttpClientTransport.java
+++ b/src/main/java/com/salesforce/dataloader/client/HttpClientTransport.java
@@ -170,7 +170,10 @@ public class HttpClientTransport implements HttpTransportInterface {
     private synchronized void initializeHttpClient() throws UnknownHostException {
         closeHttpClient();
         httpMethod = null;
-        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create().useSystemProperties();
+        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+        if (Config.getCurrentConfig().getBoolean(Config.USE_SYSTEM_PROPS_FOR_HTTP_CLIENT)) {
+            httpClientBuilder = httpClientBuilder.useSystemProperties();
+        }
         
         if (currentConnectorConfig != null
                 && currentConnectorConfig.getProxy() != null

--- a/src/main/java/com/salesforce/dataloader/config/Config.java
+++ b/src/main/java/com/salesforce/dataloader/config/Config.java
@@ -337,6 +337,7 @@ public class Config {
     public static final String API_VERSION_PROP="salesforce.api.version";
     public static final String OAUTH_INSTANCE_URL="salesforce.oauth.instanceURL";
     public static final String USE_LEGACY_HTTP_GET="sfdc.useLegacyHttpGet";
+    public static final String USE_SYSTEM_PROPS_FOR_HTTP_CLIENT="sfdc.useSysPropsForHttpClient";
     /**
      *  ===============  PILOT config properties ========
      * - These properties are used for the features in pilot phase. These features are
@@ -486,6 +487,7 @@ public class Config {
             OAUTH_PREFIX + SB_ENVIRONMENT_VAL + "." + OAUTH_PARTIAL_CLIENTSECRET,
             RESET_URL_ON_LOGIN,
             USE_LEGACY_HTTP_GET,
+            USE_SYSTEM_PROPS_FOR_HTTP_CLIENT,
     };
     
     private static final String[] ENCRYPTED_PROPERTY_NAMES = {
@@ -675,6 +677,7 @@ public class Config {
             setDefaultValue(PROXY_PORT, proxyPort);
         }
         setDefaultValue(USE_LEGACY_HTTP_GET, false);
+        setDefaultValue(USE_SYSTEM_PROPS_FOR_HTTP_CLIENT, true);
     }
 
     /**


### PR DESCRIPTION
introduce read-only property, sfdc.useSysPropsForHttpClient, set to true by default, to address issues such as issue #1265 .