### PR TITLE
Config properties cleanup

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/AppConfig.java
+++ b/src/main/java/com/salesforce/dataloader/config/AppConfig.java
@@ -226,7 +226,6 @@ public class AppConfig {
     // salesforce client connectivity
     public static final String USERNAME = "sfdc.username"; //$NON-NLS-1$
     public static final String PASSWORD = "sfdc.password"; //$NON-NLS-1$
-    public static final String AUTH_ENDPOINT = "sfdc.endpoint"; //$NON-NLS-1$
     public static final String AUTH_ENDPOINT_PROD = "sfdc.endpoint.production"; //$NON-NLS-1$
     public static final String AUTH_ENDPOINT_SANDBOX = "sfdc.endpoint.sandbox"; //$NON-NLS-1$
     public static final String PROXY_HOST = "sfdc.proxyHost"; //$NON-NLS-1$
@@ -531,11 +530,6 @@ public class AppConfig {
         
         // Properties initialization completed. Configure OAuth environment next
         setOAuthEnvironment(getString(SELECTED_AUTH_ENVIRONMENT));
-        String endpoint_prod = getString(AppConfig.AUTH_ENDPOINT_PROD);
-        if (AppConfig.DEFAULT_ENDPOINT_URL_PROD.equalsIgnoreCase(endpoint_prod)) {
-            endpoint_prod = getString(AppConfig.AUTH_ENDPOINT);
-            setValue(AUTH_ENDPOINT_PROD, endpoint_prod);
-        }
     }
     
     private String getLastRunPrefix() {
@@ -588,8 +582,7 @@ public class AppConfig {
         setDefaultValue(CSV_DELIMITER_OTHER_VALUE, "");
         setDefaultValue(CSV_DELIMITER_FOR_QUERY_RESULTS, AppUtil.COMMA);
 
-        setDefaultValue(AUTH_ENDPOINT, DEFAULT_ENDPOINT_URL_PROD);
-        setDefaultValue(AUTH_ENDPOINT_PROD, getString(AUTH_ENDPOINT));
+        setDefaultValue(AUTH_ENDPOINT_PROD, DEFAULT_ENDPOINT_URL_PROD);
         setDefaultValue(AUTH_ENDPOINT_SANDBOX, DEFAULT_ENDPOINT_URL_SANDBOX);
 
         setDefaultValue(IMPORT_BATCH_SIZE, useBulkApiByDefault() ? DEFAULT_BULK_API_IMPORT_BATCH_SIZE : DEFAULT_LOAD_BATCH_SIZE);
@@ -1255,7 +1248,7 @@ public class AppConfig {
     
     public void setAuthEndpointForEnv(String authEndpoint, String env) {
         AppUtil.validateAuthenticationHostDomainUrlAndThrow(authEndpoint);
-        if (env != null && env.equalsIgnoreCase(getString(AppConfig.SB_ENVIRONMENT_VAL))) {
+        if (env != null && env.equalsIgnoreCase(AppConfig.SB_ENVIRONMENT_VAL)) {
             this.setValue(AppConfig.AUTH_ENDPOINT_SANDBOX, authEndpoint);
         } else {
             this.setValue(AppConfig.AUTH_ENDPOINT_PROD, authEndpoint);

--- a/src/main/java/com/salesforce/dataloader/config/AppConfig.java
+++ b/src/main/java/com/salesforce/dataloader/config/AppConfig.java
@@ -568,7 +568,7 @@ public class AppConfig {
         } catch (IOException e) {
             logger.warn(Messages.getFormattedString("LastRun.errorLoading", new String[]{
                     this.lastRunProperties.getFullPath(), e.getMessage()}), e);
-        }        
+        }
     }
 
     private boolean useBulkApiByDefault() {
@@ -585,7 +585,7 @@ public class AppConfig {
         setDefaultValue(CSV_DELIMITER_COMMA, true);
         setDefaultValue(CSV_DELIMITER_TAB, true);
         setDefaultValue(CSV_DELIMITER_OTHER, false);
-        setDefaultValue(CSV_DELIMITER_OTHER_VALUE, "-");
+        setDefaultValue(CSV_DELIMITER_OTHER_VALUE, "");
         setDefaultValue(CSV_DELIMITER_FOR_QUERY_RESULTS, AppUtil.COMMA);
 
         setDefaultValue(AUTH_ENDPOINT, DEFAULT_ENDPOINT_URL_PROD);
@@ -636,6 +636,7 @@ public class AppConfig {
         setDefaultValue(OAUTH_PREFIX + SB_ENVIRONMENT_VAL + "." + OAUTH_PARTIAL_BULK_CLIENTID, OAUTH_BULK_CLIENTID_VAL);
         setDefaultValue(OAUTH_PREFIX + SB_ENVIRONMENT_VAL + "." + OAUTH_PARTIAL_PARTNER_CLIENTID, OAUTH_PARTNER_CLIENTID_VAL);
 
+        setDefaultValue(OPERATION, "insert");
         setDefaultValue(REUSE_CLIENT_CONNECTION, true);
         /*
         setDefaultValue(ENABLE_BULK_QUERY_PK_CHUNKING, false);
@@ -1195,21 +1196,8 @@ public class AppConfig {
         Properties inMemoryProperties = new LinkedProperties();
         inMemoryProperties.putAll(this.loadedProperties);
         
-        // do not save properties set through parameter overrides
-        if (this.parameterOverridesMap != null) {
-            for (String propertyName : this.parameterOverridesMap.keySet()) {
-                this.loadedProperties.remove(propertyName);
-            }
-        }
-        
-        // do not save read-only properties that were not specified
-        // in properties file
-        for (String roprop : READ_ONLY_PROPERTY_NAMES) {
-            if (!this.readOnlyPropertiesFromPropertiesFile.containsKey(roprop)) {
-                this.loadedProperties.remove(roprop);
-            }
-        }
-        
+        // property additions section - all property additions occur before removals
+        // add encrypted property name, value pairs for saving
         for (String encryptedProp : ENCRYPTED_PROPERTY_NAMES) {
             if (this.loadedProperties.containsKey(encryptedProp)) {
                 Map<?, ?> propMap = (Map<?, ?>)this.loadedProperties;
@@ -1224,7 +1212,23 @@ public class AppConfig {
                 }
             }
         }
+
+        // property removals section - all property additions occur before this
+
+        // do not save properties set through parameter overrides
+        if (this.parameterOverridesMap != null) {
+            for (String propertyName : this.parameterOverridesMap.keySet()) {
+                this.loadedProperties.remove(propertyName);
+            }
+        }
         
+        // do not save read-only properties that were not specified
+        // in properties file
+        for (String roprop : READ_ONLY_PROPERTY_NAMES) {
+            if (!this.readOnlyPropertiesFromPropertiesFile.containsKey(roprop)) {
+                this.loadedProperties.remove(roprop);
+            }
+        }        
         removeUnsupportedProperties();
         removeDecryptedProperties();
         removeCLIOptionsFromProperties();
@@ -1233,7 +1237,7 @@ public class AppConfig {
         FileOutputStream out = null;
         try {
             out = new FileOutputStream(filename);
-            save(out, "Loader Config"); //$NON-NLS-1$
+            save(out, "Salesforce Data Loader Config"); //$NON-NLS-1$
         } finally {
             if (out != null) {
                 out.close();


### PR DESCRIPTION
- set the default for "process.operation" in code to "insert".
- add all properties to consider for saving to properties file before removing specific ones that should not be saved.