### PR TITLE
use property getters consistently

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/AppConfig.java
+++ b/src/main/java/com/salesforce/dataloader/config/AppConfig.java
@@ -1856,7 +1856,6 @@ public class AppConfig {
         Map<String, String> argsMap = AppUtil.convertCommandArgsArrayToArgMap(args);
         AppConfig.setConfigurationsDir(argsMap);
         LoggingUtil.initializeLog(argsMap);
-        AppUtil.setUseGMTForDateFieldValue(argsMap);
         return AppUtil.convertCommandArgsMapToArgsArray(argsMap);
     }
 

--- a/src/main/java/com/salesforce/dataloader/util/AppUtil.java
+++ b/src/main/java/com/salesforce/dataloader/util/AppUtil.java
@@ -239,25 +239,9 @@ public class AppUtil {
     public static APP_RUN_MODE getAppRunMode() {
         return appRunMode;
     }
-
-    public static void setUseGMTForDateFieldValue(Map<String, String> argMap) {
-        if (argMap.containsKey(AppConfig.PROP_GMT_FOR_DATE_FIELD_VALUE)) {
-            if ("true".equalsIgnoreCase(argMap.get(AppConfig.PROP_GMT_FOR_DATE_FIELD_VALUE))) {
-                useGMTForDateFieldValue = true;
-            }
-        }
-    }
-    
-    public static void setUseGMTForDateFieldValue(boolean val) {
-        useGMTForDateFieldValue = val;
-    }
     
     public static boolean isContentSObject(String sObjectName) {
         return CONTENT_SOBJECT_LIST.contains(sObjectName.toLowerCase());
-    }
-    private static boolean useGMTForDateFieldValue;
-    public static boolean isUseGMTForDateFieldValue() {
-        return useGMTForDateFieldValue;
     }
     
     public static void showBanner() {

--- a/src/main/java/com/salesforce/dataloader/util/DateOnlyCalendar.java
+++ b/src/main/java/com/salesforce/dataloader/util/DateOnlyCalendar.java
@@ -30,6 +30,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
+import com.salesforce.dataloader.config.AppConfig;
 import com.salesforce.dataloader.util.DLLogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -65,7 +66,8 @@ public class DateOnlyCalendar extends GregorianCalendar {
         Calendar cal = Calendar.getInstance(myTimeZone);
         cal.setTimeInMillis(specifiedTimeInMilliSeconds);
 
-        if (!AppUtil.isUseGMTForDateFieldValue() && myTimeZone != null) {
+        if (!AppConfig.getCurrentConfig().getBoolean(AppConfig.PROP_GMT_FOR_DATE_FIELD_VALUE)
+                && myTimeZone != null) {
             // Set hour, minute, second, and millisec to 0 (12:00AM) as it is date-only value
             cal.set(Calendar.HOUR, 0);
             cal.set(Calendar.MINUTE, 0);
@@ -83,7 +85,7 @@ public class DateOnlyCalendar extends GregorianCalendar {
     }
 
     public static DateOnlyCalendar getInstance(TimeZone timeZone) {
-        if (AppUtil.isUseGMTForDateFieldValue()) {
+        if (AppConfig.getCurrentConfig().getBoolean(AppConfig.PROP_GMT_FOR_DATE_FIELD_VALUE)) {
             timeZone = GMT_TZ;
         } 
         return new DateOnlyCalendar(timeZone);

--- a/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
+++ b/src/test/java/com/salesforce/dataloader/dyna/DateConverterTest.java
@@ -30,6 +30,8 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import com.salesforce.dataloader.ConfigTestBase;
+import com.salesforce.dataloader.config.AppConfig;
 import com.salesforce.dataloader.util.AppUtil;
 
 import java.util.Calendar;
@@ -41,7 +43,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-public class DateConverterTest {
+public class DateConverterTest extends ConfigTestBase {
 
     private static final TimeZone TZ = TimeZone.getTimeZone("GMT");
 
@@ -678,7 +680,7 @@ public class DateConverterTest {
         assertEquals(6, result.get(Calendar.MONTH) + 1);
         assertEquals(22, result.get(Calendar.DAY_OF_MONTH));
 
-        AppUtil.setUseGMTForDateFieldValue(true);
+        this.getController().getAppConfig().setValue(AppConfig.PROP_GMT_FOR_DATE_FIELD_VALUE, true);
         AsianTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("Asia/Tokyo"), false);
         USTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("America/Los_Angeles"), false);
         result = (Calendar) USTZDateOnlyConverter.convert(null, "6/22/2012");
@@ -716,7 +718,7 @@ public class DateConverterTest {
         assertEquals(7, result.get(Calendar.DAY_OF_MONTH));
         assertEquals(TimeZone.getTimeZone("GMT"), result.getTimeZone());
 
-        AppUtil.setUseGMTForDateFieldValue(false);
+        this.getController().getAppConfig().setValue(AppConfig.PROP_GMT_FOR_DATE_FIELD_VALUE, false);
         AsianTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("Asia/Tokyo"), false);
         USTZDateOnlyConverter = new DateOnlyConverter(TimeZone.getTimeZone("America/Los_Angeles"), false);
 


### PR DESCRIPTION
use AppConfig getter for GMT property setting instead of AppUtil convenience wrapper.