### PR TITLE
use logger even before log4j config properties are applied from confi…

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/AppConfig.java
+++ b/src/main/java/com/salesforce/dataloader/config/AppConfig.java
@@ -120,7 +120,7 @@ import org.apache.logging.log4j.Logger;
  *
  */
 public class AppConfig {
-    private static Logger logger;
+    private static Logger logger = DLLogManager.getLogger(AppConfig.class);
     private static final String DECRYPTED_SUFFIX = ".decrypted";
 
     /**
@@ -1846,7 +1846,7 @@ public class AppConfig {
         try {
             AppConfig.configurationsDir = configDirFile.getCanonicalPath();
         } catch (IOException e) {
-            System.err.println("Unable to find configuration folder " + AppConfig.configurationsDir);
+            logger.error("Unable to find configuration folder " + AppConfig.configurationsDir);
             AppConfig.configurationsDir = configDirFile.getAbsolutePath();
         }
         System.setProperty(CLI_OPTION_CONFIG_DIR_PROP, AppConfig.configurationsDir);
@@ -1856,7 +1856,6 @@ public class AppConfig {
         Map<String, String> argsMap = AppUtil.convertCommandArgsArrayToArgMap(args);
         AppConfig.setConfigurationsDir(argsMap);
         LoggingUtil.initializeLog(argsMap);
-        logger = DLLogManager.getLogger(AppConfig.class);
         return AppUtil.convertCommandArgsMapToArgsArray(argsMap);
     }
 

--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -111,7 +111,7 @@ public class Controller {
     private boolean lastOperationSuccessful = true;
 
     // logger
-    private static Logger logger;
+    private static Logger logger = DLLogManager.getLogger(Controller.class);
     
     private IAction lastExecutedAction = null;
     
@@ -121,7 +121,7 @@ public class Controller {
             versionProps.load(Controller.class.getClassLoader().getResourceAsStream("com/salesforce/dataloader/version.properties"));
             APP_VERSION = versionProps.getProperty("dataloader.version");
         } catch (IOException e) {
-            System.err.println("Unable to read version.properties file from uber jar");
+            logger.error("Unable to read version.properties file from uber jar");
         }
     }
 
@@ -129,13 +129,8 @@ public class Controller {
         // if name is passed to controller, use it to create a unique run file name
         try {
             this.appConfig = AppConfig.getInstance(argsMap);
-            // config containing log4j config file is not initialized
-            // till AppConfig is instantiated.
-            logger = DLLogManager.getLogger(Controller.class);
         } catch (Exception e) {
-            System.err.println("Controller: Exception happened in initializing AppConfig:");
-            System.err.println(e.getMessage());
-            e.printStackTrace();
+            logger.fatal("Controller: Exception happened in initializing AppConfig:", e);
             throw new ControllerInitializationException(e.getMessage());
         }
 

--- a/src/main/java/com/salesforce/dataloader/install/Installer.java
+++ b/src/main/java/com/salesforce/dataloader/install/Installer.java
@@ -43,10 +43,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
 import com.salesforce.dataloader.util.DLLogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.status.StatusLogger.Config;
 
 import com.salesforce.dataloader.config.AppConfig;
-import com.salesforce.dataloader.config.ConfigPropertyMetadata;
 import com.salesforce.dataloader.config.Messages;
 import com.salesforce.dataloader.util.AppUtil;
 
@@ -56,7 +54,7 @@ public class Installer {
     private static final String CREATE_DEKSTOP_SHORTCUT_ON_WINDOWS = ":createDesktopShortcut";
     private static final String CREATE_START_MENU_SHORTCUT_ON_WINDOWS = ":createStartMenuShortcut";
 
-    private static Logger logger;
+    private static Logger logger =DLLogManager.getLogger(Installer.class);
     private static String[] OS_SPECIFIC_DL_COMMAND = {"dataloader.bat", "dataloader_console", "dataloader.sh"};
 
     public static void install(Map<String, String> argsmap) {
@@ -68,7 +66,6 @@ public class Installer {
             String installationFolder = ".";
             installationFolder = new File(Installer.class.getProtectionDomain().getCodeSource().getLocation()
                     .toURI()).getParent();
-            setLogger();
 
             for (String dlCmd : OS_SPECIFIC_DL_COMMAND) {
                 Path installFilePath = Paths.get(installationFolder + PATH_SEPARATOR + dlCmd);
@@ -292,7 +289,7 @@ public class Installer {
                 try {
                     input = promptAndGetUserInput(prompt);
                 } catch (IOException e) {
-                    System.err.println(Messages.getMessage(Installer.class, "responseReadError"));
+                    logger.error(Messages.getMessage(Installer.class, "responseReadError"));
                     handleException(e, Level.ERROR);
                 }
             }
@@ -305,7 +302,7 @@ public class Installer {
                         System.out.println(success);
                     }
                 } catch (Exception ex) {
-                    System.err.println(Messages.getMessage(Installer.class, "shortcutCreateError"));
+                    logger.error(Messages.getMessage(Installer.class, "shortcutCreateError"));
                     handleException(ex, Level.ERROR);
                 }
                 break;
@@ -454,7 +451,6 @@ public class Installer {
     }
 
     public static void extractInstallationArtifactsFromJar(String installationDir) throws URISyntaxException, IOException {
-        setLogger();
         AppUtil.extractDirFromJar("samples", installationDir, false);
         AppUtil.extractDirFromJar("configs", installationDir, false);
         String osSpecificExtractionPrefix = "mac/";
@@ -472,12 +468,6 @@ public class Installer {
             logger.log(level, "Installer :", ex);
         } else {
             ex.printStackTrace();
-        }
-    }
-
-    private static void setLogger() {
-        if (logger == null) {
-            logger = DLLogManager.getLogger(Installer.class);
         }
     }
 }

--- a/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/ProcessRunner.java
@@ -87,7 +87,7 @@ public class ProcessRunner implements InitializingBean, IProcess {
      */
 
     //logger
-    private static Logger logger;
+    private static Logger logger = DLLogManager.getLogger(ProcessRunner.class);
     
     private String name = null; // name of the loaded process DynaBean
 
@@ -238,25 +238,14 @@ public class ProcessRunner implements InitializingBean, IProcess {
 
     public static void logErrorAndExitProcess(String message, Throwable throwable, int exitCode) {
         if (throwable == null) {
-            if (logger == null) {
-                System.err.println(message);
-            } else {
-                logger.fatal(message);
-            }
-            throw new ExitException(message, exitCode); // expect caller to exit
+            logger.fatal(message);
         } else { // throwable != null
-            if (logger == null) {
-                System.err.println(throwable.getMessage());
-                throwable.printStackTrace();
-            } else {
-                logger.fatal(message, throwable);
-            }
-            throw new ExitException(throwable, exitCode);
+            logger.fatal(message, throwable);
         }
+        throw new ExitException(throwable, exitCode);
     }
     
     public static ProcessRunner runBatchMode(Map<String, String>argMap, ILoaderProgress progressMonitor) throws UnsupportedOperationException {
-        logger = DLLogManager.getLogger(ProcessRunner.class);
         ProcessRunner runner = null;
         try {
             // create the process

--- a/src/main/java/com/salesforce/dataloader/util/DLLogManager.java
+++ b/src/main/java/com/salesforce/dataloader/util/DLLogManager.java
@@ -25,20 +25,11 @@
  */
 package com.salesforce.dataloader.util;
 
-import java.io.IOException;
-import javax.xml.parsers.FactoryConfigurationError;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class DLLogManager {
     public static <T> Logger getLogger(Class<T> clazz) {
-        try {
-            LoggingUtil.initializeLog(null);
-        } catch (FactoryConfigurationError | IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
         return LogManager.getLogger(clazz);
     }
 }

--- a/src/main/java/com/salesforce/dataloader/util/LoggingUtil.java
+++ b/src/main/java/com/salesforce/dataloader/util/LoggingUtil.java
@@ -45,11 +45,11 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 
 import com.salesforce.dataloader.config.AppConfig;
 import com.salesforce.dataloader.config.LinkedProperties;
-import com.salesforce.dataloader.config.Messages;
 
 public class LoggingUtil {
     
@@ -57,14 +57,9 @@ public class LoggingUtil {
     private static final String LOG_CONF_DEFAULT_XML = "log-conf.xml";
     private static final String LOG_CONF_DEFAULT_PROPERTIES = "log4j2.properties";
     public static String LOG_CONF_DEFAULT = LOG_CONF_DEFAULT_PROPERTIES;
-    private static Logger logger;
-    private static boolean logInitialized = false;
-    
+    private static Logger logger = LogManager.getLogger(LoggingUtil.class);
     
     public static synchronized void initializeLog(Map<String, String> argsMap) throws FactoryConfigurationError, IOException {
-        if (logInitialized) {
-            return;
-        }
         if (argsMap == null) {
             argsMap = new HashMap<String, String>();
         }
@@ -122,9 +117,9 @@ public class LoggingUtil {
          
         // this will force a reconfiguration
         context.setConfigLocation(file.toURI());
-        logger = LogManager.getLogger(LoggingUtil.class);
-        logger.debug(Messages.getMessage(LoggingUtil.class, "logInit")); //$NON-NLS-1$
-        logInitialized = true;
+        Configurator.reconfigure();
+        
+        logger.debug("Initialized logging config"); //$NON-NLS-1$
     }
     
     public static void setLoggingLevel(String newLevelStr) {


### PR DESCRIPTION
…gs folder

avoid use of system.err.println() by calling Configurator.reconfigure() after setting LoggerContext's config location to log4j properties file.