### PR TITLE
logging during start and banner display changes

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/AppConfig.java
+++ b/src/main/java/com/salesforce/dataloader/config/AppConfig.java
@@ -1894,12 +1894,12 @@ public class AppConfig {
         if (!dirPath.exists() || !dirPath.isDirectory()) {
             isSuccessful = dirPath.mkdirs();
             if (isSuccessful) {
-                logger.info("Created config folder: " + dirPath);
+                logger.debug("Created config folder: " + dirPath);
             } else {
-                logger.info("Unable to create config folder: " + dirPath);
+                logger.warn("Unable to create config folder: " + dirPath);
             }
         } else {
-            logger.info("Config folder already exists: " + dirPath);
+            logger.debug("Config folder already exists: " + dirPath);
         }
         return isSuccessful;
     }
@@ -1934,7 +1934,7 @@ public class AppConfig {
         File configFile = new File(configurationsDir.getAbsolutePath(), CONFIG_FILE);
 
         String configFilePath = configFile.getAbsolutePath();
-        logger.info("Looking for file in config path: " + configFilePath);
+        logger.debug("Looking for file in config path: " + configFilePath);
         if (!configFile.exists()) {
 
             File defaultConfigFile = new File(configurationsDir, DEFAULT_CONFIG_FILE);
@@ -1965,15 +1965,16 @@ public class AppConfig {
             configFile.setWritable(true);
             configFile.setReadable(true);
         } else {
-            logger.info("User config is found in " + configFile.getAbsolutePath());
+            logger.debug("User config is found in " + configFile.getAbsolutePath());
         }
 
         AppConfig appConfig = null;
         try {
             appConfig = new AppConfig(configFilePath, argMap);
             currentConfig = appConfig;
-            logger.info(Messages.getMessage(AppConfig.class, "configInit")); //$NON-NLS-1$
+            logger.debug(Messages.getMessage(AppConfig.class, "configInit")); //$NON-NLS-1$
         } catch (IOException | ProcessInitializationException e) {
+            logger.error(e.getMessage());
             throw new ConfigInitializationException(Messages.getMessage(AppConfig.class, "errorConfigLoad", configFilePath), e);
         }
         return appConfig;

--- a/src/main/java/com/salesforce/dataloader/config/ConfigPropertyMetadata.java
+++ b/src/main/java/com/salesforce/dataloader/config/ConfigPropertyMetadata.java
@@ -257,12 +257,12 @@ public class ConfigPropertyMetadata {
                     csvWriter.writeRow(row);
                 } catch (DataAccessObjectException e) {
                     logger.warn(Messages.getFormattedString("ConfigPropertyMetadata.errorOutputPropInfo", propMD.getName()));
-                    logger.info(e.getStackTrace());
+                    logger.warn(e.getStackTrace());
                     continue; 
                 }
             }
         } finally {
-            logger.info(Messages.getFormattedString("ConfigPropertyMetadata.infoGeneratedCSVLocation", getFullPathToPropsFile(appConfig)));
+            logger.debug(Messages.getFormattedString("ConfigPropertyMetadata.infoGeneratedCSVLocation", getFullPathToPropsFile(appConfig)));
             csvWriter.close();
         }
     }

--- a/src/main/java/com/salesforce/dataloader/config/LastRunProperties.java
+++ b/src/main/java/com/salesforce/dataloader/config/LastRunProperties.java
@@ -84,7 +84,7 @@ public class LastRunProperties extends Properties {
             throw new IOException(Messages.getString("LastRun.fileMissing")); //$NON-NLS-1$
         }
         File lastRunFile = new File(filePath, filename);
-        logger.info(Messages.getFormattedString("LastRun.fileInfo", lastRunFile.getAbsolutePath()));
+        logger.debug(Messages.getFormattedString("LastRun.fileInfo", lastRunFile.getAbsolutePath()));
         if(!lastRunFile.exists()) {
             lastRunFile.createNewFile();
         }

--- a/src/main/java/com/salesforce/dataloader/install/Installer.java
+++ b/src/main/java/com/salesforce/dataloader/install/Installer.java
@@ -75,12 +75,6 @@ public class Installer {
                     return;
                 }
             }
-            boolean hideBanner = false;
-            
-            if (!hideBanner) {
-                logger.debug("going to show banner");
-                AppUtil.showBanner();
-            }
             String installationFolderFromCommandLine = argsmap.get(AppConfig.CLI_OPTION_INSTALLATION_FOLDER_PROP);
             boolean promptUserToDeleteExistingInstallationFolder = false;
             if (installationFolderFromCommandLine == null || installationFolderFromCommandLine.isBlank()) {

--- a/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
+++ b/src/main/java/com/salesforce/dataloader/process/DataLoaderRunner.java
@@ -62,7 +62,7 @@ public class DataLoaderRunner extends Thread {
     private static final String LOCAL_SWT_DIR = "./target/";
     private static final String PATH_SEPARATOR = System.getProperty("path.separator");
     private static final String FILE_SEPARATOR = System.getProperty("file.separator");
-    private static Logger logger;
+    private static Logger logger = DLLogManager.getLogger(DataLoaderRunner.class);
     private static int exitCode = AppUtil.EXIT_CODE_NO_ERRORS;
 
     public void run() {
@@ -72,6 +72,10 @@ public class DataLoaderRunner extends Thread {
 
     public static void main(String[] commandLineOptions) {
         try {
+            Map<String, String> argsMap = AppUtil.convertCommandArgsArrayToArgMap(commandLineOptions);
+            if (!argsMap.containsKey(AppConfig.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH)) {
+                AppUtil.showBanner();
+            }
             runApp(commandLineOptions, null);
             System.exit(exitCode);
         } catch (ExitException ex) {
@@ -90,7 +94,7 @@ public class DataLoaderRunner extends Thread {
         try {
             controller = Controller.getInstance(AppUtil.convertCommandArgsArrayToArgMap(commandLineOptions));
         } catch (FactoryConfigurationError | Exception ex) {
-            ex.printStackTrace();
+            logger.fatal(ex);
             System.exit(AppUtil.EXIT_CODE_CLIENT_ERROR);
         }
         if (AppUtil.getAppRunMode() == AppUtil.APP_RUN_MODE.BATCH) {
@@ -100,7 +104,6 @@ public class DataLoaderRunner extends Thread {
         } else {
             Map<String, String> argsMap = AppUtil.convertCommandArgsArrayToArgMap(commandLineOptions);
             /* Run in the UI mode, get the controller instance with batchMode == false */
-            logger = DLLogManager.getLogger(DataLoaderRunner.class);
             Installer.install(argsMap);
             if (argsMap.containsKey(AppConfig.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH) 
                 && "true".equalsIgnoreCase(argsMap.get(AppConfig.CLI_OPTION_SWT_NATIVE_LIB_IN_JAVA_LIB_PATH))){
@@ -116,7 +119,6 @@ public class DataLoaderRunner extends Thread {
                     UIUtils.errorMessageBox(new Shell(new Display()), e);
                 }
             } else { // SWT_NATIVE_LIB_IN_JAVA_LIB_PATH not set
-                AppUtil.showBanner();
                 rerunWithSWTNativeLib(commandLineOptions);
             }
         }


### PR DESCRIPTION
- reduce log level for successful config and control initialization messages from INFO to DEBUG to reduce console messages to essential ones when launching
- show banner only once when launching