### PR TITLE
disable ok in Settings dialog if config.properties.readonly=true

### DIFF
--- a/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/AdvancedSettingsDialog.java
@@ -965,6 +965,7 @@ public class AdvancedSettingsDialog extends BaseDialog {
         // to the entered value
         Button ok = new Button(buttonComp, SWT.PUSH | SWT.FLAT);
         ok.setText(Labels.getString("UI.ok")); //$NON-NLS-1$
+        ok.setEnabled(!appConfig.getBoolean(AppConfig.PROP_READ_ONLY_CONFIG_PROPERTIES));
         ok.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent event) {


### PR DESCRIPTION
Do not let the user change settings if config.properties.readonly=true