### PR TITLE
reduce memory footprint of large upload jobs

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/AbstractLoadAction.java
+++ b/src/main/java/com/salesforce/dataloader/action/AbstractLoadAction.java
@@ -41,6 +41,7 @@ import com.salesforce.dataloader.exception.OperationException;
 import com.salesforce.dataloader.exception.ParameterLoadException;
 import com.salesforce.dataloader.mapping.LoadMapper;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
 import com.salesforce.dataloader.util.DAORowUtil;
 import com.sforce.soap.partner.DescribeGlobalSObjectResult;
 import com.sforce.soap.partner.DescribeSObjectResult;
@@ -85,12 +86,12 @@ abstract class AbstractLoadAction extends AbstractAction {
 
         final int loadBatchSize = this.getConfig().getImportBatchSize();
         final int daoRowNumBase = getDao().getCurrentRowNumber();
-        final List<Row> daoRowList = getDao().readRowList(loadBatchSize);
+        final List<TableRow> daoRowList = getDao().readTableRowList(loadBatchSize);
         if (daoRowList == null || daoRowList.size() == 0) return false;
         int daoRowCount = 0;
 
-        for (final Row daoRow : daoRowList) {
-            if (!DAORowUtil.isValidRow(daoRow)) {
+        for (final TableRow daoRow : daoRowList) {
+            if (!DAORowUtil.isValidTableRow(daoRow)) {
                 getVisitor().setRowConversionStatus(daoRowNumBase + daoRowCount++, 
                         false);
                 return false;

--- a/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/DAOLoadVisitor.java
@@ -31,6 +31,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
 import com.salesforce.dataloader.util.DAORowUtil;
 
 import org.apache.commons.beanutils.*;
@@ -80,7 +81,7 @@ public abstract class DAOLoadVisitor extends AbstractVisitor implements DAORowVi
     protected DynaProperty[] dynaProps = null;
 
     private final int batchSize;
-    protected List<Row> daoRowList = new ArrayList<Row>();
+    protected List<TableRow> daoRowList = new ArrayList<TableRow>();
     protected ArrayList<Integer> batchRowToDAORowList = new ArrayList<Integer>();
     private int processedDAORowCounter = 0;
     private static final Logger logger = DLLogManager.getLogger(DAOLoadVisitor.class);
@@ -143,7 +144,7 @@ public abstract class DAOLoadVisitor extends AbstractVisitor implements DAORowVi
     }
 
     @Override
-    public boolean visit(Row row) throws OperationException, DataAccessObjectException,
+    public boolean visit(TableRow row) throws OperationException, DataAccessObjectException,
     ConnectionException {
         AppConfig appConfig = controller.getAppConfig();
         if (appConfig.getBoolean(AppConfig.PROP_PROCESS_BULK_CACHE_DATA_FROM_DAO)
@@ -221,7 +222,7 @@ public abstract class DAOLoadVisitor extends AbstractVisitor implements DAORowVi
             String errMsg = Messages.getMessage("Visitor", "conversionErrorMsg", conve.getMessage());
             getLogger().error(errMsg, conve);
 
-            conversionFailed(row, errMsg);
+            conversionFailed(row.convertToRow(), errMsg);
             // this row cannot be added since conversion has failed
             return false;
         } catch (InvocationTargetException e) {

--- a/src/main/java/com/salesforce/dataloader/action/visitor/DAORowVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/DAORowVisitor.java
@@ -28,7 +28,7 @@ package com.salesforce.dataloader.action.visitor;
 
 import com.salesforce.dataloader.exception.DataAccessObjectException;
 import com.salesforce.dataloader.exception.OperationException;
-import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
 import com.sforce.ws.ConnectionException;
 
 /**
@@ -38,6 +38,6 @@ import com.sforce.ws.ConnectionException;
  */
 public interface DAORowVisitor {
 
-    public boolean visit(Row row) throws OperationException, DataAccessObjectException, ConnectionException;
+    public boolean visit(TableRow row) throws OperationException, DataAccessObjectException, ConnectionException;
 
 }

--- a/src/main/java/com/salesforce/dataloader/action/visitor/partner/PartnerLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/partner/PartnerLoadVisitor.java
@@ -115,7 +115,7 @@ public abstract class PartnerLoadVisitor extends DAOLoadVisitor {
         // are a) not the same class yet b) not subclassed
         int batchRowCounter = 0;
         for (int i = 0; i < this.daoRowList.size(); i++) {
-            Row daoRow = this.daoRowList.get(i);
+            Row daoRow = this.daoRowList.get(i).convertToRow();
             if (!isRowConversionSuccessful()) {
                 continue;
             }

--- a/src/main/java/com/salesforce/dataloader/action/visitor/rest/RESTLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/rest/RESTLoadVisitor.java
@@ -82,7 +82,7 @@ public abstract class RESTLoadVisitor extends DAOLoadVisitor {
         // are a) not the same class yet b) not subclassed
         int batchRowCounter = 0;
         for (int i = 0; i < this.daoRowList.size(); i++) {
-            Row daoRow = this.daoRowList.get(i);
+            Row daoRow = this.daoRowList.get(i).convertToRow();
             if (!isRowConversionSuccessful()) {
                 continue;
             }

--- a/src/main/java/com/salesforce/dataloader/dao/DAORowCache.java
+++ b/src/main/java/com/salesforce/dataloader/dao/DAORowCache.java
@@ -28,10 +28,10 @@ package com.salesforce.dataloader.dao;
 import java.util.ArrayList;
 
 import com.salesforce.dataloader.config.AppConfig;
-import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
 
 public class DAORowCache {
-    private ArrayList<Row> rowList = new ArrayList<Row>();
+    private ArrayList<TableRow> rowList = new ArrayList<TableRow>();
     private int currentRowIndex = 0;
     private int totalRows = 0;
 
@@ -42,7 +42,7 @@ public class DAORowCache {
         currentRowIndex = 0;
     }
     
-    public Row getCurrentRow() {
+    public TableRow getCurrentRow() {
         AppConfig appConfig = AppConfig.getCurrentConfig();
         if (currentRowIndex >= totalRows
             || !appConfig.getBoolean(AppConfig.PROP_PROCESS_BULK_CACHE_DATA_FROM_DAO)) {
@@ -51,7 +51,7 @@ public class DAORowCache {
         return rowList.get(currentRowIndex++);
     }
     
-    public void addRow(Row row) {
+    public void addRow(TableRow row) {
         rowList.add(row);
         currentRowIndex++;
         totalRows++;

--- a/src/main/java/com/salesforce/dataloader/dao/DataReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/DataReader.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import com.salesforce.dataloader.exception.DataAccessObjectException;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
 
 /**
  * Interface to be implemented for data readers -- data access objects that are used for reading rows of data.
@@ -48,6 +49,14 @@ public interface DataReader extends DataAccessObject {
     Row readRow() throws DataAccessObjectException;
 
     /**
+     * Get a row of data from a data source
+     *
+     * @return a {@link Row} containing all the keys and values of a row
+     * @throws DataAccessObjectException
+     */
+    TableRow readTableRow() throws DataAccessObjectException;
+
+    /**
      * Get a list of rows of data from a data source
      *
      * @param maxRows Maximum number of rows to read in one call
@@ -55,6 +64,15 @@ public interface DataReader extends DataAccessObject {
      * @throws DataAccessObjectException
      */
     List<Row> readRowList(int maxRows) throws DataAccessObjectException;
+
+    /**
+     * Get a list of rows of data from a data source
+     *
+     * @param maxRows Maximum number of rows to read in one call
+     * @return a list of up to maxRows {@link Row} objects, each of them containing all the keys and values of a row
+     * @throws DataAccessObjectException
+     */
+    List<TableRow> readTableRowList(int maxRows) throws DataAccessObjectException;
 
     /**
      * @return Total number of rows that will be read by the current Data Access Object

--- a/src/main/java/com/salesforce/dataloader/mapping/LoadMapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/LoadMapper.java
@@ -29,6 +29,7 @@ package com.salesforce.dataloader.mapping;
 import com.salesforce.dataloader.client.PartnerClient;
 import com.salesforce.dataloader.exception.MappingInitializationException;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
 import com.salesforce.dataloader.util.AppUtil;
 import com.sforce.soap.partner.Field;
 
@@ -95,7 +96,7 @@ public class LoadMapper extends Mapper {
         return result;
     }
 
-    public Row mapData(Row localRow) {
+    public Row mapData(TableRow localRow) {
         Set<String> compositeDAOCols = this.getCompositeDAOColumns();
         HashMap<String, Object[]> compositeColValueMap = new HashMap<String, Object[]>();
         HashMap<String, Integer> compositeColSizeMap = this.getCompositeColSizeMap();
@@ -111,7 +112,7 @@ public class LoadMapper extends Mapper {
         
         HashMap<String, Integer> daoColPositionMap = this.getDaoColPositionInCompositeColMap();
         HashMap<String, String> daoColToCompositeColMap = this.getDaoColToCompositeColMap();
-        for (String daoCol : localRow.keySet()) {
+        for (String daoCol : localRow.getHeader().getColumns()) {
             String compositeColName = daoColToCompositeColMap.get(daoCol);
             if (compositeColName == null) {
                 continue; // DAO column is not mapped

--- a/src/main/java/com/salesforce/dataloader/model/TableHeader.java
+++ b/src/main/java/com/salesforce/dataloader/model/TableHeader.java
@@ -23,29 +23,32 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+package com.salesforce.dataloader.model;
 
-package com.salesforce.dataloader.action.visitor;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import com.salesforce.dataloader.model.TableRow;
-
-
-/**
- * Visitor to calculate the size of a DataAccessObject
- *
- * @author Lexi Viripaeff
- * @since 6.0
- */
-public class DAOSizeVisitor implements DAORowVisitor {
-
-    private int numberOfRows = 0;
-
-    @Override
-    public boolean visit(TableRow row) {
-        numberOfRows++;
-        return true;
+public class TableHeader {
+    private final Map<String, Integer> columnPositionMap = new HashMap<String, Integer>();
+    private int lastColPosition = 0;
+    private List<String> columns;
+    public TableHeader(List<String> cols) {
+        this.columns = cols;
+        for (String colName : cols) {
+            if (colName == null) {
+                continue;
+            }
+            columnPositionMap.put(colName.toLowerCase(), lastColPosition);
+            lastColPosition++;    
+        }
     }
 
-    public int getNumberOfRows() {
-        return numberOfRows;
+    public Integer getColumnPosition(String columnName) {
+        return columnPositionMap.get(columnName.toLowerCase());
+    }
+    
+    public List<String> getColumns() {
+        return this.columns;
     }
 }

--- a/src/main/java/com/salesforce/dataloader/model/TableRow.java
+++ b/src/main/java/com/salesforce/dataloader/model/TableRow.java
@@ -23,29 +23,58 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+package com.salesforce.dataloader.model;
 
-package com.salesforce.dataloader.action.visitor;
+import java.util.ArrayList;
+import java.util.Collections;
 
-import com.salesforce.dataloader.model.TableRow;
+public class TableRow {
+    private TableHeader header;
+    private Object[] cellValues;
 
-
-/**
- * Visitor to calculate the size of a DataAccessObject
- *
- * @author Lexi Viripaeff
- * @since 6.0
- */
-public class DAOSizeVisitor implements DAORowVisitor {
-
-    private int numberOfRows = 0;
-
-    @Override
-    public boolean visit(TableRow row) {
-        numberOfRows++;
-        return true;
+    public TableRow(TableHeader header) {
+        this.header = header;
+        cellValues = new Object[header.getColumns().size()];
+    }
+    
+    public Object get(String key) {
+        Integer colPos = this.header.getColumnPosition(key);
+        if (colPos == null) {
+            return null;
+        }
+        return cellValues[colPos];
     }
 
-    public int getNumberOfRows() {
-        return numberOfRows;
+    public Object put(String key, Object value) {
+        Integer colPos = this.header.getColumnPosition(key);
+        if (colPos == null) {
+            return null;
+        }
+        return this.cellValues[colPos] = value;
+    }
+    
+    public Row convertToRow() {
+        Row row = new Row();
+        for (String colName : this.header.getColumns()) {
+            row.put(colName, cellValues[this.header.getColumnPosition(colName)]);
+        }
+        return row;
+    }
+    
+    public TableHeader getHeader() {
+        return this.header;
+    }
+    
+    public static TableRow emptyRow() {
+        return new TableRow(new TableHeader(new ArrayList<String>()));
+    }
+    
+    public static TableRow singleEntryImmutableRow(String key, Object value) {
+        ArrayList<String> headers = new ArrayList<String>();
+        headers.add(key);
+        TableHeader tableHeader = new TableHeader(headers);
+        TableRow row = new TableRow(tableHeader);
+        row.put(key, value);
+        return row;
     }
 }

--- a/src/main/java/com/salesforce/dataloader/util/DAORowUtil.java
+++ b/src/main/java/com/salesforce/dataloader/util/DAORowUtil.java
@@ -30,6 +30,8 @@ import java.io.IOException;
 import java.util.*;
 
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
+
 import org.apache.logging.log4j.Logger;
 import com.salesforce.dataloader.util.DLLogManager;
 
@@ -65,7 +67,7 @@ public class DAORowUtil {
         try {
             //visit the rows
             DAOSizeVisitor visitor = new DAOSizeVisitor();
-            for (Row row = dataReader.readRow(); isValidRow(row); row = dataReader.readRow()) {
+            for (TableRow row = dataReader.readTableRow(); isValidTableRow(row); row = dataReader.readTableRow()) {
                 visitor.visit(row);
             }
 
@@ -90,6 +92,14 @@ public class DAORowUtil {
         return true;
     }
 
+    /**
+     * @param row
+     * @return true if row is valid
+     */
+    public static boolean isValidTableRow(TableRow row) {
+        if (row == null) { return false; }
+        return true;
+    }
     /**
      * @param row
      * @return true if row is valid

--- a/src/test/java/com/salesforce/dataloader/mapping/LoadMapperTest.java
+++ b/src/test/java/com/salesforce/dataloader/mapping/LoadMapperTest.java
@@ -28,6 +28,9 @@ package com.salesforce.dataloader.mapping;
 import com.salesforce.dataloader.ConfigTestBase;
 import com.salesforce.dataloader.exception.MappingInitializationException;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableHeader;
+import com.salesforce.dataloader.model.TableRow;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -36,6 +39,7 @@ import org.junit.Test;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -58,11 +62,13 @@ public class LoadMapperTest extends ConfigTestBase {
     private static final String[] DEST_NAMES = { "destinationOne", "destinationTwo", "destinationThree" };
     private static final String DEST_CONSTANT_NAME = "destinationConstant";
     private static final String CONSTANT_VALUE = "constantValue123";
-    private Row sourceRow;
+    private TableRow sourceRow;
 
     @Before
     public void setUp() throws Exception {
-        sourceRow = new Row();
+        List<String> headerList = Arrays.asList(SOURCE_NAMES);
+        TableHeader tableHeader = new TableHeader(headerList);
+        sourceRow = new TableRow(tableHeader);
         // populate all the available values
         for (int i = 0; i < SOURCE_NAMES.length; i++) {
             sourceRow.put(SOURCE_NAMES[i], SOURCE_VALUES[i]);
@@ -148,7 +154,7 @@ public class LoadMapperTest extends ConfigTestBase {
         mappings.setProperty("", "Value6");
         LoadMapper mapper = new LoadMapper(null, null, null, null);
         mapper.putPropertyFileMappings(mappings);
-        Row result = mapper.mapData(Row.emptyRow());
+        Row result = mapper.mapData(TableRow.emptyRow());
         assertEquals(constantValue, result.get("Name"));
         assertEquals(constantValue, result.get("field1__c"));
         assertEquals(constantValue, result.get("field2__c"));
@@ -190,7 +196,7 @@ public class LoadMapperTest extends ConfigTestBase {
         mapper.putPropertyFileMappings(mappings);
 
         //place a dao column -> sfdc field mapping
-        Row input = Row.singleEntryImmutableRow(csvFieldName, sfdcField);
+        TableRow input = TableRow.singleEntryImmutableRow(csvFieldName, sfdcField);
 
         //(src, dest).
         mapper.putMapping(csvFieldName, sfdcField);
@@ -227,7 +233,7 @@ public class LoadMapperTest extends ConfigTestBase {
         mappings.setProperty(wrappedConstantValue, sfdcField);
         mapper.putPropertyFileMappings(mappings);
 
-        Row input = Row.singleEntryImmutableRow(constantValue, sfdcField);
+        TableRow input = TableRow.singleEntryImmutableRow(constantValue, sfdcField);
 
         Map<String, Object> result = mapper.mapData(input);
 
@@ -240,7 +246,7 @@ public class LoadMapperTest extends ConfigTestBase {
         LoadMapper loadMapper = new LoadMapper(null, null, null, null);
         loadMapper.putMapping("SOURCE_COL", "");
 
-        Row inputData = Row.singleEntryImmutableRow("SOURCE_COL", "123");
+        TableRow inputData = TableRow.singleEntryImmutableRow("SOURCE_COL", "123");
 
         Map<String, Object> result = loadMapper.mapData(inputData);
 


### PR DESCRIPTION
Use TableRow and TableHeader classes to represent DAO (CSV and database) rows instead of Row class for memory savings by avoiding duplication of header labels for each row.