### PR TITLE
increase TableRow direct use - replace readRow() with readTableRow()

### DIFF
--- a/src/main/java/com/salesforce/dataloader/dao/DataReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/DataReader.java
@@ -39,15 +39,6 @@ import com.salesforce.dataloader.model.TableRow;
  * @since 8.0
  */
 public interface DataReader extends DataAccessObject {
-
-    /**
-     * Get a row of data from a data source
-     *
-     * @return a {@link Row} containing all the keys and values of a row
-     * @throws DataAccessObjectException
-     */
-    Row readRow() throws DataAccessObjectException;
-
     /**
      * Get a row of data from a data source
      *

--- a/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileReader.java
@@ -47,7 +47,6 @@ import com.salesforce.dataloader.dao.AbstractDataReaderImpl;
 import com.salesforce.dataloader.exception.DataAccessObjectException;
 import com.salesforce.dataloader.exception.DataAccessObjectInitializationException;
 import com.salesforce.dataloader.exception.DataAccessRowException;
-import com.salesforce.dataloader.model.Row;
 import com.salesforce.dataloader.model.TableHeader;
 import com.salesforce.dataloader.model.TableRow;
 import com.salesforce.dataloader.util.AppUtil;
@@ -204,15 +203,6 @@ public class CSVFileReader extends AbstractDataReaderImpl {
             trow.put(headerRow.get(i), value);
         }
         return trow;
-    }
-    
-    @Override
-    public Row readRow() throws DataAccessObjectException {
-        TableRow tableRow = readTableRow();
-        if (tableRow == null) {
-            return null;
-        }
-        return tableRow.convertToRow();
     }
 
     /**

--- a/src/main/java/com/salesforce/dataloader/dao/database/DatabaseReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/database/DatabaseReader.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.sql.*;
 import java.util.*;
 
-import com.salesforce.dataloader.model.Row;
 import com.salesforce.dataloader.model.TableHeader;
 import com.salesforce.dataloader.model.TableRow;
 
@@ -216,15 +215,6 @@ public class DatabaseReader extends AbstractDataReaderImpl {
             close();
             throw new DataAccessObjectException(errMsg, e);
         }
-    }
-    
-    @Override
-    public Row readRow() throws DataAccessObjectException {
-        TableRow tableRow = readTableRow();
-        if (tableRow == null) {
-            return null;
-        }
-        return tableRow.convertToRow();
     }
 
     @Override

--- a/src/main/java/com/salesforce/dataloader/ui/CSVViewerDialog.java
+++ b/src/main/java/com/salesforce/dataloader/ui/CSVViewerDialog.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.logging.log4j.Logger;
@@ -57,7 +56,7 @@ import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.dao.csv.CSVFileReader;
 import com.salesforce.dataloader.exception.DataAccessObjectException;
 import com.salesforce.dataloader.exception.DataAccessObjectInitializationException;
-import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
 import com.salesforce.dataloader.ui.csvviewer.CSVContentProvider;
 import com.salesforce.dataloader.ui.csvviewer.CSVLabelProvider;
 import com.salesforce.dataloader.util.AppUtil;
@@ -292,23 +291,23 @@ public class CSVViewerDialog extends Dialog {
 
         List<List<Object>> rowList = new ArrayList<List<Object>>();
         for (int i = 0; i < numberOfRows; i++) {
-            Row rowMap;
+            TableRow row;
             try {
-                rowMap = csvReader.readRow();
+                row = csvReader.readTableRow();
             } catch (DataAccessObjectException e) {
                 break;
             }
-            if (!DAORowUtil.isValidRow(rowMap)) {
+            if (!DAORowUtil.isValidTableRow(row)) {
                 break;
             }
 
             List<String> columns = csvReader.getColumnNames();
-            List<Object> row = new ArrayList<Object>();
-            row.add(0, String.valueOf(i + 1));
+            List<Object> listOfRowCells = new ArrayList<Object>();
+            listOfRowCells.add(0, String.valueOf(i + 1));
             for(String column : columns) {
-                row.add(rowMap.get(column));
+                listOfRowCells.add(row.get(column));
             }
-            rowList.add(row);
+            rowList.add(listOfRowCells);
         }
         csvReader.close();
         csvTblViewer.setInput(rowList);

--- a/src/main/java/com/salesforce/dataloader/util/DAORowUtil.java
+++ b/src/main/java/com/salesforce/dataloader/util/DAORowUtil.java
@@ -215,7 +215,7 @@ public class DAORowUtil {
             // keep skipping over rows until we run into an invalid row or we have gotten
             // to the starting row
             while (daoReader.getCurrentRowNumber() < rowToStart) {
-                if (!DAORowUtil.isValidRow(daoReader.readRow())) break;
+                if (!DAORowUtil.isValidTableRow(daoReader.readTableRow())) break;
             }
         }
     }

--- a/src/test/java/com/salesforce/dataloader/dao/CsvTest.java
+++ b/src/test/java/com/salesforce/dataloader/dao/CsvTest.java
@@ -37,6 +37,7 @@ import com.salesforce.dataloader.config.AppConfig;
 import com.salesforce.dataloader.dao.csv.CSVFileReader;
 import com.salesforce.dataloader.dao.csv.CSVFileWriter;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
 import com.salesforce.dataloader.util.AppUtil;
 
 import static org.junit.Assert.assertEquals;
@@ -105,12 +106,12 @@ public class CsvTest extends ConfigTestBase {
         assertEquals(COLUMN_2_NAME, headerRow.get(1));
         assertEquals(COLUMN_3_NAME, headerRow.get(2));
 
-        Row firstRow = csv.readRow();
+        TableRow firstRow = csv.readTableRow();
         assertEquals("row1-1", firstRow.get(COLUMN_1_NAME));
         assertEquals("row1-2", firstRow.get(COLUMN_2_NAME));
         assertEquals("row1-3", firstRow.get(COLUMN_3_NAME));
 
-        Row secondRow = csv.readRow();
+        TableRow secondRow = csv.readTableRow();
         assertEquals("row2-1", secondRow.get(COLUMN_1_NAME));
         assertEquals("row2-2", secondRow.get(COLUMN_2_NAME));
         assertEquals("row2-3", secondRow.get(COLUMN_3_NAME));
@@ -170,19 +171,19 @@ public class CsvTest extends ConfigTestBase {
 
         CSVFileReader csv = new CSVFileReader(f, getController().getAppConfig(), false, false);
         csv.open();
-        Row firstRow = csv.readRow();
+        TableRow firstRow = csv.readTableRow();
         assertEquals("somev1", firstRow.get("some"));
-        assertEquals(4, firstRow.size());
-        Row secondRow = csv.readRow();
+        assertEquals(4, firstRow.getNonEmptyCellsCount());
+        TableRow secondRow = csv.readTableRow();
         assertEquals("somev2", secondRow.get("some"));
         csv.close();
 
         getController().getAppConfig().setValue("loader.csvOther", false);
         csv = new CSVFileReader(f, getController().getAppConfig(), false, false);
         csv.open();
-        firstRow = csv.readRow();
+        firstRow = csv.readTableRow();
         assertEquals("col12!somev1", firstRow.get("column2!some"));
-        assertEquals(3, firstRow.size());
+        assertEquals(3, firstRow.getNonEmptyCellsCount());
         csv.close();
     }
 
@@ -195,10 +196,10 @@ public class CsvTest extends ConfigTestBase {
         CSVFileReader csv = new CSVFileReader(f, getController().getAppConfig(), false, false);
         csv.open();
 
-        Row firstRow = csv.readRow();
+        TableRow firstRow = csv.readTableRow();
         assertEquals("\"The Best\" Account", firstRow.get(COLUMN_1_NAME));
 
-        Row secondRow = csv.readRow();
+        TableRow secondRow = csv.readTableRow();
         assertEquals("The \"Best\" Account", secondRow.get(COLUMN_1_NAME));
 
         csv.close();
@@ -210,7 +211,7 @@ public class CsvTest extends ConfigTestBase {
         csvFileReader.open();
         assertEquals(20000, csvFileReader.getTotalRows());
         int count = 0;
-        for(Row row = csvFileReader.readRow(); row != null; row = csvFileReader.readRow(), count++);
+        for(TableRow row = csvFileReader.readTableRow(); row != null; row = csvFileReader.readTableRow(), count++);
         assertEquals(20000, count);
     }
 
@@ -262,15 +263,15 @@ public class CsvTest extends ConfigTestBase {
         }
 
         //check that row 1 is valid
-        Row firstRow = csv.readRow();
+        TableRow firstRow = csv.readTableRow();
         for (String headerColumn : writeHeader) {
-                assertEquals(row1.get(headerColumn), firstRow.get(headerColumn));
+            assertEquals(row1.get(headerColumn), firstRow.get(headerColumn));
         }
 
         //check that row 2 is valid
-        Row secondRow = csv.readRow();
+        TableRow secondRow = csv.readTableRow();
         for (String headerColumn : writeHeader) {
-                assertEquals(row2.get(headerColumn), secondRow.get(headerColumn));
+            assertEquals(row2.get(headerColumn), secondRow.get(headerColumn));
         }
         csv.close();
         if (isQueryResultsCSV) {

--- a/src/test/java/com/salesforce/dataloader/process/CsvExtractProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvExtractProcessTest.java
@@ -181,9 +181,9 @@ public class CsvExtractProcessTest extends ProcessExtractTestBase {
                 // open the results of the extraction
                 final CSVFileReader rdr = new CSVFileReader(new File(argmap.get(AppConfig.PROP_DAO_NAME)), getController().getAppConfig(), true, false);
                 rdr.open();
-                Row row = rdr.readRow();
+                TableRow row = rdr.readTableRow();
                 assertNotNull(row);
-                assertEquals(5,row.size());
+                assertEquals(5,row.getNonEmptyCellsCount());
                 // validate the extract results are correct.
                 assertEquals(leadidArr[0], row.get("LID"));
                 assertTrue(userInfo.getUserFullName().contains(row.get("LNAME").toString()));
@@ -191,7 +191,7 @@ public class CsvExtractProcessTest extends ProcessExtractTestBase {
                 assertEquals(uid, row.get("OID"));
                 assertEquals(uid,row.get("OWNID"));
                 // validate that we have read the only result. there should be only one.
-                assertNull(rdr.readRow());
+                assertNull(rdr.readTableRow());
         } finally {
             // cleanup here since the parent doesn't clean up leads
             getBinding().delete(leadidArr);
@@ -342,13 +342,13 @@ public class CsvExtractProcessTest extends ProcessExtractTestBase {
         controller = runProcess(queryArgMap, 1);
         CSVFileReader queryResultsReader = new CSVFileReader(new File(queryArgMap.get(AppConfig.PROP_DAO_NAME)), getController().getAppConfig(), true, false);
         queryResultsReader.open();
-        Row queryResultsRow = queryResultsReader.readRow();
+        TableRow queryResultsRow = queryResultsReader.readTableRow();
         String queryResultsRTVal = (String)queryResultsRow.get("RICHTEXT__c");
 
         if ("true".equalsIgnoreCase(inclueRTFBinaryData)) {
             CSVFileReader uploadedCSVReader = new CSVFileReader(new File(getTestDataDir() + "/acctsWithBinaryDataInRTF.csv"), getController().getAppConfig(), true, false);
             uploadedCSVReader.open();
-            Row uploadedRow = uploadedCSVReader.readRow();
+            TableRow uploadedRow = uploadedCSVReader.readTableRow();
             String uploadedRTVal = (String)queryResultsRow.get("RICHTEXT__c");
             assertEquals("Binary data in query result file does not match uploaded data: " 
             + queryArgMap.get(AppConfig.PROP_DAO_NAME), queryResultsRTVal, uploadedRTVal);

--- a/src/test/java/com/salesforce/dataloader/process/CsvProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/CsvProcessTest.java
@@ -120,8 +120,8 @@ public class CsvProcessTest extends ProcessTestBase {
         String successFileName = controller.getAppConfig().getString(AppConfig.PROP_OUTPUT_SUCCESS);
         File successFile = new File(successFileName);
         CSVFileReader csvReader = new CSVFileReader(successFile, controller.getAppConfig(), false, false);
-        Row row1 = csvReader.readRow();
-        Row row2 = csvReader.readRow();
+        TableRow row1 = csvReader.readTableRow();
+        TableRow row2 = csvReader.readTableRow();
         String oracleIdRow1 = (String)row1.get("oracle_id");
         String oracleIdRow2 = (String)row2.get("oracle_id");
         if (oracleIdRow1 == null) {

--- a/src/test/java/com/salesforce/dataloader/process/NAProcessTest.java
+++ b/src/test/java/com/salesforce/dataloader/process/NAProcessTest.java
@@ -215,7 +215,7 @@ public class NAProcessTest extends ProcessTestBase {
         CSVFileReader reader = new CSVFileReader(new File(csvFile), getController().getAppConfig(), true, false);
         reader.open();
         assertEquals(1, reader.getTotalRows());
-        String fieldValue = (String)reader.readRow().get(fieldName);
+        String fieldValue = (String)reader.readTableRow().get(fieldName);
         reader.close();
         return fieldValue;
     }

--- a/src/test/java/com/salesforce/dataloader/process/ProcessExtractTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessExtractTestBase.java
@@ -43,8 +43,7 @@ import com.salesforce.dataloader.dao.DataReader;
 import com.salesforce.dataloader.dao.csv.CSVFileReader;
 import com.salesforce.dataloader.exception.DataAccessObjectException;
 import com.salesforce.dataloader.exception.ProcessInitializationException;
-import com.salesforce.dataloader.model.Row;
-import com.sforce.soap.partner.SaveResult;
+import com.salesforce.dataloader.model.TableRow;
 import com.sforce.soap.partner.sobject.SObject;
 import com.sforce.ws.ConnectionException;
 
@@ -156,9 +155,9 @@ public abstract class ProcessExtractTestBase extends ProcessTestBase {
             resultReader.open();
 
             // go through item by item and assert that it's there
-            Row row;
+            TableRow row;
             int currentRow = 0;
-            while ((row = resultReader.readRow()) != null) {
+            while ((row = resultReader.readTableRow()) != null) {
                 final String resultId = (String)row.get(AppConfig.ID_COLUMN_NAME);
                 assertValidId(resultId);
                 String resultPhone = (String)row.get("Phone");
@@ -272,9 +271,9 @@ public abstract class ProcessExtractTestBase extends ProcessTestBase {
                 resultReader.open();
 
                 // go through item by item and assert that it's there
-                Row row;
+                TableRow row;
                 int rowIdx = 0;
-                while ((row = resultReader.readRow()) != null) {
+                while ((row = resultReader.readTableRow()) != null) {
                     final String resultId = (String)row.get(AppConfig.ID_COLUMN_NAME);
                     assertValidId(resultId);
                     assertEquals(resultId, testFieldIds[rowIdx]);
@@ -364,7 +363,7 @@ public abstract class ProcessExtractTestBase extends ProcessTestBase {
         runProcess(argMap, 1);
         final CSVFileReader resultReader = new CSVFileReader(new File(argMap.get(AppConfig.PROP_DAO_NAME)), getController().getAppConfig(), true, false);
         try {
-            final Row resultRow = resultReader.readRow();
+            final TableRow resultRow = resultReader.readTableRow();
             assertEquals("Query returned incorrect Contact ID", contactId, resultRow.get("CONTACT_ID"));
             assertEquals("Query returned incorrect Contact Name", "First 000000 Last 000000",
                     resultRow.get("CONTACT_NAME"));
@@ -463,7 +462,8 @@ public abstract class ProcessExtractTestBase extends ProcessTestBase {
             runProcess(argMap, 1, true);
             final CSVFileReader resultReader = new CSVFileReader(new File(argMap.get(AppConfig.PROP_DAO_NAME)), getController().getAppConfig(), true, false);
             try {
-                assertEquals(String.valueOf(numRecords - 1), resultReader.readRow().get("MAX(NUMBEROFEMPLOYEES)"));
+                String maxNumEmployees = (String)resultReader.readTableRow().get("MAX(NUMBEROFEMPLOYEES)");
+                assertEquals(String.valueOf(numRecords - 1), maxNumEmployees);
             } finally {
                 resultReader.close();
             }

--- a/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
+++ b/src/test/java/com/salesforce/dataloader/process/ProcessTestBase.java
@@ -52,7 +52,6 @@ import com.salesforce.dataloader.dao.csv.CSVFileWriter;
 import com.salesforce.dataloader.dyna.SforceDynaBean;
 import com.salesforce.dataloader.exception.*;
 import com.salesforce.dataloader.exception.UnsupportedOperationException;
-import com.salesforce.dataloader.model.Row;
 import com.salesforce.dataloader.model.TableRow;
 import com.salesforce.dataloader.util.AppUtil;
 import com.salesforce.dataloader.util.Base64;
@@ -791,7 +790,7 @@ public abstract class ProcessTestBase extends ConfigTestBase {
         assertNumRowsInCSVFile(successFile, numInserts + numUpdates);
         boolean isBulkV2Operation = ctl.getAppConfig().isBulkV2APIEnabled();
 
-        Row row = null;
+        TableRow row = null;
         CSVFileReader rdr = new CSVFileReader(new File(successFile), getController().getAppConfig(), true, false);
         String expectedUpdateStatusVal = UPDATE_MSGS.get(ctl.getAppConfig().getOperationInfo());
         String expectedInsertStatusVal = INSERT_MSG;
@@ -801,7 +800,7 @@ public abstract class ProcessTestBase extends ConfigTestBase {
         }
         int insertsFound = 0;
         int updatesFound = 0;
-        while ((row = rdr.readRow()) != null) {
+        while ((row = rdr.readTableRow()) != null) {
             String id = (String)row.get(AppConfig.ID_COLUMN_NAME);
             if (id == null) {
                 id = (String)row.get(AppConfig.ID_COLUMN_NAME_IN_BULKV2);


### PR DESCRIPTION
increase TableRow direct use - replace readRow() with readTableRow() in DataReader interface and its implementations - CsvFileReader and DatabaeReader.