### PR TITLE
reduce memory use by using TableRow instead of Row

### DIFF
--- a/src/main/java/com/salesforce/dataloader/action/AbstractLoadAction.java
+++ b/src/main/java/com/salesforce/dataloader/action/AbstractLoadAction.java
@@ -28,7 +28,6 @@ package com.salesforce.dataloader.action;
 
 import com.salesforce.dataloader.action.progress.ILoaderProgress;
 import com.salesforce.dataloader.action.visitor.DAOLoadVisitor;
-import com.salesforce.dataloader.client.PartnerClient;
 import com.salesforce.dataloader.config.AppConfig;
 import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.dao.DataAccessObject;
@@ -40,17 +39,11 @@ import com.salesforce.dataloader.exception.MappingInitializationException;
 import com.salesforce.dataloader.exception.OperationException;
 import com.salesforce.dataloader.exception.ParameterLoadException;
 import com.salesforce.dataloader.mapping.LoadMapper;
-import com.salesforce.dataloader.model.Row;
 import com.salesforce.dataloader.model.TableRow;
 import com.salesforce.dataloader.util.DAORowUtil;
-import com.sforce.soap.partner.DescribeGlobalSObjectResult;
-import com.sforce.soap.partner.DescribeSObjectResult;
-import com.sforce.soap.partner.Field;
-import com.sforce.soap.partner.FieldType;
 import com.sforce.ws.ConnectionException;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author Lexi Viripaeff

--- a/src/main/java/com/salesforce/dataloader/action/visitor/AbstractVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/AbstractVisitor.java
@@ -32,7 +32,7 @@ import com.salesforce.dataloader.controller.Controller;
 import com.salesforce.dataloader.dao.DataWriter;
 import com.salesforce.dataloader.exception.DataAccessObjectException;
 import com.salesforce.dataloader.mapping.Mapper;
-import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
 import com.salesforce.dataloader.util.LoadRateCalculator;
 import org.apache.logging.log4j.Logger;
 
@@ -131,7 +131,7 @@ public abstract class AbstractVisitor implements IVisitor {
     	return this.successWriter;
     }
 
-    protected void writeSuccess(Row row, String id, String message) throws DataAccessObjectException {
+    protected void writeSuccess(TableRow row, String id, String message) throws DataAccessObjectException {
         if (writeStatus()) {
             if (id != null && id.length() > 0) {
                 row.put(AppConfig.ID_COLUMN_NAME, id);
@@ -139,19 +139,19 @@ public abstract class AbstractVisitor implements IVisitor {
             if (message != null && message.length() > 0) {
                 row.put(AppConfig.STATUS_COLUMN_NAME, message);
             }
-            this.successWriter.writeRow(row);
+            this.successWriter.writeTableRow(row);
         }
         addSuccess();
     }
 
-    protected void writeError(Row row, String errorMessage) throws DataAccessObjectException {
+    protected void writeError(TableRow row, String errorMessage) throws DataAccessObjectException {
         if (writeStatus()) {
             if (row == null) {
-                row = Row.singleEntryImmutableRow(AppConfig.ERROR_COLUMN_NAME, errorMessage);
+                row = TableRow.singleEntryImmutableRow(AppConfig.ERROR_COLUMN_NAME, errorMessage);
             } else {
                 row.put(AppConfig.ERROR_COLUMN_NAME, errorMessage);
             }
-            this.errorWriter.writeRow(row);
+            this.errorWriter.writeTableRow(row);
         }
         addErrors();
     }

--- a/src/main/java/com/salesforce/dataloader/action/visitor/partner/PartnerLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/partner/PartnerLoadVisitor.java
@@ -28,7 +28,8 @@ package com.salesforce.dataloader.action.visitor.partner;
 
 import java.util.List;
 
-import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
+
 import org.apache.commons.beanutils.DynaBean;
 
 import com.salesforce.dataloader.action.OperationInfo;
@@ -115,7 +116,7 @@ public abstract class PartnerLoadVisitor extends DAOLoadVisitor {
         // are a) not the same class yet b) not subclassed
         int batchRowCounter = 0;
         for (int i = 0; i < this.daoRowList.size(); i++) {
-            Row daoRow = this.daoRowList.get(i).convertToRow();
+            TableRow daoRow = this.daoRowList.get(i);
             if (!isRowConversionSuccessful()) {
                 continue;
             }

--- a/src/main/java/com/salesforce/dataloader/action/visitor/rest/RESTLoadVisitor.java
+++ b/src/main/java/com/salesforce/dataloader/action/visitor/rest/RESTLoadVisitor.java
@@ -42,6 +42,7 @@ import com.salesforce.dataloader.exception.DataAccessObjectException;
 import com.salesforce.dataloader.exception.LoadException;
 import com.salesforce.dataloader.exception.OperationException;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
 import com.sforce.soap.partner.SaveResult;
 import com.sforce.soap.partner.fault.ApiFault;
 import com.sforce.ws.ConnectionException;
@@ -82,7 +83,7 @@ public abstract class RESTLoadVisitor extends DAOLoadVisitor {
         // are a) not the same class yet b) not subclassed
         int batchRowCounter = 0;
         for (int i = 0; i < this.daoRowList.size(); i++) {
-            Row daoRow = this.daoRowList.get(i).convertToRow();
+            TableRow daoRow = this.daoRowList.get(i);
             if (!isRowConversionSuccessful()) {
                 continue;
             }

--- a/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
+++ b/src/main/java/com/salesforce/dataloader/client/PartnerClient.java
@@ -44,7 +44,7 @@ import com.salesforce.dataloader.exception.ParameterLoadException;
 import com.salesforce.dataloader.exception.PasswordExpiredException;
 import com.salesforce.dataloader.exception.RelationshipFormatException;
 import com.salesforce.dataloader.mapping.LoadMapper;
-import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
 import com.salesforce.dataloader.util.AppUtil;
 import com.sforce.soap.partner.Connector;
 import com.sforce.soap.partner.DeleteResult;
@@ -942,13 +942,13 @@ public class PartnerClient extends ClientBase<PartnerConnection> {
         return result;
     }
     
-    public Field[] getSObjectFieldAttributesForRow(String sObjectName, Row dataRow) throws ConnectionException {
+    public Field[] getSObjectFieldAttributesForRow(String sObjectName, TableRow dataRow) throws ConnectionException {
         ArrayList<Field> attributesForRow = new ArrayList<Field>();
         DescribeSObjectResult entityDescribe = describeSObject(sObjectName);
-        for (Map.Entry<String, Object> dataRowField : dataRow.entrySet()) {
+        for (String headerColumnName : dataRow.getHeader().getColumns()) {
             Field[] fieldAttributesArray = entityDescribe.getFields();
             for (Field fieldAttributes : fieldAttributesArray) {
-                if (fieldAttributes.getName().equalsIgnoreCase(dataRowField.getKey())) {
+                if (fieldAttributes.getName().equalsIgnoreCase(headerColumnName)) {
                     attributesForRow.add(fieldAttributes);
                 }
             }

--- a/src/main/java/com/salesforce/dataloader/dao/DataWriter.java
+++ b/src/main/java/com/salesforce/dataloader/dao/DataWriter.java
@@ -55,6 +55,7 @@ public interface DataWriter extends DataAccessObject {
      * @throws DataAccessObjectException
      */
     boolean writeRow(Row inputRow) throws DataAccessObjectException;
+    boolean writeTableRow(TableRow inputRow) throws DataAccessObjectException;
 
     /**
      * @param inputRowList

--- a/src/main/java/com/salesforce/dataloader/dao/database/DatabaseReader.java
+++ b/src/main/java/com/salesforce/dataloader/dao/database/DatabaseReader.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.sql.*;
 import java.util.*;
 
-import com.salesforce.dataloader.model.TableHeader;
 import com.salesforce.dataloader.model.TableRow;
 
 import org.apache.commons.dbcp2.BasicDataSource;
@@ -55,8 +54,6 @@ public class DatabaseReader extends AbstractDataReaderImpl {
     private static Logger logger = DLLogManager.getLogger(DatabaseReader.class);
 
     private final BasicDataSource dataSource;
-    private List<String> headerRow = new ArrayList<String>();
-    private TableHeader tableHeader;
     private final SqlConfig sqlConfig;
     private final DatabaseContext dbContext;
     private boolean endOfTableReached = false;
@@ -85,11 +82,6 @@ public class DatabaseReader extends AbstractDataReaderImpl {
         this.dataSource = dbConfig.getDataSource();
         this.sqlConfig = dbConfig.getSqlConfig();
         this.dbContext = new DatabaseContext(dbConfigName);
-        this.headerRow = sqlConfig.getColumnNames();
-        if(headerRow == null) {
-            headerRow = new ArrayList<String>();
-        }
-        tableHeader = new TableHeader(headerRow);
     }
 
     /*
@@ -189,9 +181,9 @@ public class DatabaseReader extends AbstractDataReaderImpl {
             TableRow trow = null;
             ResultSet rs = dbContext.getDataResultSet();
             if (rs != null && rs.next()) {
-                trow = new TableRow(tableHeader);
+                trow = new TableRow(getTableHeader());
 
-                for (String columnName : headerRow) {
+                for (String columnName : getColumnNames()) {
                     currentColumnName = columnName;
                     Object value = rs.getObject(columnName);
                     trow.put(columnName, value);
@@ -217,11 +209,6 @@ public class DatabaseReader extends AbstractDataReaderImpl {
         }
     }
 
-    @Override
-    public List<String> getColumnNames() {
-        return headerRow;
-    }
-
     /*
      * (non-Javadoc)
      * @see com.salesforce.dataloader.dao.DataAccessObject#checkConnection()
@@ -245,5 +232,14 @@ public class DatabaseReader extends AbstractDataReaderImpl {
             return 0;
         }
         return super.getTotalRows();
+    }
+
+    @Override
+    protected List<String> initializeDaoColumnsList() {
+        List<String> daoColsList = sqlConfig.getColumnNames();
+        if(daoColsList == null) {
+            daoColsList = new ArrayList<String>();
+        }
+       return daoColsList;
     }
 }

--- a/src/main/java/com/salesforce/dataloader/mapping/Mapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/Mapper.java
@@ -55,6 +55,7 @@ import com.salesforce.dataloader.dyna.ParentIdLookupFieldFormatter;
 import com.salesforce.dataloader.dyna.ParentSObjectFormatter;
 import com.salesforce.dataloader.exception.MappingInitializationException;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
 import com.salesforce.dataloader.util.AppUtil;
 import com.salesforce.dataloader.util.OrderedProperties;
 
@@ -249,8 +250,10 @@ public abstract class Mapper {
         return constantVal.substring(1, constantVal.length() - 1);
     }
 
-    protected void mapConstants(Row rowMap) {
-        rowMap.putAll(constants);
+    protected void mapConstants(TableRow row) {
+        for (String constKey : constants.keySet()) {
+            row.put(constKey, constants.get(constKey));
+        }
     }
 
     private Properties loadProperties(String fileName) throws MappingInitializationException {

--- a/src/main/java/com/salesforce/dataloader/mapping/SOQLMapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/SOQLMapper.java
@@ -31,6 +31,7 @@ import com.salesforce.dataloader.exception.MappingInitializationException;
 import com.salesforce.dataloader.mapping.SOQLInfo.SOQLFieldInfo;
 import com.salesforce.dataloader.mapping.SOQLInfo.SOQLParserException;
 import com.salesforce.dataloader.model.Row;
+import com.salesforce.dataloader.model.TableRow;
 import com.sforce.soap.partner.DescribeSObjectResult;
 import com.sforce.soap.partner.Field;
 import com.sforce.soap.partner.FieldType;
@@ -191,6 +192,13 @@ public class SOQLMapper extends Mapper {
         }
         mapConstants(resultRow);
         return resultRow;
+    }
+    
+
+    protected void mapConstants(Row row) {
+        for (String constKey : getConstantsMap().keySet()) {
+            row.put(constKey, getConstantsMap().get(constKey));
+        }
     }
     
     public boolean parseSoql(String soql) throws InvalidMappingException {

--- a/src/main/java/com/salesforce/dataloader/model/Row.java
+++ b/src/main/java/com/salesforce/dataloader/model/Row.java
@@ -25,6 +25,7 @@
  */
 package com.salesforce.dataloader.model;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -141,5 +142,13 @@ public class Row implements Map<String, Object> {
                 " size=" + internalMap.size() +
                 " columns=" + internalMap +
                 '}';
+    }
+    
+    public TableRow convertToTableRow(TableHeader header) {
+        TableRow trow = new TableRow(header);
+        for (String headerColName : header.getColumns()) {
+            trow.put(headerColName, this.get(headerColName));
+        }
+        return trow;
     }
 }

--- a/src/test/java/com/salesforce/dataloader/mapping/LoadMapperTest.java
+++ b/src/test/java/com/salesforce/dataloader/mapping/LoadMapperTest.java
@@ -154,7 +154,7 @@ public class LoadMapperTest extends ConfigTestBase {
         mappings.setProperty("", "Value6");
         LoadMapper mapper = new LoadMapper(null, null, null, null);
         mapper.putPropertyFileMappings(mappings);
-        Row result = mapper.mapData(TableRow.emptyRow());
+        TableRow result = mapper.mapData(TableRow.emptyRow(), true);
         assertEquals(constantValue, result.get("Name"));
         assertEquals(constantValue, result.get("field1__c"));
         assertEquals(constantValue, result.get("field2__c"));
@@ -200,7 +200,7 @@ public class LoadMapperTest extends ConfigTestBase {
 
         //(src, dest).
         mapper.putMapping(csvFieldName, sfdcField);
-        Map<String, Object> result = mapper.mapData(input);
+        TableRow result = mapper.mapData(input, true);
 
         //verify that the old value holds
         assertEquals(constantValue, result.get(sfdcField));
@@ -235,7 +235,7 @@ public class LoadMapperTest extends ConfigTestBase {
 
         TableRow input = TableRow.singleEntryImmutableRow(constantValue, sfdcField);
 
-        Map<String, Object> result = mapper.mapData(input);
+        TableRow result = mapper.mapData(input, true);
 
         //verify that the old value holds
         assertEquals(constantValue, result.get(sfdcField));
@@ -248,9 +248,8 @@ public class LoadMapperTest extends ConfigTestBase {
 
         TableRow inputData = TableRow.singleEntryImmutableRow("SOURCE_COL", "123");
 
-        Map<String, Object> result = loadMapper.mapData(inputData);
-
-        assertTrue("Empty destination column should have not been mapped", result.isEmpty());
+        TableRow result = loadMapper.mapData(inputData, true);
+        assertTrue("Empty destination column should have not been mapped", result.getNonEmptyCellsCount() == 0);
     }
 
     @Test
@@ -276,7 +275,7 @@ public class LoadMapperTest extends ConfigTestBase {
      * Helper method to verify that the LoadMapper has mapped the specified columns to their correct respective field, along with any constants in the mapping file.
      */
     private void verifyMapping(LoadMapper mapper, String... destNames) {
-        Row destValueMap = mapper.mapData(this.sourceRow);
+        TableRow destValueMap = mapper.mapData(this.sourceRow, true);
         for (int i = 0; i < destNames.length; i++) {
             assertNotNull("Destination# " + i + "(" + destNames[i]
                     + ") should have a mapped value",


### PR DESCRIPTION
More extensively use TableRow by replacing Row usage. This leads to about 100% reduction in memory use for large loads.