### PR TITLE
config property to output csv files in a specific charset

### DIFF
--- a/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileWriter.java
+++ b/src/main/java/com/salesforce/dataloader/dao/csv/CSVFileWriter.java
@@ -132,7 +132,7 @@ public class CSVFileWriter implements DataWriter {
     private byte[] getBOM() {
         if (StandardCharsets.UTF_8.equals(Charset.forName(this.encoding))) {
             return new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
-        } else if (StandardCharsets.UTF_16.equals(Charset.forName(this.encoding))) {
+        } else if (this.encoding.startsWith(StandardCharsets.UTF_16.name())) {
             return new byte[]{(byte) 0xFE, (byte) 0xFF};
         }
         return new byte[0];

--- a/src/main/resources/labels.properties
+++ b/src/main/resources/labels.properties
@@ -482,6 +482,7 @@ AppConfig.property.description.sfdc.extraction.allCapsHeaders=set it to "true" t
 AppConfig.property.description.sfdc.extraction.outputByteOrderMark=set to "true" by default. When set to "true", it writes Byte Order Mark (BOM) character if the CSV file is created in UTF-8 format.
 AppConfig.property.description.config.properties.readonly=Do not modify config.properties file even if the user makes changes through Settings dialog.
 AppConfig.property.description.dataAccess.readCharset=Override system default charset by specifying charset to use for import operations. Set it to UTF-8, UTF-16BE, UTF-16LE, UTF-32BE, or UTF-32LE to handle import CSVs with Byte Order Mark (BOM) character.
+AppConfig.property.description.dataAccess.writeCharset=Override system default charset by specifying charset to use for export operations. Set it to UTF-8 or UTF-16 to write export CSVs with Byte Order Mark (BOM) character.
 AppConfig.property.description.loader.cacheSObjectNamesAndField=Cache object names and fields metadata across multiple operations. Applicable in the UI mode because batch mode executes one operation and stops.
 AppConfig.property.description.sfdc.timezone=Details documented at https://developer.salesforce.com/docs/atlas.en-us.dataLoader.meta/dataLoader/configuring_the_data_loader.htm
 AppConfig.property.description.process.outputSuccess=Details documented at https://developer.salesforce.com/docs/atlas.en-us.dataLoader.meta/dataLoader/loader_params.htm

--- a/src/test/java/com/salesforce/dataloader/dao/CsvTest.java
+++ b/src/test/java/com/salesforce/dataloader/dao/CsvTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.salesforce.dataloader.ConfigTestBase;
@@ -131,6 +132,41 @@ public class CsvTest extends ConfigTestBase {
     }
     
     @Test
+    public void testCSVWriteUTF8BOMBasic() throws Exception{
+        getController().getAppConfig().setValue(AppConfig.PROP_READ_CHARSET, "UTF-8");
+        getController().getAppConfig().setValue(AppConfig.PROP_WRITE_CHARSET, "UTF-8");
+        doTestCSVWriteBasic(AppUtil.COMMA);
+    }
+    
+    @Test
+    public void testCSVWriteUTF16LEBOMBasic() throws Exception{
+        getController().getAppConfig().setValue(AppConfig.PROP_READ_CHARSET, "UTF-16LE");
+        getController().getAppConfig().setValue(AppConfig.PROP_WRITE_CHARSET, "UTF-16LE");
+        doTestCSVWriteBasic(AppUtil.COMMA);
+    }
+    
+    @Test
+    public void testCSVWriteUTF16BEBOMBasic() throws Exception{
+        getController().getAppConfig().setValue(AppConfig.PROP_READ_CHARSET, "UTF-16BE");
+        getController().getAppConfig().setValue(AppConfig.PROP_WRITE_CHARSET, "UTF-16BE");
+        doTestCSVWriteBasic(AppUtil.COMMA);
+    }   
+    
+    @Test
+    public void testCSVWriteUTF32LEBOMBasic() throws Exception{
+        getController().getAppConfig().setValue(AppConfig.PROP_READ_CHARSET, "UTF-32LE");
+        getController().getAppConfig().setValue(AppConfig.PROP_WRITE_CHARSET, "UTF-32LE");
+        doTestCSVWriteBasic(AppUtil.COMMA);
+    }
+    
+    @Test
+    public void testCSVWriteUTF32BEBOMBasic() throws Exception{
+        getController().getAppConfig().setValue(AppConfig.PROP_READ_CHARSET, "UTF-32BE");
+        getController().getAppConfig().setValue(AppConfig.PROP_WRITE_CHARSET, "UTF-32BE");
+        doTestCSVWriteBasic(AppUtil.COMMA);
+    }
+    
+    @Test
     public void testCSVWriteBasicWithDashDelimiter() throws Exception {
         doTestCSVWriteBasic("-");
     }
@@ -145,8 +181,9 @@ public class CsvTest extends ConfigTestBase {
         doTestCSVWriteBasic(AppUtil.TAB);
     }
     
+    private String writeCSVFilename = getTestDataDir() + "/csvtestTemp.csv";
     private void doTestCSVWriteBasic(String delimiter) throws Exception {
-        File f = new File(getTestDataDir(), "csvtestTemp.csv");
+        File f = new File(writeCSVFilename);
         String path = f.getAbsolutePath();
         CSVFileWriter writer = new CSVFileWriter(path, getController().getAppConfig(), delimiter);
         List<RowInterface> rowList = new ArrayList<RowInterface>();


### PR DESCRIPTION
config property "dataAccess.writeCharset" to output csv files in a specific charset and CSV BOM (Byte Order Mark) if charset supports CSV BOM (UTF-8, UTF-16LE, UTF-16BE, UTF-32LE, UTF_32BE).