### PR TITLE
RTF field value formatting improvements

### DIFF
--- a/src/test/java/com/salesforce/dataloader/dao/RichTextHTMLEncodingTest.java
+++ b/src/test/java/com/salesforce/dataloader/dao/RichTextHTMLEncodingTest.java
@@ -172,6 +172,22 @@ public class RichTextHTMLEncodingTest extends ConfigTestBase {
     }
     
     @Test
+    public void testHTMLTagsAndLineBreaks() throws Exception {    
+        String origText = "1\n2\r\n3\r<p>a</p><p>b</p><p>c</p>";
+        String convertedText = DAOLoadVisitor.preserveWhitespaceInRichText(origText, regex);
+        // preserveWhitespaceInRichText() should convert newline chars into a space char ' '
+        assertEquals("Incorrect conversion of " + origText, origText.length(), convertedText.length()+1);
+    }
+    
+    @Test
+    public void testNoHTMLTagsAndLineBreaks() throws Exception {    
+        String origText = "1\n2\r\n3\r";
+        String convertedText = DAOLoadVisitor.preserveWhitespaceInRichText(origText, regex);
+        // preserveWhitespaceInRichText() should convert newline chars into html tag "<br/>"
+        assertEquals("Incorrect conversion of " + origText, origText.length(), convertedText.length()-11);
+    }
+    
+    @Test
     public void testHTMLEncodedString() throws Exception {
         String origText = "  &amp; & < * $ ~ % &quot;6400L -37° &#127752; \n1  \r2  \r\n3";
         String convertedText = DAOLoadVisitor.preserveWhitespaceInRichText(origText, regex);


### PR DESCRIPTION
- replace line break characters with `"<br/>"` if the field value does not contain any HTML formatting.
- Replace line break characters with a single half-width space character if the field value contains HTML formatting.
- Use unicode based check of characters in the field value to detect and replace consecutive whitespace chars with non-breaking space char `'&nbsp;'`.