### PR TITLE
trim leading and trailing whitespace chars in idlookup fields during …

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/AppConfig.java
+++ b/src/main/java/com/salesforce/dataloader/config/AppConfig.java
@@ -339,6 +339,7 @@ public class AppConfig {
     public static final String PROP_EXTRACT_ALL_CAPS_HEADERS="sfdc.extraction.allCapsHeaders";
     public static final String PROP_EXTRACT_CSV_OUTPUT_BOM="sfdc.extraction.outputByteOrderMark";
     public static final String PROP_LOAD_PRESERVE_WHITESPACE_IN_RICH_TEXT = "sfdc.load.preserveWhitespaceInRichText";
+    public static final String PROP_LOAD_REMOVE_NONBREAKING_SPACE_IN_IDLOOKUP_FIELD="sfdc.load.removeNonBreakingSpaceInIdLookupField";
 
     //
     // process configuration (action parameters)
@@ -787,7 +788,7 @@ public class AppConfig {
         setDefaultValue(PROP_SAVE_ALL_PROPS, false);
         setDefaultValue(PROP_EXTRACT_ALL_CAPS_HEADERS, false);
         setDefaultValue(PROP_EXTRACT_CSV_OUTPUT_BOM, true);
-        
+        setDefaultValue(PROP_LOAD_REMOVE_NONBREAKING_SPACE_IN_IDLOOKUP_FIELD, true);
     }
 
     /**


### PR DESCRIPTION
…uploads

trim leading and trailing whitespace chars in idlookup fields during uploads if sfdc.load.removeNonBreakingSpaceInIdLookupField is set to true (default is true). This is to work around server side not handling leading and trailing full-width space chars in the same way as half-width space chars.