### PR TITLE
trim leading and trailing whitespace chars in relationship lookup

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/AppConfig.java
+++ b/src/main/java/com/salesforce/dataloader/config/AppConfig.java
@@ -339,7 +339,7 @@ public class AppConfig {
     public static final String PROP_EXTRACT_ALL_CAPS_HEADERS="sfdc.extraction.allCapsHeaders";
     public static final String PROP_EXTRACT_CSV_OUTPUT_BOM="sfdc.extraction.outputByteOrderMark";
     public static final String PROP_LOAD_PRESERVE_WHITESPACE_IN_RICH_TEXT = "sfdc.load.preserveWhitespaceInRichText";
-    public static final String PROP_LOAD_REMOVE_NONBREAKING_SPACE_IN_IDLOOKUP_FIELD="sfdc.load.removeNonBreakingSpaceInIdLookupField";
+    public static final String PROP_LOAD_REMOVE_LEADING_TRAILING_WHITESPACE_IN_IDLOOKUP_FIELD="sfdc.load.removeLeadingTrailingWhitepaceInIdLookupField";
 
     //
     // process configuration (action parameters)
@@ -788,7 +788,7 @@ public class AppConfig {
         setDefaultValue(PROP_SAVE_ALL_PROPS, false);
         setDefaultValue(PROP_EXTRACT_ALL_CAPS_HEADERS, false);
         setDefaultValue(PROP_EXTRACT_CSV_OUTPUT_BOM, true);
-        setDefaultValue(PROP_LOAD_REMOVE_NONBREAKING_SPACE_IN_IDLOOKUP_FIELD, true);
+        setDefaultValue(PROP_LOAD_REMOVE_LEADING_TRAILING_WHITESPACE_IN_IDLOOKUP_FIELD, true);
     }
 
     /**

--- a/src/test/resources/testfiles/data/insertTaskWithContactAsWhoCsv.csv
+++ b/src/test/resources/testfiles/data/insertTaskWithContactAsWhoCsv.csv
@@ -1,2 +1,2 @@
 Subject,Who:Contact-email
-testPolymorphicLookup,contactFor@PolymorphicMappingOfTask.com
+testPolymorphicLookup," contactFor@PolymorphicMappingOfTask.com　 　"

--- a/src/test/resources/testfiles/data/upsertAccountCsvTemplate.csv
+++ b/src/test/resources/testfiles/data/upsertAccountCsvTemplate.csv
@@ -1,5 +1,5 @@
 NAME,TYPE,PHONE,ACCOUNTNUMBER__C,WEBSITE,ANNUALREVENUE,ORACLE_ID__C
-account Upsert #0,Account,415-555-0000,ACCT_0,http://www.accountUpsert0.com,0,1-000000
+account Upsert #0,Account,415-555-0000,ACCT_0,http://www.accountUpsert0.com,0,"　 　1-000000　 　"
 account Upsert #1,Account,415-555-0001,ACCT_1,http://www.accountUpsert1.com,1000,1-000001
 account Upsert #2,Account,415-555-0002,ACCT_2,http://www.accountUpsert2.com,2000,1-000002
 account Upsert #3,Account,415-555-0003,ACCT_3,http://www.accountUpsert3.com,3000,1-000003

--- a/src/test/resources/testfiles/data/upsertAccountSmallTemplate.csv
+++ b/src/test/resources/testfiles/data/upsertAccountSmallTemplate.csv
@@ -1,5 +1,5 @@
 NAME,TYPE,PHONE,ACCOUNTNUMBER__C,WEBSITE,ANNUALREVENUE,ORACLE_ID__C
-account Upsert #0,Account,415-555-0000,ACCT_0,http://www.accountUpsert0.com,0,1-000000
+account Upsert #0,Account,415-555-0000,ACCT_0,http://www.accountUpsert0.com,0,"　 　1-000000　 　"
 account Upsert #1,Account,415-555-0001,ACCT_1,http://www.accountUpsert1.com,1000,1-000001
 account Upsert #2,Account,415-555-0002,ACCT_2,http://www.accountUpsert2.com,2000,1-000002
 account Upsert #3,Account,415-555-0003,ACCT_3,http://www.accountUpsert3.com,3000,1-000003


### PR DESCRIPTION
trim leading and trailing whitespace chars in idlookup field of a relationship during uploads if sfdc.load.removeNonBreakingSpaceInIdLookupField is set to true (default is true). This is to work around server side not handling leading and trailing full-width space chars in the same way as half-width space chars.