### PR TITLE
Fix W-17702537 - handle csv column name containing ',' char correctly

### DIFF
--- a/src/main/java/com/salesforce/dataloader/mapping/LoadMapper.java
+++ b/src/main/java/com/salesforce/dataloader/mapping/LoadMapper.java
@@ -70,7 +70,7 @@ public class LoadMapper extends Mapper {
         String sfdc = (String)entry.getValue();
         if (isConstant(dao))
             putConstant(sfdc, dao);
-        else if (!hasDaoColumns() || hasDaoColumn(dao)) putMapping(dao, sfdc);
+        else if (!hasDaoColumns() || hasDaoColumn(dao)) putMapping(dao, sfdc, true);
     }
 
     public Map<String, String> getMappingWithUnmappedColumns(boolean includeUnmapped) {

--- a/src/test/java/com/salesforce/dataloader/mapping/LoadMapperTest.java
+++ b/src/test/java/com/salesforce/dataloader/mapping/LoadMapperTest.java
@@ -283,7 +283,7 @@ public class LoadMapperTest extends ConfigTestBase {
         }
         LoadMapper loadMapper = new LoadMapper(getController().getPartnerClient(), null, fields, null);
         loadMapper.putMapping(SOURCE_NAMES[0] + "," + SOURCE_NAMES[1],
-               DEST_NAMES[0] + "," + DEST_NAMES[1]);
+               DEST_NAMES[0] + "," + DEST_NAMES[1], true);
         TableRow destValueRow = loadMapper.mapData(this.sourceRow, true);
         String expectedDestValue = this.sourceRow.get(SOURCE_NAMES[0]) + ", " + this.sourceRow.get(SOURCE_NAMES[1]);
         assertEquals(destValueRow.get(DEST_NAMES[0]), expectedDestValue);


### PR DESCRIPTION
W-17702537 - handle csv column name containing ',' char correctly