### PR TITLE
check for newer versions of data loader only if running in UI or Batc…

### DIFF
--- a/src/main/java/com/salesforce/dataloader/controller/Controller.java
+++ b/src/main/java/com/salesforce/dataloader/controller/Controller.java
@@ -137,7 +137,8 @@ public class Controller {
         if (daoFactory == null) {
             daoFactory = new DataAccessObjectFactory();
         }
-        if (AppUtil.getAppRunMode() != AppUtil.APP_RUN_MODE.INSTALL) {
+        if (AppUtil.getAppRunMode() == AppUtil.APP_RUN_MODE.UI
+                || AppUtil.getAppRunMode() == AppUtil.APP_RUN_MODE.BATCH) {
             getLatestDownloadableDataLoaderVersion();
         }
     }


### PR DESCRIPTION
…h mode

check for newer versions of data loader only if running in UI or Batch mode, thereby skipping the check during installation or key encryption/decryption modes.