### PR TITLE
code cleanup - refactor

### DIFF
--- a/src/main/java/com/salesforce/dataloader/config/AppConfig.java
+++ b/src/main/java/com/salesforce/dataloader/config/AppConfig.java
@@ -1897,11 +1897,9 @@ public class AppConfig {
         System.setProperty(CLI_OPTION_CONFIG_DIR_PROP, AppConfig.configurationsDir);
     }
 
-    private static synchronized String[] initializeAppConfig(String[] args) throws FactoryConfigurationError, IOException, ConfigInitializationException {
-        Map<String, String> argsMap = AppUtil.convertCommandArgsArrayToArgMap(args);
+    private static synchronized void initializeAppConfig(Map<String, String> argsMap) throws FactoryConfigurationError, IOException, ConfigInitializationException {
         AppConfig.setConfigurationsDir(argsMap);
         LoggingUtil.initializeLog(argsMap);
-        return AppUtil.convertCommandArgsMapToArgsArray(argsMap);
     }
 
     /**
@@ -1940,7 +1938,7 @@ public class AppConfig {
         if (argMap.isEmpty()) {
             logger.debug("No arguments provided to initialize AppConfig. Loading default configuration.");
         }
-        AppConfig.initializeAppConfig(AppUtil.convertCommandArgsMapToArgsArray(argMap));
+        AppConfig.initializeAppConfig(argMap);
 
         String configurationsDirPath = AppConfig.getConfigurationsDir();
         File configurationsDir;

--- a/src/main/java/com/salesforce/dataloader/security/EncryptionUtil.java
+++ b/src/main/java/com/salesforce/dataloader/security/EncryptionUtil.java
@@ -29,7 +29,6 @@ import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import com.salesforce.dataloader.util.AppUtil;
 

--- a/src/test/java/com/salesforce/dataloader/util/AppUtilTest.java
+++ b/src/test/java/com/salesforce/dataloader/util/AppUtilTest.java
@@ -28,7 +28,6 @@ package com.salesforce.dataloader.util;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +36,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.salesforce.dataloader.ConfigTestBase;
+import com.salesforce.dataloader.process.DataLoaderRunner;
 
 public class AppUtilTest extends ConfigTestBase {    
     @Test
@@ -64,18 +64,9 @@ public class AppUtilTest extends ConfigTestBase {
     @Test
     public void testConvertCommandArgsArrayToArgMap() {
         String[] args = {"key1=value1", "key2=value2"};
-        Map<String, String> argMap = AppUtil.convertCommandArgsArrayToArgMap(args);
+        Map<String, String> argMap = DataLoaderRunner.configureRunModeAndGetArgsMap(args);
         Assert.assertEquals("value1", argMap.get("key1"));
         Assert.assertEquals("value2", argMap.get("key2"));
-    }
-
-    @Test
-    public void testConvertCommandArgsMapToArgsArray() {
-        Map<String, String> argMap = new HashMap<>();
-        argMap.put("key1", "value1");
-        argMap.put("key2", "value2");
-        String[] argsArray = AppUtil.convertCommandArgsMapToArgsArray(argMap);
-        Assert.assertArrayEquals(new String[]{"key1=value1", "key2=value2"}, argsArray);
     }
 
     @Test


### PR DESCRIPTION
- avoid multiple calls to convert from array of command line arguments to a map of command line arguments.
- avoid conversion from command line arguments map to command line arguments array
- move convertCommandArgsArrayToArgMap() to DataLoaderRunner and rename it configureRunModeAndGetArgsMap() to better reflect its purpose.