### PR TITLE
fix for W-18207625

### DIFF
--- a/src/main/java/com/salesforce/dataloader/client/ClientBase.java
+++ b/src/main/java/com/salesforce/dataloader/client/ClientBase.java
@@ -157,7 +157,8 @@ public abstract class ClientBase<ConnectionType> {
             cc.setCompression(!appConfig.getBoolean(AppConfig.PROP_NO_COMPRESSION));
         }
 
-        if (appConfig.getBoolean(AppConfig.PROP_DEBUG_MESSAGES)) {
+        if (appConfig.getBoolean(AppConfig.PROP_DEBUG_MESSAGES)
+                || appConfig.getBoolean(AppConfig.PROP_WIRE_OUTPUT)) {
             cc.setTraceMessage(true);
             cc.setPrettyPrintXml(true);
             String filename = appConfig.getString(AppConfig.PROP_DEBUG_MESSAGES_FILE);
@@ -175,7 +176,6 @@ public abstract class ClientBase<ConnectionType> {
             cc.setServiceEndpoint(server + PartnerClient.getServicePath()); // Partner SOAP service
             cc.setRestEndpoint(server + BulkV1Client.getServicePath());  // REST service: Bulk v1
         }
-        cc.setTraceMessage(appConfig.getBoolean(AppConfig.PROP_WIRE_OUTPUT));
 
         return cc;
     }


### PR DESCRIPTION
Fix for the regression introduced in v61 regarding SOAP trace logging in CLI mode:

Trace logging for SOAP API calls is broken in v61.0.0 and later releases