### PR TITLE
reduce reliance on os-native scripts

### DIFF
--- a/src/main/resources/mac/util/util.sh
+++ b/src/main/resources/mac/util/util.sh
@@ -17,8 +17,6 @@ include() {
 
 initVars() {
     DATALOADER_VERSION="@@FULL_VERSION@@"
-    DATALOADER_SHORT_VERSION=$(echo "${DATALOADER_VERSION}" | cut -d'.' -f 1)
-    MIN_JAVA_VERSION=@@MIN_JAVA_VERSION@@
     
     # Source shell-specific files if they exist
     if [ "$SHELL_NAME" = "bash" ]; then
@@ -31,36 +29,8 @@ initVars() {
     include "${HOME}/.profile"
 }
 
-checkJavaVersion() {
-    initVars
-    
-    echo "Data Loader requires Java JRE ${MIN_JAVA_VERSION} or later. Checking if it is installed..."
-    if [ -n "${DATALOADER_JAVA_HOME:-}" ]; then
-        JAVA_HOME="${DATALOADER_JAVA_HOME}"
-    fi
-    
-    PATH="${JAVA_HOME}/bin:${PATH}"
-    JAVA_VERSION=$(java -version 2>&1 | grep -i version | cut -d'"' -f 2 | cut -d'.' -f 1)
-    if [ -z "${JAVA_VERSION:-}" ]; then
-        echo "Did not find java command."
-        echo ""
-        exitWithJavaDownloadMessage
-    fi
-    if [ "${JAVA_VERSION}" -lt "${MIN_JAVA_VERSION}" ]; then
-        echo "Found Java JRE version ${JAVA_VERSION} whereas Data Loader requires Java JRE ${MIN_JAVA_VERSION} or later."
-        exitWithJavaDownloadMessage
-    fi
-}
-
-exitWithJavaDownloadMessage() {
-    echo "Java JRE ${MIN_JAVA_VERSION} or later is not installed or DATALOADER_JAVA_HOME environment variable is not set."
-    echo "For example, download and install Zulu JRE ${MIN_JAVA_VERSION} or later from here:"
-    echo "    https://www.azul.com/downloads/"
-    exit 1
-}
-
 runDataLoader() {
-    checkJavaVersion
+    initVars
     SCRIPT_DIR=$( cd -- "$( dirname -- "$0" )" >/dev/null 2>&1 && pwd -P )
     java -cp "${SCRIPT_DIR}/*" com.salesforce.dataloader.process.DataLoaderRunner "$@"
 }

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,0 +1,2 @@
+dataloader.version=@@FULL_VERSION@@
+min.java.version=@@MIN_JAVA_VERSION@@ 

--- a/src/main/resources/win/util/util.bat
+++ b/src/main/resources/win/util/util.bat
@@ -7,68 +7,13 @@ EXIT /b %ERRORLEVEL%
 
 :initVars
     SET DATALOADER_VERSION=@@FULL_VERSION@@
-    FOR /f "tokens=1 delims=." %%a IN ("%DATALOADER_VERSION%") DO (
-      SET DATALOADER_SHORT_VERSION=%%a
-    )
-    SET MIN_JAVA_VERSION=@@MIN_JAVA_VERSION@@
     EXIT /b 0
 
-:checkJavaVersion
-    echo Data Loader requires Java JRE %MIN_JAVA_VERSION% or later. Checking if it is installed...
-    IF NOT "%DATALOADER_JAVA_HOME%" == "" (
-        SET "JAVA_HOME=%DATALOADER_JAVA_HOME%"
-    )
-    SET "PATH=%JAVA_HOME%\bin\;%PATH%;"
-
-    java -version 1>nul 2>nul || (
-        echo Did not find java command.
-        echo.
-        GOTO :exitWithJavaDownloadMessage
-    )
-
-    FOR /f "tokens=3" %%a IN ('java -version 2^>^&1 ^| FINDSTR /i "version"') DO (
-        SET JAVA_FULL_VERSION=%%a
-    )
-    SET JAVA_FULL_VERSION=%JAVA_FULL_VERSION:"=%
-
-    FOR /f "tokens=1 delims=." %%m IN ("%JAVA_FULL_VERSION%") DO (
-        SET /A JAVA_MAJOR_VERSION=%%m
-    )
-
-    IF %JAVA_MAJOR_VERSION% LSS %MIN_JAVA_VERSION% (
-        echo Found Java JRE version %JAVA_FULL_VERSION% whereas Data Loader requires Java JRE %MIN_JAVA_VERSION% or later.
-        GOTO :exitWithJavaDownloadMessage
-    )
-    EXIT /b 0
-
-:exitWithJavaDownloadMessage
-    echo Java JRE %MIN_JAVA_VERSION% or later is not installed or DATALOADER_JAVA_HOME environment variable is not set.
-    echo For example, download and install Zulu JRE %MIN_JAVA_VERSION% or later from here:
-    echo     https://www.azul.com/downloads/
-    echo.
-    echo After the installation, set DATALOADER_JAVA_HOME environment variable to the value
-    echo ^<full path to the JRE installation folder^>
-    echo.
-    EXIT -1
-    
 :runDataLoader
-    CALL :checkJavaVersion
     java -cp "%~dp0..\*" com.salesforce.dataloader.process.DataLoaderRunner %*
     EXIT /b %ERRORLEVEL%
 
 REM Shortcut files have .lnk extension
 :CreateShortcut
     powershell -Command "$WshShell = New-Object -comObject WScript.Shell; $Shortcut = $WshShell.CreateShortcut(""""%~1""""); $Shortcut.WorkingDirectory = """"%~2""""; $Shortcut.TargetPath = """"%~2\dataloader.bat""""; $Shortcut.IconLocation = """"%~2\dataloader.ico""""; $Shortcut.WindowStyle=7; $Shortcut.Save()"
-    EXIT /b 0
-
-:createStartMenuShortcut
-    IF NOT EXIST "%APPDATA%\Microsoft\Windows\Start Menu\Programs\Salesforce\" (
-        mkdir "%APPDATA%\Microsoft\Windows\Start Menu\Programs\Salesforce"
-    )
-    CALL :CreateShortcut "%APPDATA%\Microsoft\Windows\Start Menu\Programs\Salesforce\Dataloader %DATALOADER_VERSION%.lnk" "%~1"
-    EXIT /b 0
-
-:createDesktopShortcut
-    for /f "usebackq tokens=3*" %%D IN (`reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v Desktop`) do set DESKTOP_DIR=%%D
-    CALL :CreateShortcut "%DESKTOP_DIR%\Dataloader %DATALOADER_VERSION%.lnk" "%~1"
     EXIT /b 0


### PR DESCRIPTION
- java version check in java code reduces code duplication in util.sh and util.bat

- invoke :CreateShortcut in util.bat directly from Installer.java, thereby avoiding wrapper functions :createStartMenuShortcut and :createDesktopShortcut and reducing native code in util.bat