### PR TITLE
fix for issue #1564

### DIFF
--- a/src/main/resources/mac/util/util.sh
+++ b/src/main/resources/mac/util/util.sh
@@ -62,5 +62,5 @@ exitWithJavaDownloadMessage() {
 runDataLoader() {
     checkJavaVersion
     SCRIPT_DIR=$( cd -- "$( dirname -- "$0" )" >/dev/null 2>&1 && pwd -P )
-    java -cp "${SCRIPT_DIR}/*" com.salesforce.dataloader.process.DataLoaderRunner "$@"
+    java --enable-native-access=ALL-UNNAMED -cp "${SCRIPT_DIR}/*" com.salesforce.dataloader.process.DataLoaderRunner "$@"
 }

--- a/src/main/resources/win/util/util.bat
+++ b/src/main/resources/win/util/util.bat
@@ -53,7 +53,7 @@ EXIT /b %ERRORLEVEL%
     
 :runDataLoader
     CALL :checkJavaVersion
-    java -cp "%~dp0..\*" com.salesforce.dataloader.process.DataLoaderRunner %*
+    java --enable-native-access=ALL-UNNAMED -cp "%~dp0..\*" com.salesforce.dataloader.process.DataLoaderRunner %*
     EXIT /b %ERRORLEVEL%
 
 REM Shortcut files have .lnk extension


### PR DESCRIPTION
fix #1564 by setting --enable-native-access=ALL-UNNAMED for Java Runtime to suppress the warning.