### PR TITLE
revert jface from 3.37.0 to 3.36.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.jface</artifactId>
-      <version>3.37.0</version>
+      <version>3.36.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.platform</groupId>


### PR DESCRIPTION
jface 3.37.0 causes data loader to fail with the following error:

Exception in thread "main" java.lang.NoClassDefFoundError: org/eclipse/swt/internal/NativeImageLoader
	at org.eclipse.jface.resource.URLImageDescriptor.loadImageFromStream(URLImageDescriptor.java:152)
	at org.eclipse.jface.resource.URLImageDescriptor.getImageData(URLImageDescriptor.java:137)
	at org.eclipse.jface.resource.URLImageDescriptor.getImageData(URLImageDescriptor.java:109)

...