### PR TITLE
introduce support for ECA

### DIFF
--- a/src/main/java/com/salesforce/dataloader/oauth/OAuthSecretFlowUtil.java
+++ b/src/main/java/com/salesforce/dataloader/oauth/OAuthSecretFlowUtil.java
@@ -51,7 +51,7 @@ public class OAuthSecretFlowUtil {
                 "/services/oauth2/authorize"
                 + "?response_type=code"
                 + "&display=popup"
-                + "&" + appConfig.getClientIdNameValuePair()
+                + "&client_id=" + URLEncoder.encode(appConfig.getEffectiveClientIdForCurrentEnv(), StandardCharsets.UTF_8.name())
                 + "&redirect_uri="
                 + URLEncoder.encode(appConfig.getOAuthRedirectURIForCurrentEnv(), StandardCharsets.UTF_8.name());
     }
@@ -61,8 +61,8 @@ public class OAuthSecretFlowUtil {
         SimplePostInterface client = SimplePostFactory.getInstance(appConfig, server,
                 new BasicNameValuePair("grant_type", "authorization_code"),
                 new BasicNameValuePair("code", code),
-                new BasicNameValuePair(AppConfig.CLIENT_ID_HEADER_NAME, appConfig.getClientIDForCurrentEnv()),
-                new BasicNameValuePair("client_secret", appConfig.getOAuthClientSecretForCurrentEnv()),
+                new BasicNameValuePair(AppConfig.CLIENT_ID_HEADER_NAME, appConfig.getEffectiveClientIdForCurrentEnv()),
+                new BasicNameValuePair("client_secret", appConfig.getEffectiveClientSecretForCurrentEnv()),
                 new BasicNameValuePair("redirect_uri", appConfig.getOAuthRedirectURIForCurrentEnv())
         );
         client.post();

--- a/src/main/resources/labels.properties
+++ b/src/main/resources/labels.properties
@@ -356,6 +356,23 @@ LoginPage.loginOAuthWithSoftToken=OAuth with User Code
 LoginPage.loginStandard=Password Authentication
 LoginPage.loginAdvanced=Advanced
 
+# External Client App labels
+LoginPage.useExternalClientApp=Use External Client App:
+LoginPage.ECAClientId=External Client App ID:
+LoginPage.ECAClientSecret=External Client App Secret:
+LoginPage.ECADescription=External Client Apps provide enhanced security and policy controls. Contact your Salesforce admin to set up an External Client App for Data Loader.
+LoginPage.ECAConfigRequired=External Client App configuration is required. Please configure the External Client App ID and Secret in Settings.
+LoginPage.ECAValidationError=External Client App validation failed: {0}
+
+# Settings dialog labels for ECA
+AdvancedSettingsDialog.useExternalClientApp=Use External Client App
+AdvancedSettingsDialog.ECAClientIdProd=External Client App ID (Production):
+AdvancedSettingsDialog.ECAClientSecretProd=External Client App Secret (Production):
+AdvancedSettingsDialog.ECAClientIdSandbox=External Client App ID (Sandbox):
+AdvancedSettingsDialog.ECAClientSecretSandbox=External Client App Secret (Sandbox):
+AdvancedSettingsDialog.ECATooltip=Enable to use External Client App instead of Connected App for enhanced security
+AdvancedSettingsDialog.ECASetupGuide=Setup Guide: Create an External Client App in Salesforce Setup > App Manager > New External Client App
+
 ExtractionInputDialog.proxyUsername=Proxy Username:
 ExtractionInputDialog.proxyPassword=Proxy Password:
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -198,6 +198,10 @@ OperationInfoUIHelper.errorOperationInstantiation=Error instantiating operation 
 DataAccessObjectFactory.errorDaoInstantiation=Error instantiating data access object {0}: error getting class: {1}.  Please make sure a correct class is defined and accessible for the data access object.
 DataAccessObjectFactory.errorDaoNoConstructor=Error instantiating data access object {0}: constructor: {1} has to be implemented
 DataAccessObjectFactory.errorInterfaceNotImplemented=Error instantiating data access object {0}: interface DataAccessObject has to be implemented
+
+# External Client App (ECA) validation messages
+AppConfig.ecaClientIdRequired=External Client App ID is required when using External Client Apps
+AppConfig.ecaClientSecretRequired=External Client App Secret is required when using External Client Apps
 DataAccessObjectFactory.errorDaoConstructorCall=Error instantiating data access object {0} using constructor: {1}
 DataAccessObjectFactory.daoTypeNotSupported=The specified data access object type: {0} is not supported
 DataAccessObjectFactory.creatingDao=Instantiating data access object: {0} of type: {1}


### PR DESCRIPTION
Ability to specify External Client Application settings in Data Loader using following properties:

sfdc.oauth.useExternalClientApp - boolean flag

sfdc.oauth.Production.eca.clientid

sfdc.oauth.Production.eca.clientsecret

sfdc.oauth.Sandbox.eca.clientid

sfdc.oauth.Sandbox.eca.clientsecret