### PR TITLE
handle log4j-core upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <version>2.25.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core-config-plugins-processor</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!--
         https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
@@ -356,6 +362,7 @@
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
           <compilerArgs>
             <!-- <arg>-verbose</arg> -->
+            <arg>-proc:none</arg>
           </compilerArgs>
         </configuration>
       </plugin>


### PR DESCRIPTION
Fix compilation error in upgrading log4j-core from 2.24.3 to 2.25.0 by switching off Graal annotation processor.

Not doing so causes the following compilation error:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.14.0:compile (default-compile) on project dataloader: Compilation failure [ERROR] 	at org.apache.logging.log4j.core.config.plugins.processor.GraalVmProcessor.getReachabilityMetadataPath(GraalVmProcessor.java:224) [ERROR] 	at org.apache.logging.log4j.core.config.plugins.processor.GraalVmProcessor.writeReachabilityMetadata(GraalVmProcessor.java:191) [ERROR] 	at org.apache.logging.log4j.core.config.plugins.processor.GraalVmProcessor.process(GraalVmProcessor.java:128) [ERROR] 	at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment.callProcessor(JavacProcessingEnvironment.java:1021) [ERROR] 	at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment$DiscoveredProcessors$ProcessorStateIterator.runContributingProcs(JavacProcessingEnvironment.java:857) [ERROR] 	at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment$Round.run(JavacProcessingEnvironment.java:1263) [ERROR] 	at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvi