### PR TITLE
@W-23559528 Add #GUSINFO to CODEOWNERS (OSPO compliance)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
 #ECCN:Open Source
+#GUSINFO:Enterprise API - Bulk,Data Loader

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 # Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
 #ECCN:Open Source
 #GUSINFO:Enterprise API - Bulk,Data Loader
+*


### PR DESCRIPTION
## What

Adds the required `#GUSINFO` line to the repo's `CODEOWNERS` file:

```
#GUSINFO:Enterprise API - Bulk,Data Loader
```

## Why

Per the OSPO (Open Source Program Office) FY27 V2MOM compliance check, the `CODEOWNERS` file for `forcedotcom/dataloader` was missing a valid GUS Scrum Team and GUS Product Tag. Every Salesforce OSS repo must declare which GUS Team owns the codebase via a `#GUSINFO:<Scrum Team>,<Product Tag>` line.

Both values point to **active** GUS records owned by our team:
- **Scrum Team:** Enterprise API - Bulk
- **Product Tag:** Data Loader

Format follows the [oss-template CODEOWNERS](https://github.com/salesforce/oss-template/blob/main/CODEOWNERS) — the line is left-aligned and sits directly below the `#ECCN` comment.

## Work item

W-23559528